### PR TITLE
fix(editor): migrate ha-textfield to ha-input for HA 2026.5+

### DIFF
--- a/src/rendering/editor.styles.ts
+++ b/src/rendering/editor.styles.ts
@@ -14,6 +14,14 @@ export default css`
     margin: 8px 0;
   }
 
+  /*
+   * ha-input (HA 2026.4+) replaces ha-textfield. It is display: flex with its
+   * own vertical padding, so it only needs an explicit width to fill the editor.
+   */
+  ha-input {
+    width: 100%;
+  }
+
   .card-config {
     display: flex;
     flex-direction: column;

--- a/src/rendering/editor.ts
+++ b/src/rendering/editor.ts
@@ -11,6 +11,7 @@
 //-----------------------------------------------------------------------------
 
 import { LitElement, TemplateResult, html, nothing } from 'lit';
+import { literal, html as staticHtml } from 'lit/static-html.js';
 import { property } from 'lit/decorators.js';
 import styles from './editor.styles';
 import * as Types from '../config/types';
@@ -29,6 +30,37 @@ import {
   mdiPalette, // For Appearance & Layout
   mdiWeatherPartlyCloudy, // For Weather Integration
 } from '@mdi/js';
+
+/**
+ * Text input element tag.
+ *
+ * Home Assistant 2026.4 introduced `ha-input` as the successor of `ha-textfield`
+ * and removed `ha-textfield` in 2026.5, which made every text-based field in the
+ * visual editor render as nothing. Detect which element the running frontend
+ * provides so the editor keeps working on both old and new Home Assistant versions.
+ *
+ * Resolved lazily on first use rather than at module load, because the card bundle
+ * can be evaluated before Home Assistant has registered its own components. The
+ * result is only cached once one of the two elements is actually defined, so an
+ * early render can never permanently pin the editor to the wrong element.
+ */
+let haInputTag: ReturnType<typeof literal> | undefined;
+
+function getInputTag(): ReturnType<typeof literal> {
+  if (haInputTag !== undefined) return haInputTag;
+
+  if (customElements.get('ha-input')) {
+    haInputTag = literal`ha-input`;
+  } else if (customElements.get('ha-textfield')) {
+    haInputTag = literal`ha-textfield`;
+  } else {
+    // Neither is registered yet — assume the current element without caching,
+    // so the next render can still resolve the correct one.
+    return literal`ha-input`;
+  }
+
+  return haInputTag;
+}
 
 // Deprecated parameter mappings for config upgrade
 const DEPRECATED_CONFIG_MAP: Record<string, string> = {
@@ -425,9 +457,9 @@ export class CalendarCardProEditor extends LitElement {
       return; // Don't save the UI mode itself to config
     } else if (name === 'start_date_fixed' || name === 'start_date_offset') {
       // These are UI-only fields that map to the single 'start_date' parameter
-      // For offset field, only apply on blur/enter (change), not on every keystroke (keyup),
+      // For offset field, only apply on blur/enter (change), not on every keystroke,
       // because intermediate values (e.g. empty or "-") change the detected mode and hide the field
-      if (name === 'start_date_offset' && event.type === 'keyup') return;
+      if (name === 'start_date_offset' && event.type !== 'change') return;
       this.setConfigValue('start_date', target.value);
       this.requestUpdate();
       return; // Don't save these UI fields to config
@@ -1194,13 +1226,14 @@ export class CalendarCardProEditor extends LitElement {
                   // Show custom pattern field if we have a string value that's not 'true'/'false'
                   const value = this._config.remove_location_country;
                   if (typeof value === 'string' && value !== 'true' && value !== 'false') {
-                    return html`
-                      <ha-textfield
+                    const inputTag = getInputTag();
+                    return staticHtml`
+                      <${inputTag}
                         label="${this._getTranslation('custom_country_pattern')}"
                         .value="${value}"
                         @change="${(e) =>
                           this.setConfigValue('remove_location_country', e.target.value)}"
-                      ></ha-textfield>
+                      ></${inputTag}>
                       <div class="helper-text">
                         ${this._getTranslation('custom_country_pattern_note')}
                       </div>
@@ -1458,15 +1491,17 @@ export class CalendarCardProEditor extends LitElement {
       value = ''; // Empty string instead of undefined
     }
 
-    return html`
-      <ha-textfield
+    const inputTag = getInputTag();
+
+    return staticHtml`
+      <${inputTag}
         name="${name}"
         label="${label ?? this._getTranslation(name)}"
         type="${type ?? 'text'}"
         .value="${value}"
-        @keyup="${this._valueChanged}"
+        @input="${this._valueChanged}"
         @change="${this._valueChanged}"
-      ></ha-textfield>
+      ></${inputTag}>
     `;
   }
 
