### PR TITLE
fix(#28): Resolve all-day event timezone display issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar-card-pro-dev",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Custom Home Assistant calendar card",
   "main": "dist/calendar-card-pro.js",
   "scripts": {


### PR DESCRIPTION
## Description

This PR fixes an issue where all-day calendar events were displaying on the wrong day for users in certain timezones (primarily in timezones west of UTC like US timezones). The problem was caused by the way JavaScript Date objects interpret date-only strings, which resulted in all-day events being incorrectly shifted to the previous day in some timezones.

The fix implements proper timezone-aware handling of all-day events by:

Adding a specialized function to parse all-day date strings into local Date objects
Adding a function to generate consistent date keys using local date components
Modifying event filtering and grouping logic to use these timezone-safe functions

## Related Issue

This PR fixes or closes issue: fixes #28 

## Motivation and Context

All-day events in calendars are stored as date strings (e.g., "2025-03-17") without time information. Previously, these were parsed using `new Date()`, which interprets dates at UTC midnight. When converted to local time in western timezones (like MDT/UTC-6), this would become the previous day (March 16, 6:00 PM). The bug affected users in western timezones but not eastern ones, making it difficult to reproduce in all environments.

This change ensures all-day events display on their intended day regardless of the user's timezone.

## How Has This Been Tested

- Tested with all-day events in multiple timezones
- Verified fix with users experiencing the issue who confirmed it correctly displays events

## Types of changes

- [ x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ x] My code follows the code style of this project.
- [ x] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have tested the change in my local Home Assistant instance.
- [ ] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.
