### PR TITLE
add french translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calendar-card-pro-dev",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calendar-card-pro-dev",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@material/web": "^2.2.0"

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -1,0 +1,14 @@
+
+{
+  "daysOfWeek": ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"],
+  "fullDaysOfWeek": ["Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi"],
+  "months": ["Jan", "Fév", "Mar", "Avr", "Mai", "Juin", "Juil", "Aoû", "Sep", "Oct", "Nov", "Déc"],
+  "allDay": "toute la journée",
+  "multiDay": "jusqu'à",
+  "at": "à",
+  "endsToday": "se termine aujourd'hui",
+  "endsTomorrow": "se termine demain",
+  "noEvents": "Aucun événement à venir",
+  "loading": "Chargement des événements du calendrier...",
+  "error": "Erreur : Entité du calendrier introuvable ou mal configurée"
+}

--- a/src/translations/localize.ts
+++ b/src/translations/localize.ts
@@ -19,6 +19,7 @@ import plTranslations from './languages/pl.json';
 import ruTranslations from './languages/ru.json';
 import svTranslations from './languages/sv.json';
 import ukTranslations from './languages/uk.json';
+import frTranslations from './languages/fr.json';
 
 /**
  * Available translations keyed by language code
@@ -34,6 +35,7 @@ export const TRANSLATIONS: Record<string, Types.Translations> = {
   ru: ruTranslations,
   sv: svTranslations,
   uk: ukTranslations,
+  fr: frTranslations,
 };
 
 /**


### PR DESCRIPTION
## Description

Add support for french language


## Motivation and Context

Enable french readers to use the calendar-card-pro

## How Has This Been Tested

Tested using the dev build in an home assistant instance  on hassos, hosted on a raspberry 4.

## Types of changes

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ x] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have linted and formatted my code (`` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have tested the change in my local Home Assistant instance.
- [x] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.