@@ -1915,6 +1950,7 @@ export class CalendarCardProEditor extends LitElement {
       unknown
     >;
     const action = (actionConfig.action as string) || 'none';
+    const inputTag = getInputTag();
 
     return html`
       <div class="action-config">
@@ -1934,41 +1970,41 @@ export class CalendarCardProEditor extends LitElement {
         </ha-select>
 
         ${action === 'navigate'
-          ? html`
-              <ha-textfield
+          ? staticHtml`
+              <${inputTag}
                 name="${configKey}.navigation_path"
                 .value="${actionConfig.navigation_path || ''}"
                 label="${this._getTranslation('navigation_path')}"
                 @change="${this._valueChanged}"
-              ></ha-textfield>
+              ></${inputTag}>
             `
           : html``}
         ${action === 'url'
-          ? html`
-              <ha-textfield
+          ? staticHtml`
+              <${inputTag}
                 name="${configKey}.url_path"
                 .value="${actionConfig.url_path || ''}"
                 label="${this._getTranslation('url_path')}"
                 @change="${this._valueChanged}"
-              ></ha-textfield>
+              ></${inputTag}>
             `
           : html``}
         ${action === 'call-service'
-          ? html`
-              <ha-textfield
+          ? staticHtml`
+              <${inputTag}
                 name="${configKey}.service"
                 .value="${actionConfig.service || ''}"
                 label="${this._getTranslation('service')}"
                 @change="${this._valueChanged}"
-              ></ha-textfield>
-              <ha-textfield
+              ></${inputTag}>
+              <${inputTag}
                 name="${configKey}.service_data"
-                .value="${actionConfig.service_data
-                  ? JSON.stringify(actionConfig.service_data)
-                  : '{}'}"
+                .value="${
+                  actionConfig.service_data ? JSON.stringify(actionConfig.service_data) : '{}'
+                }"
                 label="${this._getTranslation('service_data')}"
                 @change="${this._serviceDataChanged}"
-              ></ha-textfield>
+              ></${inputTag}>
             `
           : html``}
       </div>
@@ -2167,23 +2203,27 @@ export class CalendarCardProEditor extends LitElement {
           ? this._getTranslation('emoji_indicator_note')
           : this._getTranslation('text_label_note');
 
-      return html`
-        <ha-textfield
+      const inputTag = getInputTag();
+
+      return staticHtml`
+        <${inputTag}
           name="${path}"
           label="${fieldLabel}"
           .value="${value as string}"
           @change="${this._valueChanged}"
-        ></ha-textfield>
+        ></${inputTag}>
         <div class="helper-text">${helperText}</div>
       `;
     } else if (valueType === 'image') {
-      return html`
-        <ha-textfield
+      const inputTag = getInputTag();
+
+      return staticHtml`
+        <${inputTag}
           name="${path}"
           label="${this._getTranslation('image_path')}"
           .value="${value as string}"
           @change="${this._valueChanged}"
-        ></ha-textfield>
+        ></${inputTag}>
         <div class="helper-text">${this._getTranslation('image_indicator_note')}</div>
       `;
     }


### PR DESCRIPTION
## Description

Home Assistant 2026.4 introduced `ha-input` as the successor of `ha-textfield` and **removed `ha-textfield` entirely in 2026.5** ([home-assistant/frontend#30349](https://github.com/home-assistant/frontend/pull/30349), commit `ab20383`). Because the visual editor still emitted `<ha-textfield>`, every text-based field rendered as *nothing* on HA 2026.5+, leaving the editor largely unusable.

This migrates the editor to `ha-input` while keeping older Home Assistant versions working.

## Related Issue

Fixes #338

## Motivation and Context

Issue #338 has 7 👍 and multiple comments asking whether the project is still maintained. Every `ha-textfield`-backed field — colours, font sizes, spacing, title, navigation paths, service data, and more — is invisible in the visual editor on current Home Assistant.

### Approach

The input element is resolved at render time via `customElements.get()` and emitted through lit's `static-html`, so the editor renders the correct element on both old and new Home Assistant:

```ts
if (customElements.get('ha-input'))          → ha-input
else if (customElements.get('ha-textfield')) → ha-textfield
else                                          → ha-input (not cached)
```

The result is cached **only once one of the two elements is actually defined**. The card bundle can be evaluated before Home Assistant registers its own components, so caching an early "neither exists yet" guess could otherwise permanently pin the editor to the wrong element.

Verified against all three Home Assistant scenarios plus both first-render race conditions:

| Scenario | Resolves to |
|---|---|
| HA 2026.3 (only `ha-textfield`) | `ha-textfield` |
| HA 2026.4 (both registered) | `ha-input` |
| HA 2026.5+ (only `ha-input`) | `ha-input` |
| Empty registry → `ha-input` appears | `ha-input` |
| Empty registry → `ha-textfield` appears | `ha-textfield` |

### Additional changes

- **`keyup` → `input`** on the shared text field. `keyup` is not explicitly handled by `ha-input` and does not reliably cross its shadow DOM.
- **`start_date_offset` guard updated** to key off `change` instead of `keyup`. Without this the field would commit on every keystroke, changing the detected start-date mode and making the field vanish mid-edit — re-breaking the fix from 9e23877.
- **CSS**: added `ha-input { width: 100%; }`. `ha-input` is `display: flex` with its own vertical padding, unlike `ha-textfield`'s `display: block` + explicit margin. The existing `ha-textfield` rule is left in place for older Home Assistant.

### Scope

Only `ha-textfield` was removed in this wave. `ha-select`, `ha-formfield`, `ha-entity-picker`, `ha-icon-picker`, `ha-switch`, `ha-expansion-panel`, `ha-alert`, `ha-button`, `ha-icon`, and `ha-svg-icon` are all still present and need no changes. The editor's `ha-select` handlers already use `@selected`, which matches the current API.

No API surface used by this card was renamed — `type="number"`, `min`/`max`/`step`, `name`, `label`, and `.value` all carry over unchanged. The card uses its own `.helper-text` divs rather than the `helper` attribute (renamed to `hint`), and does not use `prefix`/`suffix` (now slots), so nothing else needed adjusting.

## How Has This Been Tested

- `npx tsc --noEmit` — passes
- `npm run lint` — passes
- `npm run format` — clean
- `npm run build` — succeeds; verified the bundle contains the feature check and both tag names
- Element-detection logic simulated across all three HA versions and both race conditions (table above)

⚠️ **Not yet verified in a live Home Assistant instance** — worth a smoke test on HA 2026.5+ before release to confirm the fields render and save correctly.

## Types of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have tested the change in my local Home Assistant instance.
- [ ] I have followed the translation guidelines if I'm adding or updating a translation.