### PR TITLE
Calendar Card Pro: Bug Fixes and Enhancements (v1.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The following table provides an overview of all available configuration options.
 | **days_to_show**            | number  | `3`                           | Number of days to display                         |
 | **max_events_to_show**      | number  | `-`                           | Maximum number of events to show in compact mode  |
 | **show_past_events**        | boolean | `false`                       | Show today's events that have already ended       |
-| **language**                | string  | `System`                      | Interface language (`en`, `de`)                   |
+| **language**                | string  | `System`, fallback `en`       | Interface language (`en`, `de`)                   |
 | **time_24h**                | boolean | `true`                        | Use 24-hour time format                           |
 | **show_end_time**           | boolean | `true`                        | Show event end times                              |
 | **show_month**              | boolean | `true`                        | Show month names                                  |

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -304,11 +304,17 @@ class CalendarCardPro extends HTMLElement implements Types.CalendarComponent {
       return;
     }
 
+    // Get the effective language based on priority order
+    const effectiveLanguage = Localize.getEffectiveLanguage(
+      this.config.language,
+      this._hass?.locale,
+    );
+
     const eventsByDay = EventUtils.groupEventsByDay(
       this.events,
       this.config,
       this.isExpanded,
-      this.config.language,
+      effectiveLanguage,
     );
 
     if (eventsByDay.length === 0) {
@@ -324,7 +330,7 @@ class CalendarCardPro extends HTMLElement implements Types.CalendarComponent {
       const { container: contentContainer, style } = await Render.renderCalendarCard(
         this.config,
         eventsByDay,
-        (event) => FormatUtils.formatEventTime(event, this.config, this.config.language),
+        (event) => FormatUtils.formatEventTime(event, this.config, effectiveLanguage),
         (location) => FormatUtils.formatLocation(location, this.config.remove_location_country),
         Constants.PERFORMANCE.CHUNK_SIZE,
         Constants.PERFORMANCE.RENDER_DELAY,
@@ -416,8 +422,12 @@ class CalendarCardPro extends HTMLElement implements Types.CalendarComponent {
   }
 
   get translations() {
-    const lang = this.config.language || 'en';
-    return Localize.getTranslations(lang);
+    // Use the effective language based on priority order
+    const effectiveLanguage = Localize.getEffectiveLanguage(
+      this.config.language,
+      this._hass?.locale,
+    );
+    return Localize.getTranslations(effectiveLanguage);
   }
 
   //-----------------------------------------------------------------------------

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -28,7 +28,7 @@ export const DEFAULTS = {
   /** Default number of days to show if not specified */
   DAYS_TO_SHOW: 3,
   /** Default language */
-  LANGUAGE: 'en',
+  LANGUAGE: '',
   /** Default showPastEvents setting */
   SHOW_PAST_EVENTS: false,
   /** Default max events to show when compact */

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -195,15 +195,17 @@ export interface HassMoreInfoEvent extends CustomEvent {
  * Interface for language translations
  */
 export interface Translations {
-  daysOfWeek: string[];
-  fullDaysOfWeek: string[];
-  months: string[];
+  loading: string;
+  noEvents: string;
+  error: string;
   allDay: string;
   multiDay: string;
   at: string;
-  noEvents: string;
-  loading: string;
-  error: string;
+  months: string[];
+  daysOfWeek: string[];
+  fullDaysOfWeek: string[];
+  endsToday: string;
+  endsTomorrow: string;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -161,6 +161,9 @@ export interface Hass {
   // Fix API call method signature to match what Home Assistant actually provides
   callApi: (method: string, path: string, parameters?: object) => Promise<unknown>;
   callService: (domain: string, service: string, serviceData?: object) => void;
+  locale?: {
+    language: string;
+  };
   // Add connection property that may be needed
   connection?: {
     subscribeEvents: (callback: (event: unknown) => void, eventType: string) => Promise<() => void>;

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -13,6 +13,8 @@
   "allDay": "ganztägig",
   "multiDay": "bis",
   "at": "um",
+  "endsToday": "endet heute",
+  "endsTomorrow": "endet morgen",
   "noEvents": "Keine anstehenden Termine",
   "loading": "Kalendereinträge werden geladen...",
   "error": "Fehler: Kalender-Entity nicht gefunden oder falsch konfiguriert"

--- a/src/translations/languages/en.json
+++ b/src/translations/languages/en.json
@@ -5,6 +5,8 @@
   "allDay": "all-day",
   "multiDay": "until",
   "at": "at",
+  "endsToday": "ends today",
+  "endsTomorrow": "ends tomorrow",
   "noEvents": "No upcoming events",
   "loading": "Loading calendar events...",
   "error": "Error: Calendar entity not found or improperly configured"

--- a/src/translations/localize.ts
+++ b/src/translations/localize.ts
@@ -31,6 +31,58 @@ export const DEFAULT_LANGUAGE = 'en';
 //-----------------------------------------------------------------------------
 
 /**
+ * Determine the effective language based on priority order:
+ * 1. User config language (if specified and supported)
+ * 2. HA system language (if available and supported)
+ * 3. Default language fallback
+ *
+ * @param configLanguage - Language from user configuration
+ * @param hassLocale - Home Assistant locale information
+ * @returns The effective language code to use
+ */
+export function getEffectiveLanguage(
+  configLanguage?: string,
+  hassLocale?: { language: string },
+): string {
+  Logger.debug(`Language detection - Config language: ${configLanguage || 'not set'}`);
+  Logger.debug(
+    `Language detection - HA system language: ${hassLocale?.language || 'not available'}`,
+  );
+
+  // Priority 1: Use config language if specified and supported
+  if (configLanguage && configLanguage.trim() !== '') {
+    const configLang = configLanguage.toLowerCase();
+    if (TRANSLATIONS[configLang]) {
+      Logger.debug(`Using config language: ${configLang}`);
+      return configLang;
+    }
+    Logger.debug(`Config language ${configLang} not supported, trying HA system language`);
+  }
+
+  // Priority 2: Use HA system language if available and supported
+  if (hassLocale?.language) {
+    const sysLang = hassLocale.language.toLowerCase();
+    if (TRANSLATIONS[sysLang]) {
+      Logger.debug(`Using HA system language: ${sysLang}`);
+      return sysLang;
+    }
+
+    // Check for language part only (e.g., "de" from "de-DE")
+    const langPart = sysLang.split(/[-_]/)[0];
+    if (langPart !== sysLang && TRANSLATIONS[langPart]) {
+      Logger.debug(`Using base language part from HA system language: ${langPart}`);
+      return langPart;
+    }
+
+    Logger.debug(`No supported translation for HA language ${sysLang}`);
+  }
+
+  // Priority 3: Use default language as fallback
+  Logger.debug(`Using default language: ${DEFAULT_LANGUAGE}`);
+  return DEFAULT_LANGUAGE;
+}
+
+/**
  * Get translations for the specified language
  * Falls back to English if the language is not available
  *

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -257,6 +257,13 @@ export function groupEventsByDay(
       // Use special parsing for all-day events that preserves correct day
       startDate = event.start.date ? FormatUtils.parseAllDayDate(event.start.date) : null;
       endDate = event.end.date ? FormatUtils.parseAllDayDate(event.end.date) : null;
+
+      // Adjust end date for all-day events (which is exclusive in iCal format)
+      if (endDate) {
+        const adjustedEndDate = new Date(endDate);
+        adjustedEndDate.setDate(adjustedEndDate.getDate() - 1);
+        endDate = adjustedEndDate;
+      }
     } else {
       startDate = event.start.dateTime ? new Date(event.start.dateTime) : null;
       endDate = event.end.dateTime ? new Date(event.end.dateTime) : null;
@@ -266,9 +273,13 @@ export function groupEventsByDay(
 
     const isEventToday = startDate >= todayStart && startDate <= todayEnd;
     const isFutureEvent = startDate > todayEnd;
+    // NEW: Check if event ends today or in the future (is still ongoing)
+    const isOngoingEvent = endDate >= todayStart;
 
-    // Keep only current and future events
-    if (!isEventToday && !isFutureEvent) {
+    // Include events that:
+    // 1. Start today or in the future, OR
+    // 2. Started in the past BUT are still ongoing
+    if (!(isEventToday || isFutureEvent || isOngoingEvent)) {
       return false;
     }
 
@@ -292,26 +303,52 @@ export function groupEventsByDay(
     const isAllDayEvent = !event.start.dateTime;
 
     let startDate: Date | null;
+    let endDate: Date | null;
 
-    if (isAllDayEvent && event.start.date) {
-      // Use special parsing for all-day events that preserves correct day
-      startDate = FormatUtils.parseAllDayDate(event.start.date);
+    if (isAllDayEvent) {
+      startDate = event.start.date ? FormatUtils.parseAllDayDate(event.start.date) : null;
+      endDate = event.end.date ? FormatUtils.parseAllDayDate(event.end.date) : null;
+
+      // For all-day events, end date is exclusive in iCal format
+      if (endDate) {
+        const adjustedEndDate = new Date(endDate);
+        adjustedEndDate.setDate(adjustedEndDate.getDate() - 1);
+        endDate = adjustedEndDate;
+      }
     } else {
       startDate = event.start.dateTime ? new Date(event.start.dateTime) : null;
+      endDate = event.end.dateTime ? new Date(event.end.dateTime) : null;
     }
 
-    if (!startDate) return;
+    if (!startDate || !endDate) return;
 
-    // Use local date components for grouping instead of ISO string
-    const eventDateKey = FormatUtils.getLocalDateKey(startDate);
+    // NEW: Determine which day to display this event on
+    let displayDate: Date;
+
+    if (startDate >= todayStart) {
+      // Event starts today or in future: Display on start date
+      displayDate = startDate;
+    } else if (endDate.toDateString() === todayStart.toDateString()) {
+      // Event ends today: Display on today
+      displayDate = todayStart;
+    } else if (startDate < todayStart && endDate > todayStart) {
+      // Multi-day event that started in past and continues after today: Display on today
+      displayDate = todayStart;
+    } else {
+      // Fallback (shouldn't happen given our filter): Display on start date
+      displayDate = startDate;
+    }
+
+    // Use displayDate for grouping instead of startDate
+    const eventDateKey = FormatUtils.getLocalDateKey(displayDate);
     const translations = Localize.getTranslations(language);
 
     if (!eventsByDay[eventDateKey]) {
       eventsByDay[eventDateKey] = {
-        weekday: translations.daysOfWeek[startDate.getDay()],
-        day: startDate.getDate(),
-        month: translations.months[startDate.getMonth()],
-        timestamp: startDate.getTime(),
+        weekday: translations.daysOfWeek[displayDate.getDay()],
+        day: displayDate.getDate(),
+        month: translations.months[displayDate.getMonth()],
+        timestamp: displayDate.getTime(),
         events: [],
       };
     }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -211,16 +211,57 @@ function formatMultiDayTime(
   language: string,
   translations: Types.Translations,
 ): string {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  // Case 3: Event ends today
+  if (endDate.toDateString() === today.toDateString()) {
+    const endTimeStr = formatTime(endDate, true);
+    return `${translations.endsToday} ${translations.at} ${endTimeStr}`;
+  }
+
+  // NEW Case 4: Event ends tomorrow
+  if (endDate.toDateString() === tomorrow.toDateString()) {
+    const endTimeStr = formatTime(endDate, true);
+    return `${translations.endsTomorrow} ${translations.at} ${endTimeStr}`;
+  }
+
   const endDay = endDate.getDate();
   const endMonthName = translations.months[endDate.getMonth()];
   const endWeekday = translations.fullDaysOfWeek[endDate.getDay()];
-
-  const startTimeStr = formatTime(startDate, true);
   const endTimeStr = formatTime(endDate, true);
 
-  // Different date formats based on language
+  // Case 2: Today is after start date but before end date (middle day)
+  if (today.toDateString() !== startDate.toDateString() && today < endDate) {
+    // Omit start time for days between start and end
+    if (language === 'de') {
+      return [
+        translations.multiDay,
+        endWeekday + ',',
+        `${endDay}.`,
+        endMonthName,
+        translations.at,
+        endTimeStr,
+      ].join(' ');
+    } else {
+      return [
+        translations.multiDay,
+        endWeekday + ',',
+        endMonthName,
+        endDay,
+        translations.at,
+        endTimeStr,
+      ].join(' ');
+    }
+  }
+
+  // Case 1: Default - Today is on start date (or before start)
+  const startTimeStr = formatTime(startDate, true);
+
+  // Use existing format with start time
   if (language === 'de') {
-    // German: "7:00 bis Freitag, 21. Mär um 20:00"
     return [
       startTimeStr,
       translations.multiDay,
@@ -231,7 +272,6 @@ function formatMultiDayTime(
       endTimeStr,
     ].join(' ');
   } else {
-    // English: "7:00 until Friday, Mar 21 at 20:00"
     return [
       startTimeStr,
       translations.multiDay,
@@ -257,6 +297,21 @@ function formatMultiDayAllDayTime(
   language: string,
   translations: Types.Translations,
 ): string {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  // UPDATED: On the end date, just show "All-day"
+  if (endDate.toDateString() === today.toDateString()) {
+    return translations.allDay;
+  }
+
+  // NEW: Day before end date shows "ends tomorrow"
+  if (endDate.toDateString() === tomorrow.toDateString()) {
+    return `${translations.allDay}, ${translations.endsTomorrow}`;
+  }
+
   const endDay = endDate.getDate();
   const endMonthName = translations.months[endDate.getMonth()];
 


### PR DESCRIPTION
# Pull Request: Bug Fixes and Enhancements (v1.0.3)

## Description

This PR implements multiple improvements and bug fixes for Calendar Card Pro:

### Automatic Language Detection (Issue #36)
- **Automatic system language detection**: Calendar Card Pro now automatically detects and uses the Home Assistant system language
- **Language priority system**: 
  1. User-configured language in card config (highest priority)
  2. Home Assistant system language (if supported by our card)
  3. Default language (English) as fallback
- **Support for region codes**: Added handling for language codes with region specifiers (e.g., "de-DE")
- **Debug logging**: Added helpful logs for language detection troubleshooting

### Multi-day Event Display Enhancements (Issue #16)
- **Fixed multi-day event display**: Improved how multi-day events are displayed, especially for ongoing events
- **Added "Ends Today" and "Ends Tomorrow" indicators**: Better context for multi-day events that are about to end
- **Added support for all-day multi-day events**: Proper formatting for multi-day events that span the entire day
- **Enhanced time formatting**: More intuitive time presentation for events spanning multiple days

### New Translations
- **Added new translation keys**: For improved multi-day event display
  - `endsToday`: For events that end on the current day
  - `endsTomorrow`: For events ending the next day

### Technical Improvements
- **Updated the Hass interface** to include locale property for language detection
- **Enhanced format.ts module** with specialized functions for different event types
- **Changed default language constant** to empty string to properly trigger detection logic
- **Improved cache handling** for better performance across language changes

## Related Issue

This PR fixes or closes issue: fixes #36 #16

## Motivation and Context

- **Language Detection**: Previously, Calendar Card Pro would always default to English unless manually configured. This created a suboptimal experience for non-English users who had to explicitly configure the language despite already having set their preferred language in Home Assistant.

- **Multi-day Event Display**: Multi-day events were not displaying optimally, with limited context about when events were ending. The enhancement adds clearer indicators for events ending today or tomorrow and improves the overall readability.

## How Has This Been Tested

Testing was performed in a Home Assistant development environment:

**Language Detection**:
- Tested with explicit language configuration (should override system settings)
- Tested with no language configuration (should use system language)
- Tested with system languages that have region codes (e.g., de-DE)
- Tested with unsupported languages (should fall back to English)

**Multi-day Event Display**:
- Tested with single-day events
- Tested with multi-day events in various states:
  - Starting today
  - Ongoing (middle of event)
  - Ending today
  - Ending tomorrow
- Verified all-day and timed multi-day events display correctly

This release significantly improves the user experience by providing more context for multi-day events and automatically using the user's preferred language without requiring manual configuration.

## Types of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change in my local Home Assistant instance.
- [x] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.