### PR TITLE
Option to show UV index, incl threshold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calendar-card-pro-dev",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calendar-card-pro-dev",
-      "version": "3.0.6",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@material/web": "^2.2.0",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -110,6 +110,8 @@ export const DEFAULT_CONFIG: Types.Config = {
       show_conditions: true,
       show_high_temp: true,
       show_low_temp: false,
+      show_uvindex: true,
+      show_uvindex_threshold: 0,
       icon_size: '14px',
       font_size: '12px',
       color: 'var(--primary-text-color)',
@@ -117,6 +119,8 @@ export const DEFAULT_CONFIG: Types.Config = {
     event: {
       show_conditions: true,
       show_temp: true,
+      show_uvindex: true, 
+      show_uvindex_threshold: 0,      
       icon_size: '14px',
       font_size: '12px',
       color: 'var(--primary-text-color)',

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -119,8 +119,8 @@ export const DEFAULT_CONFIG: Types.Config = {
     event: {
       show_conditions: true,
       show_temp: true,
-      show_uvindex: true, 
-      show_uvindex_threshold: 0,      
+      show_uvindex: true,
+      show_uvindex_threshold: 0,
       icon_size: '14px',
       font_size: '12px',
       color: 'var(--primary-text-color)',

--- a/src/rendering/editor.ts
+++ b/src/rendering/editor.ts
@@ -1232,6 +1232,14 @@ export class CalendarCardProEditor extends LitElement {
                             'weather.date.show_low_temp',
                             this._getTranslation('show_low_temp'),
                           )}
+                          ${this.addBooleanField(
+                            'weather.date.show_uvindex',
+                            this._getTranslation('show_uvindex'),
+                          )}
+                          ${this.addTextField(
+                            'weather.date.show_uvindex_threshold',
+                            this._getTranslation('show_uvindex_threshold'),
+                          )}
                           ${this.addTextField(
                             'weather.date.icon_size',
                             this._getTranslation('icon_size'),
@@ -1255,6 +1263,14 @@ export class CalendarCardProEditor extends LitElement {
                             'weather.event.show_temp',
                             this._getTranslation('show_temp'),
                           )}
+                          ${this.addBooleanField(
+                            'weather.event.show_uvindex',
+                            this._getTranslation('show_uvindex'),
+                          )}
+                          ${this.addTextField(
+                            'weather.event.show_uvindex_threshold',
+                            this._getTranslation('show_uvindex_threshold'),
+                          )}                          
                           ${this.addTextField(
                             'weather.event.icon_size',
                             this._getTranslation('icon_size'),

--- a/src/rendering/editor.ts
+++ b/src/rendering/editor.ts
@@ -1270,7 +1270,7 @@ export class CalendarCardProEditor extends LitElement {
                           ${this.addTextField(
                             'weather.event.show_uvindex_threshold',
                             this._getTranslation('show_uvindex_threshold'),
-                          )}                          
+                          )}
                           ${this.addTextField(
                             'weather.event.icon_size',
                             this._getTranslation('icon_size'),

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -517,8 +517,7 @@ function renderDateColumn(
       const showConditions = dateConfig.show_conditions !== false;
       const showHighTemp = dateConfig.show_high_temp !== false;
       const showLowTemp = dateConfig.show_low_temp === true && dailyForecast.templow !== undefined;
-      const showUvIndex = (dateConfig.show_uvindex !== false) && (dailyForecast.uvindex >= dateConfig.show_uvindex_threshold); // technically I don't know if the threshold is a number, but then this returns false and should not create issues later. 
-
+      const showUvIndex = (dateConfig.show_uvindex !== false) && (dailyForecast.uvindex >= dateConfig.show_uvindex_threshold); 
 
       // Get styling from config
       const iconSize = dateConfig.icon_size || '14px';
@@ -541,12 +540,13 @@ function renderDateColumn(
           ${showLowTemp
             ? html` <span class="weather-temp-low">/${dailyForecast.templow}°</span> `
             : nothing}
-          ${showUvIndex 
+          ${showUvIndex
             ? html`<ha-icon icon="mdi:sun-wireless" style="--mdc-icon-size: ${iconSize};"></ha-icon>
-                   <span style="font-size: ${fontSize}; color: ${color}; white-space: nowrap; display: inline-block;">
-                     ${dailyForecast.uvindex}
-                   </span>`
-            : nothing}                 
+                <span
+                  style="font-size: ${fontSize}; color: ${color};">
+                  ${dailyForecast.uvindex}
+                </span>`
+            : nothing}
         </div>
       `;
     }
@@ -1046,8 +1046,8 @@ function renderEventWeather(
   const eventConfig = config.weather?.event || {};
   const showConditions = eventConfig.show_conditions !== false;
   const showTemp = eventConfig.show_temp !== false;
-  const showUvIndex = (eventConfig.show_uvindex !== false) && (forecast.uvindex >= eventConfig.show_uvindex_threshold);
-      
+  const showUvIndex = eventConfig.show_uvindex !== false && forecast.uvindex >= eventConfig.show_uvindex_threshold;
+
   // Get styling from config
   const iconSize = eventConfig.icon_size || '14px';
   const fontSize = eventConfig.font_size || '12px';
@@ -1066,10 +1066,10 @@ function renderEventWeather(
         : nothing}
       ${showUvIndex
         ? html`<ha-icon icon="mdi:sun-wireless" style="--mdc-icon-size: ${iconSize};"></ha-icon>
-               <span style="font-size: ${fontSize}; color: ${color}; white-space: nowrap;padding-left: 5px;">
-                  ${forecast.uvindex} 
-               </span>`
-        : nothing}         
+            <span style="font-size: ${fontSize}; color: ${color};">
+              ${forecast.uvindex}
+            </span>`
+        : nothing}
     </div>
   `;
 }

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -542,10 +542,10 @@ function renderDateColumn(
             : nothing}
           ${showUvIndex
             ? html`<ha-icon icon="mdi:sun-wireless" style="--mdc-icon-size: ${iconSize};"></ha-icon>
-                <span
-                  style="font-size: ${fontSize}; color: ${color};">
-                  ${dailyForecast.uvindex}
-                </span>`
+                   <span style="font-size: ${fontSize}; color: ${color};">
+                     ${dailyForecast.uvindex}
+                   </span>
+              `
             : nothing}
         </div>
       `;
@@ -1066,9 +1066,9 @@ function renderEventWeather(
         : nothing}
       ${showUvIndex
         ? html`<ha-icon icon="mdi:sun-wireless" style="--mdc-icon-size: ${iconSize};"></ha-icon>
-            <span style="font-size: ${fontSize}; color: ${color};">
-              ${forecast.uvindex}
-            </span>`
+               <span style="font-size: ${fontSize}; color: ${color};">
+                 ${forecast.uvindex}
+               </span>`
         : nothing}
     </div>
   `;

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -517,6 +517,8 @@ function renderDateColumn(
       const showConditions = dateConfig.show_conditions !== false;
       const showHighTemp = dateConfig.show_high_temp !== false;
       const showLowTemp = dateConfig.show_low_temp === true && dailyForecast.templow !== undefined;
+      const showUvIndex = (dateConfig.show_uvindex !== false) && (dailyForecast.uvindex >= dateConfig.show_uvindex_threshold); // technically I don't know if the threshold is a number, but then this returns false and should not create issues later. 
+
 
       // Get styling from config
       const iconSize = dateConfig.icon_size || '14px';
@@ -539,6 +541,12 @@ function renderDateColumn(
           ${showLowTemp
             ? html` <span class="weather-temp-low">/${dailyForecast.templow}°</span> `
             : nothing}
+          ${showUvIndex 
+            ? html`<ha-icon icon="mdi:sun-wireless" style="--mdc-icon-size: ${iconSize};"></ha-icon>
+                   <span style="font-size: ${fontSize}; color: ${color}; white-space: nowrap; display: inline-block;">
+                     ${dailyForecast.uvindex}
+                   </span>`
+            : nothing}                 
         </div>
       `;
     }
@@ -1038,7 +1046,8 @@ function renderEventWeather(
   const eventConfig = config.weather?.event || {};
   const showConditions = eventConfig.show_conditions !== false;
   const showTemp = eventConfig.show_temp !== false;
-
+  const showUvIndex = (eventConfig.show_uvindex !== false) && (forecast.uvindex >= eventConfig.show_uvindex_threshold);
+      
   // Get styling from config
   const iconSize = eventConfig.icon_size || '14px';
   const fontSize = eventConfig.font_size || '12px';
@@ -1055,6 +1064,12 @@ function renderEventWeather(
             ${forecast.temperature}°
           </span>`
         : nothing}
+      ${showUvIndex
+        ? html`<ha-icon icon="mdi:sun-wireless" style="--mdc-icon-size: ${iconSize};"></ha-icon>
+               <span style="font-size: ${fontSize}; color: ${color}; white-space: nowrap;padding-left: 5px;">
+                  ${forecast.uvindex} 
+               </span>`
+        : nothing}         
     </div>
   `;
 }

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -218,6 +218,8 @@
     "color": "Farbe",
     "event_row_weather": "Ereignisreihe Wetter",
     "show_temp": "Temperatur anzeigen",
+    "show_uvindex": "Zeige UV Index",
+    "show_uvindex_threshold": "Grenzwert ab dem der UV Index angezeigt werden soll",    
 
     "interactions": "Interaktionen",
     "tap_action": "Aktion antippen",

--- a/src/translations/languages/en.json
+++ b/src/translations/languages/en.json
@@ -210,7 +210,9 @@
     "color": "Color",
     "event_row_weather": "Event Row Weather",
     "show_temp": "Show temperature",
-
+    "show_uvindex": "Show UV index",
+    "show_uvindex_threshold": "Threshold when to show UV index",        
+    
     "interactions": "Interactions",
     "tap_action": "Tap Action",
     "hold_action": "Hold Action",

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -97,7 +97,7 @@ function processForecastData(
       hour,
       precipitation: item.precipitation,
       precipitation_probability: item.precipitation_probability,
-      uvindex: item.uv_index !== undefined ? Math.round(item.uv_index) : undefined, // not sure if the check !== undefined is really needed
+      uvindex: item.uv_index !== undefined ? Math.round(item.uv_index) : undefined, 
     };
   });
 

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -97,6 +97,7 @@ function processForecastData(
       hour,
       precipitation: item.precipitation,
       precipitation_probability: item.precipitation_probability,
+      uvindex: item.uv_index !== undefined ? Math.round(item.uv_index) : undefined, // not sure if the check !== undefined is really needed
     };
   });
 


### PR DESCRIPTION
## Description

Under weather there is a option to show the UV index, including a option to set a threshold from which onwards it is shown. 

## Related Issue

This PR fixes or closes issue: fixes #269 (was from me)

## Motivation and Context

High temperature or sunny weather correlate with the need to wear sun screen, but the UV index is best to have in sight. 

## How Has This Been Tested

Testing conducted on my home assistant instance. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] 🚀 New feature (non-breaking change which adds functionality)
- [X] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [X] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have tested the change in my local Home Assistant instance.
- [] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.

## Remarks
 - I don't frequently sent pull requests. 
 - The input threshold is not error checked, so users could add letters, later code can deal with this, but thats not ideal
 - I don't understand why the rending of icons works with a leading . before the "icon", but in my code I had to leave the dot out before the icon. Probably because I don't know ts. 
 - I was not able to make the threshold disappear, when show_uv is off. The code got too messy for me. 
 - I have not found a official icon for UV index and choose the next best. 
 - I was not sure, if UV index - which only I seem to request - should got at the very bottm on in the middle. 
 
## Preview
 - Left how it looks for events
 - Right how for days

<img width="263" height="386" alt="grafik" src="https://github.com/user-attachments/assets/e72f63a4-d296-40d8-986d-7162700d8285" />

And here how the editor looks
<img width="520" height="174" alt="grafik" src="https://github.com/user-attachments/assets/49c90f89-8261-47ce-a7d4-76ee3a0655c7" />


