### PR TITLE
Entity specify show_location

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ entities:
 - An **object with `entity` and optional parameters** allows customization per calendar:
   - `entity`: The **calendar entity ID** (required).
   - `color`: Custom event title color (optional) – **Overrides** the default `event_color` setting.
+  - `show_location`:  Whether to show event locations (optional) – **Overrides** the default `show_location` setting.
 
 ### 🏗️ Event Display & Compact Mode
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -78,7 +78,7 @@ export const DEFAULT_CONFIG: Types.Config = {
  */
 export function normalizeEntities(
   entities: Array<
-    string | { entity: string; label?: string; color?: string; accent_color?: string }
+    string | { entity: string; label?: string; color?: string; accent_color?: string; show_location?: boolean }
   >,
 ): Array<Types.EntityConfig> {
   if (!Array.isArray(entities)) {
@@ -92,6 +92,7 @@ export function normalizeEntities(
           entity: item,
           color: 'var(--primary-text-color)',
           accent_color: 'var(--calendar-card-line-color-vertical)',
+          show_location: true,
         };
       }
       if (typeof item === 'object' && item.entity) {
@@ -100,6 +101,7 @@ export function normalizeEntities(
           label: item.label,
           color: item.color || 'var(--primary-text-color)',
           accent_color: item.accent_color || 'var(--calendar-card-line-color-vertical)',
+          show_location: item.show_location !== null && item.show_location !== undefined ? item.show_location : true,
         };
       }
       return null;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -74,6 +74,7 @@ export interface EntityConfig {
   label?: string;
   color?: string;
   accent_color?: string;
+  show_location?: boolean;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -156,10 +156,7 @@ export function renderEvent(
 
   // Format event time and location
   const eventTime = FormatUtils.formatEventTime(event, config, language);
-  const eventLocation =
-    event.location && config.show_location
-      ? FormatUtils.formatLocation(event.location, config.remove_location_country)
-      : '';
+  const eventLocation = EventUtils.getLocation(event._entityId, event.location, config);
 
   // Determine event position for styling
   const isFirst = index === 0;

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -325,6 +325,35 @@ export function getEntityLabel(
   return entityConfig.label;
 }
 
+/**
+ * Get entity location based on configuration based on entity ID
+ *
+ * @param entityId - The entity ID to find color for
+ * @param location - the location for the event
+ * @param config - Current card configuration
+ * @returns Formatted location string
+ */
+export function getLocation(entityId: string | undefined, location: string | undefined, config: Types.Config): string {
+  if (!entityId) return '';
+  if (!location) return '';
+
+  var entity_show_location: boolean = true;
+
+  const entityConfig = config.entities.find(
+    (e) =>
+      (typeof e === 'string' && e === entityId) || (typeof e === 'object' && e.entity === entityId),
+  );
+
+  if (entityConfig && typeof entityConfig === 'object' && entityConfig.show_location !== undefined && entityConfig.show_location !== null) 
+  {
+    entity_show_location = entityConfig.show_location
+  }
+
+  return location && config.show_location && entity_show_location
+    ? FormatUtils.formatLocation(location, config.remove_location_country)
+    : '';
+}
+
 //-----------------------------------------------------------------------------
 // DATA FETCHING FUNCTIONS
 //-----------------------------------------------------------------------------
@@ -383,7 +412,7 @@ export async function fetchEventData(
   // Fetch from API if needed
   Logger.info('Fetching events from API');
   const entities = config.entities.map((e) =>
-    typeof e === 'string' ? { entity: e, color: 'var(--primary-text-color)' } : e,
+    typeof e === 'string' ? { entity: e, color: 'var(--primary-text-color)', show_location: true } : e,
   );
 
   const timeWindow = getTimeWindow(config.days_to_show);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add an entity specific override as to whether to show location

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I have a calendar for Formula 1 Grand Prix. I don't really need the location as a) I won't be going there and b) the country is generally in the event title. 

However, I do want the location on my other more local events.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Loaded up my calendars and set it to false on the one calendar I didn't want location. It dissappeared on that calendar but stayed on the ohters.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [x] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have tested the change in my local Home Assistant instance.
- [ ] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.
