### PR TITLE
fix: ignore empty and invalid numeric config values

### DIFF
--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -487,6 +487,7 @@ class CalendarCardPro extends LitElement {
 
     this.config = mergedConfig;
     this.config.entities = Config.normalizeEntities(this.config.entities);
+    Config.normalizeNumericOptions(this.config);
 
     // Generate deterministic ID for caching
     this._instanceId = Helpers.generateDeterministicId(

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -148,6 +148,54 @@ export const DEFAULT_CONFIG: Types.Config = {
 //-----------------------------------------------------------------------------
 
 /**
+ * Coerces a raw configuration value into a usable number.
+ *
+ * The visual editor persists an empty string when a numeric field is cleared, and
+ * hand-written YAML can supply `null` or non-numeric text. Such values pass the
+ * `!== undefined` guards used throughout the card but then coerce to `0` in numeric
+ * comparisons, silently suppressing events or entire days (issue #327).
+ *
+ * @param value - Raw value taken from the user configuration
+ * @param minimum - Smallest value that should be treated as valid
+ * @returns The numeric value, or `undefined` when it cannot be used
+ */
+export function toValidNumber(value: unknown, minimum = 0): number | undefined {
+  const parsed = typeof value === 'string' && value.trim() !== '' ? Number(value) : value;
+
+  if (typeof parsed !== 'number' || !Number.isFinite(parsed) || parsed < minimum) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+/**
+ * Sanitizes every numeric option so invalid values fall back to their defaults.
+ *
+ * Applied on each `setConfig` call, which means configurations already saved with an
+ * empty value recover automatically without the user having to edit them again.
+ *
+ * @param config - Configuration to normalize (mutated in place)
+ * @returns The same configuration instance, for chaining
+ */
+export function normalizeNumericOptions(config: Types.Config): Types.Config {
+  // Required values fall back to their defaults; a missing or invalid value must never
+  // reduce the visible range to zero.
+  config.days_to_show = toValidNumber(config.days_to_show, 1) ?? DEFAULT_CONFIG.days_to_show;
+  config.refresh_interval =
+    toValidNumber(config.refresh_interval, 1) ?? DEFAULT_CONFIG.refresh_interval;
+  config.event_background_opacity =
+    toValidNumber(config.event_background_opacity, 0) ?? DEFAULT_CONFIG.event_background_opacity;
+
+  // Optional limits: `undefined` means "no limit", so invalid values clear them rather
+  // than collapsing to zero and hiding content.
+  config.compact_days_to_show = toValidNumber(config.compact_days_to_show, 1);
+  config.compact_events_to_show = toValidNumber(config.compact_events_to_show, 0);
+
+  return config;
+}
+
+/**
  * Normalizes entity configuration to ensure consistent format
  */
 export function normalizeEntities(
@@ -193,7 +241,7 @@ export function normalizeEntities(
           show_time: item.show_time,
           show_location: item.show_location,
           show_description: item.show_description,
-          compact_events_to_show: item.compact_events_to_show,
+          compact_events_to_show: toValidNumber(item.compact_events_to_show, 0),
           blocklist: item.blocklist,
           allowlist: item.allowlist,
           split_multiday_events: item.split_multiday_events,

--- a/src/rendering/editor.ts
+++ b/src/rendering/editor.ts
@@ -406,7 +406,7 @@ export class CalendarCardProEditor extends LitElement {
     const target = event.target as HTMLInputElement | HTMLSelectElement;
     const name = target.getAttribute('name');
 
-    let value: string | boolean | number | null = target.value;
+    let value: string | boolean | number | null | undefined = target.value;
 
     if (!name) return;
 
@@ -479,8 +479,11 @@ export class CalendarCardProEditor extends LitElement {
     }
 
     // Handle numeric inputs
-    if (target.getAttribute('type') === 'number' && value !== '') {
-      value = parseFloat(value as string);
+    if (target.getAttribute('type') === 'number') {
+      // An emptied field must remove the key instead of persisting an empty string.
+      // Empty strings survive `!== undefined` guards and then coerce to 0 in numeric
+      // comparisons, which silently hides events or blanks the card (issue #327).
+      value = value === '' ? undefined : parseFloat(value as string);
     }
 
     this.setConfigValue(name, value);

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -358,8 +358,10 @@ export function groupEventsByDay(
         }
         const configKey = configIdx !== -1 ? `${entityId}__${configIdx}` : entityId || '';
         // Get entity-specific compact_events_to_show (if set)
+        // Guard on the type rather than `=== undefined`: a non-numeric value would
+        // otherwise coerce to 0 below and drop every event for this entity (issue #327).
         const entityMaxEvents = matchedConfig?.compact_events_to_show;
-        if (entityMaxEvents === undefined) {
+        if (typeof entityMaxEvents !== 'number' || !Number.isFinite(entityMaxEvents)) {
           filteredEvents.push(event);
           continue;
         }
@@ -385,7 +387,9 @@ export function groupEventsByDay(
     // Get the effective max events setting
     const maxEvents = config.compact_events_to_show;
 
-    if (maxEvents !== undefined) {
+    // Type guard mirrors the per-entity check above (issue #327): a non-numeric value
+    // must mean "no limit" rather than collapsing to 0 in the comparisons below.
+    if (typeof maxEvents === 'number' && Number.isFinite(maxEvents)) {
       let filteredDays: Types.EventsByDay[] = [];
       let totalEventsShown = 0;
 


### PR DESCRIPTION
## Problem

Clearing a numeric field in the visual editor persists an **empty string** rather than removing the key. Empty strings slip past the `!== undefined` guards the card uses throughout, then coerce to `0` in numeric comparisons — so `currentCount < ""` is always `false` and **every event for that entity is dropped**.

The reporter's calendar had a per-entity limit written as:

```yaml
- entity: calendar.rhs25_26
  compact_events_to_show: ""
```

## Not actually an all-day bug

The issue reads as "all-day events never show", but the filtering happens at the **entity** level — timed events on that calendar vanish identically. The reporter's school calendar simply happened to contain only all-day events, so its total disappearance looked like an all-day rendering failure.

## Blast radius is wider than reported

Measured against a reproduction harness:

| cleared field | effect before this PR |
| --- | --- |
| per-entity `compact_events_to_show` | that entity disappears (the reported symptom) |
| global `compact_events_to_show` | **entire card renders empty** |
| global `days_to_show` | **entire card renders empty** |
| global `compact_days_to_show` | safe — read with `\|\|`, falls back |

So a user could blank their whole card just by selecting a number field's contents and pressing delete.

## Fix

Three layers, because each one alone leaves a gap:

**Producer** — `src/rendering/editor.ts`
An emptied `type="number"` input now writes `undefined`. `setConfigValue` already deletes a key on `undefined`, so nothing is persisted at all. The field stays visually empty; no default is repopulated and the cursor doesn't jump.

**Normalizer** — `src/config/config.ts`
New `toValidNumber()` and `normalizeNumericOptions()`, called from `setConfig()`. This is the part that matters most for anyone already affected: **configurations saved with an empty value repair themselves on load**, so the reporter doesn't have to hunt down and re-edit the broken field.

Required options fall back to `DEFAULT_CONFIG`; optional limits become `undefined`, meaning "no limit".

**Consumers** — `src/utils/events.ts`
Both event limiters now guard on the value being a finite number rather than merely not `undefined`, so a bad value can never reach the comparison.

## Behaviour preserved

- `0` still means "hide this entity" — only `''`, `null`, `NaN`, negatives and non-finite values are neutralized
- numeric strings such as `"3"` still work, so YAML-quoted numbers keep functioning
- `days_to_show`, `compact_days_to_show` and `refresh_interval` use a minimum of `1`, since `0` is meaningless there and would blank the card

## Verification

No test framework in this repo, so the fix was checked with a throwaway harness that bundles `src/` and drives `groupEventsByDay()` through the real `setConfig()` normalization path:

```
PASS  key omitted entirely                         school=3  (expected 3)
PASS  compact_events_to_show: "" (reporter!)       school=3  (expected 3)
PASS  compact_events_to_show: null                 school=3  (expected 3)
PASS  compact_events_to_show: "   " (whitespace)   school=3  (expected 3)
PASS  compact_events_to_show: "abc" (garbage)      school=3  (expected 3)
PASS  compact_events_to_show: -1 (negative)        school=3  (expected 3)
PASS  compact_events_to_show: 2 (a real limit)     school=2  (expected 2)
PASS  compact_events_to_show: "3" (numeric string) school=3  (expected 3)
PASS  compact_events_to_show: 0 (explicit zero)    school=0  (expected 0)

9/9 passed
```

Both "card renders empty" cases in the blast-radius run are gone; `days_to_show: ""` now correctly falls back to the default of 3 rather than rendering nothing.

`npx tsc --noEmit`, `npm run lint` and `npm run build` all clean. Harness files were removed before committing.

Fixes #327
