### PR TITLE
Bug Fix Release v2.4.3

### DIFF
--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -645,8 +645,12 @@ export function renderGroupedEvents(
       // Determine which separator to show based on precedence rules
       let separator: TemplateResult | typeof nothing = nothing;
 
-      // Apply precedence: Month separator > Week separator
-      if (isNewMonth && (!isNewWeek || config.show_week_numbers === null)) {
+      // Don't prioritize month separator if its width is 0px
+      if (
+        isNewMonth &&
+        config.month_separator_width !== '0px' &&
+        (!isNewWeek || config.show_week_numbers === null)
+      ) {
         // Month boundaries without week change get month separator
         separator = renderMonthSeparator(config);
       } else if (isNewWeek) {

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -450,20 +450,15 @@ export function groupEventsByDay(
   if (config.show_empty_days) {
     const translations = Localize.getTranslations(language);
 
-    // Determine the date range to add empty days for
-    // In compact mode: only add empty days for the date range of days we're already showing
-    // In expanded mode: add empty days for the full date range (up to effectiveDaysToShow)
-
+    // Always start from the configured reference date
     let startDateForEmptyDays = new Date(referenceDate);
     let endDateForEmptyDays: Date;
 
     if (!isExpanded && days.length > 0) {
-      // In compact mode with existing days: only fill empty days within the range of days we're showing
-      const minTimestamp = Math.min(...days.map((d) => d.timestamp));
+      // In compact mode with existing days: only fill empty days within the range of days we're already showing
       const maxTimestamp = Math.max(...days.map((d) => d.timestamp));
 
-      startDateForEmptyDays = new Date(minTimestamp);
-      // Set to end of the day
+      // Keep startDateForEmptyDays as the configured reference date
       endDateForEmptyDays = new Date(maxTimestamp);
     } else {
       // In expanded mode or when no days: use full range from reference date


### PR DESCRIPTION
## Description

Calendar Card Pro v2.4.3 brings important bug fixes related to empty day displays and separator rendering while maintaining full compatibility with existing configurations.

### Major Changes:

1. **Fixed Week/Month Separator Display Issue** - Corrected a bug where week separators weren't displaying when month boundaries coincided with week boundaries and month_separator_width was set to '0px'
2. **Fixed Empty Days Display Logic** - Resolved issues where the calendar would incorrectly skip empty days and show events from future days instead of properly displaying "No events" messages
3. **Improved days_to_show Behavior** - Fixed cases where days_to_show parameter wasn't properly respected when filtering events, especially with past events

## Related Issues

This release addresses two community-reported issues:

- [#160](https://github.com/alexpfau/calendar-card-pro/issues/160) - Fixed bug where the calendar would show future days' events instead of properly respecting the days_to_show parameter
- [#175](https://github.com/alexpfau/calendar-card-pro/issues/175) - Fixed week separators not showing when they coincide with month boundaries

## How Has This Been Tested

Testing has been conducted across:
- Multiple calendar configurations with various days_to_show and start_date settings
- Scenarios with only past events today but events tomorrow
- Calendars with month/week boundaries falling on the same day
- Various combinations of separator width settings
- Different browser environments including Firefox, Chrome, Safari, and Edge
- Verified mobile compatibility

All changes maintain backward compatibility with existing configurations.

## Types of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have thoroughly tested changes in my local Home Assistant environment
- [x] All changes maintain backward compatibility

