### PR TITLE
Release v1.2.1: Fix max_events_to_show limit and Icelandic translation

### DIFF
--- a/src/translations/languages/is.json
+++ b/src/translations/languages/is.json
@@ -10,9 +10,9 @@
     "Laugardagur"
   ],
   "months": ["Jan", "Feb", "Mar", "Apr", "Maí", "Jún", "Júl", "Ágú", "Sep", "Okt", "Nóv", "Des"],
-  "allDay": "allur dagurinn",
+  "allDay": "Allur dagurinn",
   "multiDay": "þar til",
-  "at": "hjá",
+  "at": "kl",
   "endsToday": "lýkur í dag",
   "endsTomorrow": "lýkur á morgun",
   "noEvents": "Engir viðburðir á næstunni",


### PR DESCRIPTION
## Description

This PR fixes the `max_events_to_show` functionality that was not correctly limiting events across multiple days. The fix properly implements the event limit to work at the event level rather than the day level.

## Related Issue

This PR fixes or closes issue: fixes #64

## Motivation and Context

The `max_events_to_show` configuration option was not functioning as expected. When a user set a limit (e.g., `max_events_to_show: 2`), the card was incorrectly filtering at the day level instead of the event level:

- If a single day had more events than the limit, all events were shown
- If multiple days had events, the card would show all events from each day until reaching a day that would exceed the total limit

This PR changes the implementation to:
- Count total events shown across all days
- Only include events up to the configured limit
- Create new day objects with limited event lists
- Continue showing days until the total event limit is reached

## How Has This Been Tested

Testing was performed in a Home Assistant development environment with various calendar configurations:

1. Setting `max_events_to_show: 2` with a day containing 4 events - verified only 2 events show
2. Setting `max_events_to_show: 5` with 4 events on day 1 and 4 on day 2 - verified 4 events from day 1 and only 1 from day 2
3. Verifying the expand functionality works properly to show all events when expanded

## Types of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change in my local Home Assistant instance.
- [ ] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.