### PR TITLE
fix: allow expanding when the only compact limit is 0 or per-entity

### DIFF
--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -560,10 +560,32 @@ class CalendarCardPro extends LitElement {
   }
 
   /**
+   * Determine whether compact mode is actually limiting what the card renders.
+   *
+   * Mirrors the guards in `groupEventsByDay`: a limit counts as set when it is a
+   * finite number, not merely truthy. `compact_events_to_show: 0` is a valid
+   * configuration meaning "show nothing until expanded", and per-entity limits
+   * constrain the compact view even when no global limit is set.
+   */
+  private hasCompactModeLimits(): boolean {
+    const isLimit = (value: unknown): boolean =>
+      typeof value === 'number' && Number.isFinite(value);
+
+    if (isLimit(this.config.compact_events_to_show) || isLimit(this.config.compact_days_to_show)) {
+      return true;
+    }
+
+    return (this.config.entities ?? []).some(
+      (entity) =>
+        typeof entity === 'object' && entity !== null && isLimit(entity.compact_events_to_show),
+    );
+  }
+
+  /**
    * Toggle expanded state for view modes with limited events
    */
   toggleExpanded(): void {
-    if (this.config.compact_events_to_show || this.config.compact_days_to_show) {
+    if (this.hasCompactModeLimits()) {
       this.isExpanded = !this.isExpanded;
     }
   }


### PR DESCRIPTION
### Why

`toggleExpanded()` refuses to do anything unless the card is actually in compact mode. Reasonable — but the check it used had drifted away from what `groupEventsByDay()` actually honours, in two separate ways.

```ts
if (this.config.compact_events_to_show || this.config.compact_days_to_show) {
  this.isExpanded = !this.isExpanded;
}
```

**1. `compact_events_to_show: 0` could never be expanded.**
Since #327 that is a valid value meaning *"show nothing until expanded"* — `normalizeNumericOptions` deliberately allows a minimum of `0` for this key. But `0` is falsy, so the guard treated it as unset. The card rendered empty, tapping it did nothing, and there was no way back.

**2. Per-entity limits were invisible to the guard.**
`groupEventsByDay()` applies a per-entity `compact_events_to_show` independently of the card-level one, so a card can be genuinely hiding events with no card-level limit set at all. `toggleExpanded()` never looked at `config.entities`, so those cards also refused to expand.

### What changed

Extracted the check into `hasCompactModeLimits()`, which mirrors the guard `groupEventsByDay()` uses on the same values — a limit counts as set when it is a *finite number*, not merely truthy — and additionally walks per-entity configs.

`compact_days_to_show` needs no special handling (`normalizeNumericOptions` gives it a minimum of 1, so it can never legitimately be `0`); it goes through the same helper purely for consistency.

No config changes, no new options, no visual changes to correctly-configured cards.

### Testing

Deployed to a live Home Assistant instance and verified against four dedicated test cards:

- `compact_events_to_show: 0` — renders empty, now expands to the full range and collapses again
- per-entity limit only, no card-level limit — compact view caps that entity, expand reveals the rest
- correctly-configured compact card — unchanged, still expands and collapses
- card with no compact limits at all — unchanged, tapping is still a no-op

Also `tsc --noEmit`, `eslint`, and a production build.

### Related Issues

None — this was found while investigating #335 but is independent of it. #335 was a configuration trap, not a code defect; this is a genuine defect that predates it.
