### PR TITLE
fix: add RTL support for event borders and accent lines

### DIFF
--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -903,7 +903,7 @@ export function renderEvent(
         : ''}
       <td
         class=${classMap(eventClasses)}
-        style="border-left: var(--calendar-card-line-width-vertical) solid ${entityAccentColor}; background-color: ${entityAccentBackgroundColor};"
+        style="border-inline-start: var(--calendar-card-line-width-vertical) solid ${entityAccentColor}; background-color: ${entityAccentBackgroundColor};"
       >
         <div class="event-content">
           ${renderEventTitle(event, config, weatherForecasts)}

--- a/src/rendering/styles.ts
+++ b/src/rendering/styles.ts
@@ -441,12 +441,15 @@ export const cardStyles = css`
 
   /* Event positioning variations */
   .event-first.event-last {
-    border-radius: 0 var(--calendar-card-event-border-radius)
-      var(--calendar-card-event-border-radius) 0;
+    border-start-start-radius: 0;
+    border-start-end-radius: var(--calendar-card-event-border-radius);
+    border-end-end-radius: var(--calendar-card-event-border-radius);
+    border-end-start-radius: 0;
   }
 
   .event-first {
-    border-radius: 0 var(--calendar-card-event-border-radius) 0 0;
+    border-start-end-radius: var(--calendar-card-event-border-radius);
+    border-start-start-radius: 0;
   }
 
   .event-middle {
@@ -454,7 +457,8 @@ export const cardStyles = css`
   }
 
   .event-last {
-    border-radius: 0 0 var(--calendar-card-event-border-radius) 0;
+    border-end-end-radius: var(--calendar-card-event-border-radius);
+    border-end-start-radius: 0;
   }
 
   /* Past event styling */


### PR DESCRIPTION
This PR adds RTL language support for event borders and accent lines.

## Changes
- Replace border-left with border-inline-start for vertical accent line
- Add logical border-radius properties for proper RTL corner rounding

## Fixes
- Fix #259: RTL Language event alignment
- Fix #183: RTL language support

The vertical line now appears on the right side in RTL languages, and event corners are properly rounded on the appropriate side.