### PR TITLE
fix(ci): restore MIT license detection and modernize action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'alexpfau/calendar-card-pro'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: HACS validation
         uses: hacs/action@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -51,7 +51,7 @@ jobs:
         run: npm run build
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: true
           body_path: release-body.md

--- a/LICENSE
+++ b/LICENSE
@@ -19,28 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-## THIRD-PARTY LICENSES AND ATTRIBUTIONS
-
-Calendar Card Pro incorporates code and design elements from the following projects:
-
-1. lit / LitElement
-   Copyright (c) 2017 Google LLC
-   BSD-3-Clause License
-   https://github.com/lit/lit/
-
-2. Home Assistant Frontend
-   Copyright (c) 2013-present Home Assistant contributors
-   Apache License 2.0
-   https://github.com/home-assistant/frontend
-
-   Calendar Card Pro uses components from and is designed to work with
-   Home Assistant. Interaction patterns were inspired by Home Assistant's
-   Tile Card component.
-
-3. Design Inspiration
-   Calendar design elements were inspired by Home Assistant community member
-   @kdw2060's button-card calendar design.
-   https://community.home-assistant.io/t/calendar-add-on-some-calendar-designs/385790

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,24 @@
+THIRD-PARTY LICENSES AND ATTRIBUTIONS
+
+Calendar Card Pro is licensed under the MIT License (see LICENSE).
+
+It incorporates code and design elements from the following projects:
+
+1. lit / LitElement
+   Copyright (c) 2017 Google LLC
+   BSD-3-Clause License
+   https://github.com/lit/lit/
+
+2. Home Assistant Frontend
+   Copyright (c) 2013-present Home Assistant contributors
+   Apache License 2.0
+   https://github.com/home-assistant/frontend
+
+   Calendar Card Pro uses components from and is designed to work with
+   Home Assistant. Interaction patterns were inspired by Home Assistant's
+   Tile Card component.
+
+3. Design Inspiration
+   Calendar design elements were inspired by Home Assistant community member
+   @kdw2060's button-card calendar design.
+   https://community.home-assistant.io/t/calendar-add-on-some-calendar-designs/385790

--- a/README.md
+++ b/README.md
@@ -1576,6 +1576,8 @@ To add a new language:
 - **Interaction patterns** inspired by Home Assistant’s [Tile Card](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/cards/hui-tile-card.ts), which is licensed under the [Apache License 2.0](https://github.com/home-assistant/frontend/blob/dev/LICENSE.md).
 - **Material Design ripple interactions**, originally by Google, used under the [Apache License 2.0](https://github.com/material-components/material-components-web/blob/master/LICENSE).
 
+Calendar Card Pro is released under the [MIT License](./LICENSE). Full third-party attributions are listed in [NOTICE](./NOTICE).
+
 <p align="right"><a href="#top">⬆️ back to top</a></p>
 
  <!--Badges-->


### PR DESCRIPTION
Docs/CI-only maintenance. **No source changes — the shipped bundle is byte-identical to v3.3.0, so no version bump.**

## Why

The daily HACS validation run has been failing, not warning:

```
<Validation license> failed: The repository license could not be identified (SPDX: NOASSERTION)
<Plugin alexpfau/calendar-card-pro> 1/8 checks failed
```

GitHub detects licenses with [licensee](https://github.com/licensee/licensee), whose `similarity` is a Sørensen–Dice coefficient over the **set of unique words** in the file, with a 98% threshold. Because it is a *set*, appending unrelated prose inflates the denominator while the overlap stays fixed, so the score collapses.

`LICENSE` had a `## THIRD-PARTY LICENSES AND ATTRIBUTIONS` block appended below the MIT text. That contributed 52 of 143 unique words and scored **77.78%** — well under the threshold — so GitHub reported `NOASSERTION` and HACS rejected it.

Measured with a local reimplementation of the licensee algorithm (self-validated against canonical MIT = 100%):

| | similarity |
|---|---|
| before | 77.78% ❌ |
| after | 100.00% ✅ |

## Changes

- **`LICENSE`** — now verbatim MIT and nothing else. Also fixed unusual `600` file permissions to `644`.
- **`NOTICE`** *(new)* — the three third-party attributions moved here verbatim (lit BSD-3-Clause, Home Assistant Frontend Apache-2.0, @kdw2060 design credit). Nothing was dropped.
- **`README.md`** — points at both files from the Acknowledgements section.
- **Workflow runtimes** — `actions/checkout` → `v7`, `actions/setup-node` → `v7`, `softprops/action-gh-release` → `v3`, and `node-version` `20` → `24`. Node 20 reached EOL in April 2026; GitHub was already force-running these actions on Node 24 and emitting deprecation warnings. `action-gh-release@v3` is a pure runtime bump with no input changes, so `draft`/`body_path`/`files` are unaffected.

> [!IMPORTANT]
> Do not append anything to `LICENSE` again — even a one-line pointer to `NOTICE` adds unique words and lowers the similarity score. That is why the pointer lives in `README.md` instead.

## Verification

- Local licensee-algorithm check: 100.00%, 0 foreign words
- Dispatching the HACS workflow against `dev` still failed, proving the check reads the repository default branch and the fix must land on `main`
- All three workflows re-parsed as valid YAML
- `npm run format` clean
- Diff confirms the MIT body itself is untouched; only the appended block was removed

Once merged, `repos/alexpfau/calendar-card-pro/license` should report `MIT` and the nightly run should pass 8/8.
