### PR TITLE
fix: leading 0 for 24 hour format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Before contributing code, I strongly recommend reviewing my [architecture docume
 2. Clone your fork: `git clone https://github.com/[your-username]/calendar-card-pro.git`
 3. Install dependencies: `npm install`
 4. Start development mode: `npm run dev`
-5. The compiled card will be available in `dist/calendar-card-pro.js`
+5. The compiled card will be available in `dist/calendar-card-pro-dev.js`
 6. For testing in Home Assistant, follow the [testing instructions](#testing-in-home-assistant)
 
 ## Branch Structure

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -216,7 +216,7 @@ export function formatTime(date: Date, use24h = true): string {
     return `${hours}:${minutes.toString().padStart(2, '0')} ${ampm}`;
   }
 
-  return `${hours}:${minutes.toString().padStart(2, '0')}`;
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
 }
 
 /**


### PR DESCRIPTION
## Description

Add leading 0 to hours in 24 hour format if it is only 1 digit.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

The most common format for 24 hour time format is to always have 2 digits in the hour part. See e.g. ISO 8601 or Google Calendar UI.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by building dev version and installing it in Home Assistant, and then verifying the output:
![image](https://github.com/user-attachments/assets/661940ba-c8cd-472f-b618-129e6e22571a)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change in my local Home Assistant instance.
- [ ] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.
