### PR TITLE
Fixed wrong language code for Norwegian and added Nynorsk

### DIFF
--- a/src/translations/languages/nb.json
+++ b/src/translations/languages/nb.json
@@ -8,6 +8,6 @@
   "endsToday": "slutter i dag",
   "endsTomorrow": "slutter i morgen",
   "noEvents": "Ingen kommende hendelser",
-  "loading": "Lasting kalenderhendelser...",
+  "loading": "Laster kalenderhendelser...",
   "error": "Feil: Kalenderenheten ble ikke funnet eller er ikke konfigurert riktig"
 }

--- a/src/translations/languages/nn.json
+++ b/src/translations/languages/nn.json
@@ -1,0 +1,13 @@
+{
+  "daysOfWeek": ["Søn", "Mån", "Tys", "Ons", "Tor", "Fre", "Lau"],
+  "fullDaysOfWeek": ["Søndag", "Måndag", "Tysdag", "Onsdag", "Torsdag", "Fredag", "Laurdag"],
+  "months": ["Jan", "Feb", "Mar", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Des"],
+  "allDay": "heile dagen",
+  "multiDay": "inntil",
+  "at": "kl. ",
+  "endsToday": "sluttar i dag",
+  "endsTomorrow": "sluttar i morgon",
+  "noEvents": "Ingen kommande hendingar",
+  "loading": "Lastar kalenderhendingar...",
+  "error": "Feil: Kalendereininga vart ikkje funnen eller er ikkje konfigurert riktig"
+}

--- a/src/translations/localize.ts
+++ b/src/translations/localize.ts
@@ -22,8 +22,9 @@ import heTranslations from './languages/he.json';
 import huTranslations from './languages/hu.json';
 import isTranslations from './languages/is.json';
 import itTranslations from './languages/it.json';
+import nbTranslations from './languages/nb.json';
 import nlTranslations from './languages/nl.json';
-import noTranslations from './languages/no.json';
+import nnTranslations from './languages/nn.json';
 import plTranslations from './languages/pl.json';
 import ptTranslations from './languages/pt.json';
 import ruTranslations from './languages/ru.json';
@@ -51,8 +52,9 @@ export const TRANSLATIONS: Record<string, Types.Translations> = {
   hu: huTranslations,
   is: isTranslations,
   it: itTranslations,
+  nb: nbTranslations,
   nl: nlTranslations,
-  no: noTranslations,
+  nn: nnTranslations,
   pl: plTranslations,
   pt: ptTranslations,
   ru: ruTranslations,


### PR DESCRIPTION
## Description

I was a little quick with the Norwegian language and forgot that there is no language code "no" in HA. Norwegian consists of two written languages so i addem them both with the right code:

- Norwegian Bokmål (nb)
- Norwegian Nynorsk (nn)

## Related Issue

## Motivation and Context

The language code "no" is not the used in HA because Norwegian consists of Norwegian Bokmål (nb) and Norwegian Nynorsk (nn).

## How Has This Been Tested

## Types of changes

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have tested the change in my local Home Assistant instance.
- [x] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.
