### PR TITLE
fix: default item color to undefined to ensure event_color config is applied

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -177,7 +177,7 @@ export function normalizeEntities(
       if (typeof item === 'string') {
         return {
           entity: item,
-          color: 'var(--primary-text-color)',
+          color: undefined,
           accent_color: undefined,
           label_icon_color: undefined,
         };
@@ -186,7 +186,7 @@ export function normalizeEntities(
         return {
           entity: item.entity,
           label: item.label,
-          color: item.color || 'var(--primary-text-color)',
+          color: item.color || undefined,
           accent_color: item.accent_color || undefined,
           label_icon_color: item.label_icon_color || undefined,
           show_time: item.show_time,


### PR DESCRIPTION
## Description

This is a fix for event_color not being applied.

## Related Issue

This PR fixes issue #284 

## Motivation and Context

### Problem

The top-level `event_color` config setting had no effect on event title colors. The fallback in `renderEventTitle` was dead code:

```typescript
event._matchedConfig?.color || config.event_color
```

`_matchedConfig.color` was **always truthy** because `normalizeEntities` unconditionally assigned `'var(--primary-text-color)'` as the default color for every entity — even when no per-entity color was configured by the user. The `|| config.event_color` branch could never be reached.

### Fix

Stop baking the default into `normalizeEntities`. Leave `color` as `undefined` when the user has not explicitly set a per-entity color:

```typescript
// Before
color: 'var(--primary-text-color)'          // string entity
color: item.color || 'var(--primary-text-color)'  // object entity

// After
color: undefined                             // string entity
color: item.color || undefined               // object entity
```

With `_matchedConfig.color` now `undefined` for un-configured entities, the fallback chain in `renderEventTitle` works as intended — applying `config.event_color` globally, while still allowing per-entity `color` overrides to take precedence.

All other consumers of `_matchedConfig.color` already carry their own `|| 'var(--primary-text-color)'` guards and are unaffected.

## How Has This Been Tested

According to the testing instructions from the project, I added calendar-card-pro-dev.js to my HA installation's resources and created a card instance on a dashboard.
I tested that event_color is now applied and other color configs still behave as expected, especially when leaving them blank in the config dialog / omitting them in the config yaml.

## Types of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change in my local Home Assistant instance.
- [ ] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.
