### PR TITLE
perf: memoize color to RGBA conversion

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -10,13 +10,49 @@
 //-----------------------------------------------------------------------------
 
 /**
+ * Cache of resolved RGBA strings, keyed by `${color}|${opacity}`.
+ *
+ * Resolving a color requires a synchronous layout flush (see computeRGBA), which is
+ * far too expensive to repeat for every event on every render. Colors and opacity both
+ * come from the card configuration, so the number of distinct keys stays very small.
+ *
+ * Theme-dependent colors are not cached by value here: `var(...)` colors short-circuit
+ * before any computed-style lookup and resolve to a CSS expression that the browser
+ * re-evaluates itself, so a theme switch is still picked up correctly.
+ */
+const rgbaCache = new Map<string, string>();
+
+/**
  * Convert any color format to RGBA with specific opacity
+ *
+ * Results are memoized because the underlying color resolution forces a synchronous
+ * reflow and this is called once per rendered event.
  *
  * @param color - Color in any valid CSS format
  * @param opacity - Opacity value (0-100)
  * @returns RGBA color string
  */
 export function convertToRGBA(color: string, opacity: number): string {
+  const cacheKey = `${color}|${opacity}`;
+
+  const cached = rgbaCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const result = computeRGBA(color, opacity);
+  rgbaCache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Resolve a color to RGBA, without caching.
+ *
+ * @param color - Color in any valid CSS format
+ * @param opacity - Opacity value (0-100)
+ * @returns RGBA color string
+ */
+function computeRGBA(color: string, opacity: number): string {
   // If color is a CSS variable, we need to handle it specially
   if (color.startsWith('var(')) {
     // Create a temporary CSS variable with opacity


### PR DESCRIPTION
## What

`convertToRGBA()` resolved every colour by creating a `<div>`, appending it to `document.body`, reading `getComputedStyle()`, then removing it again. That is a forced synchronous layout, and it ran **once per rendered event, on every render**.

With `days_to_show: 60` and a busy calendar that is hundreds of forced layouts per refresh — repeated on every `refresh_interval` tick, and again on every config change. The inputs are drawn from the card config, so the same handful of colour/opacity pairs were being recomputed from scratch over and over.

## How

Results are now memoized in a module-level `Map` keyed by `` `${color}|${opacity}` ``. The original body moved verbatim into a private `computeRGBA()`; `convertToRGBA()` is a thin cache wrapper in front of it. No behavioural change.

Cache cardinality is bounded by (distinct configured colours × distinct configured opacities), which is tiny, so no eviction policy is needed.

### Why this is safe for themes

Theme-dependent colours are unaffected. A `var(...)` colour short-circuits at the top of `computeRGBA()` **before** any `getComputedStyle()` call and returns a CSS expression that the browser re-evaluates itself, so a theme switch still repaints correctly. Only theme-independent literals (hex, named colours) ever reach the DOM path, and those resolve to the same value every time by definition.

## Testing

Validated with `npx tsc --noEmit`, `npm run lint` and `npx rollup -c`, and confirmed the memoization survives minification in the shipped bundle.

Deployed to a live Home Assistant instance and checked in the browser against four purpose-built cards:

1. **Four accent colours in one card** at opacity 30 — catches a colour-blind cache key (every event would share one tint). Four distinct tints render correctly.
2. **Identical purple at opacity 10 vs 70** — catches an opacity-blind cache key (both cards would look the same). Clearly different.
3. **A/B against the released build**, identical config — indistinguishable.
4. A missing-entity case, unrelated to this change, kept in to confirm nothing regressed there either.

No console errors, no visual difference from the released build.