### PR TITLE
Release v2.0.1: Fix calendar preview, scrollbar behavior, start_date with empty days, and Dutch translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar-card-pro-dev",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Custom Home Assistant calendar card",
   "main": "dist/calendar-card-pro.js",
   "scripts": {

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -441,6 +441,9 @@ class CalendarCardPro extends LitElement {
   render() {
     const customStyles = this.getCustomStyles();
 
+    // Detect if a max-height is explicitly set
+    const maxHeightSet = this.config.max_height !== 'none';
+
     // Create event handlers object for the card
     const handlers = {
       keyDown: (ev: KeyboardEvent) => this._handleKeyDown(ev),
@@ -473,7 +476,13 @@ class CalendarCardPro extends LitElement {
     }
 
     // Render main card structure with content
-    return Render.renderMainCardStructure(customStyles, this.config.title, content, handlers);
+    return Render.renderMainCardStructure(
+      customStyles,
+      this.config.title,
+      content,
+      handlers,
+      maxHeightSet,
+    );
   }
 }
 
@@ -483,6 +492,17 @@ class CalendarCardPro extends LitElement {
 
 // Register the editor - main component registered by decorator
 customElements.define('calendar-card-pro-dev-editor', Editor.CalendarCardProEditor);
+
+// Create interface extending CustomElementConstructor to allow getStubConfig property
+interface CalendarCardConstructor extends CustomElementConstructor {
+  getStubConfig?: typeof Config.getStubConfig;
+}
+
+// Expose getStubConfig for Home Assistant card picker preview
+const element = customElements.get('calendar-card-pro-dev');
+if (element) {
+  (element as CalendarCardConstructor).getStubConfig = Config.getStubConfig;
+}
 
 // Register with HACS
 window.customCards = window.customCards || [];

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -226,6 +226,21 @@ export function haveEntityColorsChanged(
  * Find a calendar entity in Home Assistant states
  */
 export function findCalendarEntity(hass: Record<string, { state: string }>): string | null {
+  // No valid hass object provided
+  if (!hass || typeof hass !== 'object') {
+    return null;
+  }
+
+  // Check for entities in the states property (standard Home Assistant structure)
+  if ('states' in hass && typeof hass.states === 'object') {
+    const stateKeys = Object.keys(hass.states);
+    const calendarInStates = stateKeys.find((key) => key.startsWith('calendar.'));
+    if (calendarInStates) {
+      return calendarInStates;
+    }
+  }
+
+  // Check for entities at the top level (alternative structure)
   return Object.keys(hass).find((entityId) => entityId.startsWith('calendar.')) || null;
 }
 

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -29,6 +29,7 @@ import * as EventUtils from '../utils/events';
  * @param title Card title from configuration
  * @param content Main card content (events or status)
  * @param handlers Event handler functions
+ * @param maxHeightSet Flag to add max-height-set class
  * @returns TemplateResult for the complete card
  */
 export function renderMainCardStructure(
@@ -42,10 +43,11 @@ export function renderMainCardStructure(
     pointerCancel: (ev: Event) => void;
     pointerLeave: (ev: Event) => void;
   },
+  maxHeightSet: boolean = false,
 ): TemplateResult {
   return html`
     <ha-card
-      class="calendar-card-pro"
+      class="calendar-card-pro ${maxHeightSet ? 'max-height-set' : ''}"
       style=${styleMap(customStyles)}
       tabindex="0"
       @keydown=${handlers.keyDown}

--- a/src/rendering/styles.ts
+++ b/src/rendering/styles.ts
@@ -99,26 +99,36 @@ export const cardStyles = css`
     width: 100%;
   }
 
-  /* Add scrolling to content container */
+  /* Content container - Default state (no scrolling) */
   .content-container {
     max-height: var(--calendar-card-max-height, none);
+    overflow-y: visible;
+  }
+
+  /* Only apply scrolling styles when max-height is explicitly set */
+  ha-card.max-height-set .content-container {
     overflow-y: auto;
     scrollbar-width: thin; /* Firefox */
     scrollbar-color: var(--secondary-text-color) transparent; /* Firefox */
   }
 
-  /* Webkit scrollbar styling */
-  .content-container::-webkit-scrollbar {
+  /* Webkit scrollbar styling - only applied when max-height is set */
+  ha-card.max-height-set .content-container::-webkit-scrollbar {
     width: 6px;
   }
 
-  .content-container::-webkit-scrollbar-thumb {
+  ha-card.max-height-set .content-container::-webkit-scrollbar-thumb {
     background-color: var(--secondary-text-color);
     border-radius: 3px;
   }
 
-  .content-container::-webkit-scrollbar-track {
+  ha-card.max-height-set .content-container::-webkit-scrollbar-track {
     background: transparent;
+  }
+
+  /* Remove default webkit scrollbars when max-height is not set */
+  .content-container::-webkit-scrollbar {
+    display: none;
   }
 
   .card-header-placeholder {

--- a/src/translations/languages/nl.json
+++ b/src/translations/languages/nl.json
@@ -1,13 +1,13 @@
 {
   "daysOfWeek": ["Zo", "Ma", "Di", "Wo", "Do", "Vr", "Za"],
   "fullDaysOfWeek": [
-    "Zondag",
-    "Maandag",
-    "Dinsdag",
-    "Woensdag",
-    "Donderdag",
-    "Vrijdag",
-    "Zaterdag"
+    "zondag",
+    "maandag",
+    "dinsdag",
+    "woensdag",
+    "donderdag",
+    "vrijdag",
+    "zaterdag"
   ],
   "months": ["Jan", "Feb", "Mrt", "Apr", "Mei", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dec"],
   "allDay": "hele dag",


### PR DESCRIPTION
## Description

This PR includes several bug fixes and improvements for Calendar Card Pro v2.0.1, addressing issues reported by users after the major v2.0.0 release.

## Related Issue

This PR fixes or closes issues: fixes #97, fixes #99, fixes #102

## Motivation and Context

After the v2.0.0 major release, some issues were reported by users:

1. The card preview in the "Add to Dashboard" dialog showed an error instead of auto-detecting calendar entities
2. Scrollbars sometimes appeared even when max_height was not set
3. When using show_empty_days with a custom start_date, the calendar would still show days from today instead of the configured date
4. Dutch translations had capitalization issues for day and month names

## How Has This Been Tested

Testing was performed in a Home Assistant development environment with various configurations:

1. Calendar preview: Tested adding the card via the Home Assistant UI
2. Scrollbar behavior: Tested with and without max_height on different browsers
3. start_date with show_empty_days: Verified calendar properly shows empty days from the configured start date
4. Dutch translations: Verified proper capitalization according to Dutch grammar rules

## Types of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🌎 Translation (addition or update for a language)
- [x] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change in my local Home Assistant instance.
- [x] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) for the Dutch translation update.