### PR TITLE
Bug Fix Release v2.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar-card-pro-dev",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Custom Home Assistant calendar card",
   "main": "dist/calendar-card-pro.js",
   "scripts": {

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -313,7 +313,7 @@ export function groupEventsByDay(
   // Sort days and determine effective days to show based on mode
   const effectiveDaysToShow = isExpanded
     ? config.days_to_show
-    : config.compact_days_to_show || config.days_to_show;
+    : Math.min(config.compact_days_to_show || config.days_to_show, config.days_to_show);
 
   // Get days in chronological order limited to effective days to show
   let days = Object.values(eventsByDay)

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -471,22 +471,34 @@ export function groupEventsByDay(
   }
 
   // Only add empty days AFTER we've filtered events in compact mode
-  // This ensures empty days are only added for days that would actually be shown
   if (config.show_empty_days) {
     const translations = Localize.getTranslations(language);
 
     // Always start from the configured reference date
-    let startDateForEmptyDays = new Date(referenceDate);
+    const startDateForEmptyDays = new Date(referenceDate);
+
+    // Determine the end date for empty days generation based on mode and parameters
     let endDateForEmptyDays: Date;
 
-    if (!isExpanded && days.length > 0) {
-      // In compact mode with existing days: only fill empty days within the range of days we're already showing
-      const maxTimestamp = Math.max(...days.map((d) => d.timestamp));
-
-      // Keep startDateForEmptyDays as the configured reference date
-      endDateForEmptyDays = new Date(maxTimestamp);
-    } else {
-      // In expanded mode or when no days: use full range from reference date
+    // In expanded mode or when using compact_days_to_show - use the full configured range
+    if (isExpanded || (config.compact_days_to_show && !config.compact_events_to_show)) {
+      // Use the full configured range from reference date to reference date + days_to_show - 1
+      endDateForEmptyDays = new Date(referenceDate);
+      endDateForEmptyDays.setDate(endDateForEmptyDays.getDate() + effectiveDaysToShow - 1);
+    }
+    // In compact mode with compact_events_to_show - use only days with events as reference
+    else if (!isExpanded && config.compact_events_to_show) {
+      // Only add empty days up to the last day with visible events
+      if (days.length > 0) {
+        const lastDayTimestamp = Math.max(...days.map((d) => d.timestamp));
+        endDateForEmptyDays = new Date(lastDayTimestamp);
+      } else {
+        // If no days with events, default to reference date
+        endDateForEmptyDays = new Date(referenceDate);
+      }
+    }
+    // Default fallback - use full configured range
+    else {
       endDateForEmptyDays = new Date(referenceDate);
       endDateForEmptyDays.setDate(endDateForEmptyDays.getDate() + effectiveDaysToShow - 1);
     }
@@ -514,6 +526,9 @@ export function groupEventsByDay(
 
       // Only add if we don't already have events for this day
       if (!existingDayKeys.has(dateKey)) {
+        // Use helper function to calculate week number with majority rule
+        const weekNumber = calculateWeekNumberWithMajorityRule(currentDate, config, firstDayOfWeek);
+
         // Create an empty day with a "fake" event
         const dayObj: Types.EventsByDay = {
           weekday: translations.daysOfWeek[currentDate.getDay()],
@@ -530,7 +545,7 @@ export function groupEventsByDay(
               location: '',
             },
           ],
-          weekNumber: calculateWeekNumberWithMajorityRule(currentDate, config, firstDayOfWeek),
+          weekNumber,
           monthNumber: currentDate.getMonth(),
           isFirstDayOfMonth: currentDate.getDate() === 1,
           isFirstDayOfWeek: currentDate.getDay() === firstDayOfWeek,


### PR DESCRIPTION
## Description

Calendar Card Pro v2.4.4 brings important bug fixes to improve the consistency of empty days display, ensuring that the calendar shows exactly what you expect in all configurations.

### Major Changes:

1. **Fixed Empty Days Display** - Resolved an issue where empty days weren't consistently displayed at the end of the date range when `show_empty_days: true` was configured
2. **Improved Parameter Validation** - Ensured `compact_days_to_show` never exceeds `days_to_show` to prevent showing empty days beyond the API fetch range
3. **Enhanced Compact Mode Behavior** - Fixed how empty days interact with compact mode settings, especially when using `compact_events_to_show`

## Related Issues

This release addresses a community-reported issue:

- [#189](https://github.com/alexpfau/calendar-card-pro/issues/189) - Fixed bug where empty days weren't shown at the end of the date range when `show_empty_days: true` was configured

## How Has This Been Tested

Testing has been conducted across:
- Multiple calendar configurations with various `days_to_show` ranges
- Scenarios with events in different distribution patterns (beginning, middle, or end of range)
- Different combinations of compact mode parameters (`compact_days_to_show`, `compact_events_to_show`)
- Configurations with `show_empty_days` enabled and disabled
- Edge cases where `compact_days_to_show` is greater than `days_to_show`
- Various browser environments including Firefox, Chrome, Safari, and Edge

All changes maintain backward compatibility with existing configurations.

## Types of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have thoroughly tested changes in my local Home Assistant environment
- [x] All changes maintain backward compatibility