### PR TITLE
fix(countdown): count whole calendar days for all-day events

### DIFF
--- a/src/translations/dayjs.ts
+++ b/src/translations/dayjs.ts
@@ -51,11 +51,13 @@ import 'dayjs/locale/zh-tw';
  *
  * @param date Target date
  * @param locale Language code
+ * @param reference Instant to measure from; defaults to now
  * @returns Formatted relative time string
  */
-export function getRelativeTimeString(date: Date, locale: string): string {
+export function getRelativeTimeString(date: Date, locale: string, reference?: Date): string {
   const mappedLocale = mapLocale(locale);
-  return dayjs(date).locale(mappedLocale).fromNow();
+  const target = dayjs(date).locale(mappedLocale);
+  return reference ? target.from(dayjs(reference)) : target.fromNow();
 }
 
 /**

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -104,6 +104,9 @@ export function formatEventTime(
  * Generates a localized countdown string for an event
  * Uses dayjs for consistent, localized relative time formatting
  *
+ * All-day events are measured from the start of today rather than from the
+ * current instant, so the countdown reflects whole calendar days.
+ *
  * @param event Calendar event to generate countdown for
  * @param language Language to use
  * @returns Countdown string or null if event is past or empty day
@@ -116,6 +119,7 @@ export function getCountdownString(
   if (event._isEmptyDay || !event.start) return null;
 
   const now = new Date();
+  const isAllDayEvent = !event.start.dateTime;
   const startDate = event.start.dateTime
     ? new Date(event.start.dateTime)
     : event.start.date
@@ -124,8 +128,17 @@ export function getCountdownString(
 
   if (!startDate || startDate <= now) return null;
 
+  // All-day events start at local midnight and carry no meaningful time of day.
+  // Measuring from the current instant would count remaining 24-hour periods, so
+  // the countdown drops a day once the clock passes midday and renders tomorrow's
+  // event as "in 4 hours". Anchoring to the start of today makes the difference a
+  // whole number of calendar days, which is what an all-day countdown means.
+  const reference = isAllDayEvent
+    ? new Date(now.getFullYear(), now.getMonth(), now.getDate())
+    : undefined;
+
   // Use dayjs for relative time formatting
-  return getRelativeTimeString(startDate, language);
+  return getRelativeTimeString(startDate, language, reference);
 }
 
 /**


### PR DESCRIPTION
## Problem

All-day events parse to **local midnight** and are then handed to dayjs's `relativeTime`
plugin, which does an exact millisecond diff and rounds it. That is the wrong semantic for
a date-only event, and it produces two distinct symptoms:

**1. The reported off-by-one.** Viewing an all-day event on 19 Jun from 14 Jun:

| Time of day | Before | After |
|---|---|---|
| 00:00 – 12:00 | `in 5 days` ✅ | `in 5 days` |
| 12:01 – 23:59 | `in 4 days` ❌ | `in 5 days` |

The flip point is exactly midday, so roughly half of every day showed the wrong value —
matching the reporter's "for most of the current day".

**2. An unreported second symptom.** An all-day event **tomorrow** counted down in *hours*:

```
08:00 → "in 16 hours"    14:00 → "in 10 hours"    20:00 → "in 4 hours"
```

An hours-precision countdown is meaningless for an event with no time of day.

## Fix

For all-day events only, measure from the **start of today** instead of the current
instant. Midnight-to-midnight is always a whole number of calendar days, so the rounding
can no longer land on the wrong one.

Timed events are untouched and keep exact instant-to-instant behaviour. The existing
`startDate <= now` guard is deliberately still evaluated against the original start date,
so an all-day event already under way continues to show no countdown.

No new configuration surface — the previous output was simply incorrect, so there is
nothing worth making opt-in.

## Why this is DST-safe

dayjs caps its `hh` threshold at 21 hours and `d` at 35 hours. A DST-shifted 23-hour or
25-hour span therefore still renders as "a day", which is verified explicitly below.

## Validation

The real `getCountdownString` was bundled from source and exercised under a faked clock —
24 assertions, all passing:

- Reporter's scenario at 7 times of day, including either side of the midday flip point
- All-day event tomorrow at 5 times of day
- Three Europe/London DST boundaries (spring forward, fall back, and a span crossing each)
- Guard behaviour: event today, event yesterday, and empty days all still return `null`
- Timed events unchanged (`in 4 hours`, `in 5 days`, past → `null`)
- Localisation preserved through the new code path (`de`, `pl`, `lv`)

Also `npx tsc --noEmit`, `npm run lint`, `npm run build` — all clean.
Deployed to the live HA instance for visual confirmation.

Fixes #344
