### PR TITLE
fix(weather): fall back to daily forecast for timed events beyond the hourly horizon

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,6 +915,7 @@ This flexible configuration allows you to create a personalized experience that 
 | `event → show_temp`          | boolean | `true`                      | Whether to show temperature in event column                                                 |
 | `event → show_uv_index`      | boolean | `false`                     | Whether to show UV index in event column                                                    |
 | `event → uv_index_threshold` | number  | `0`                         | Only show UV index when it exceeds this value (0 = always show when enabled)                |
+| `event → daily_forecast_fallback` | boolean | `true`                 | Fall back to the daily forecast for timed events beyond the hourly forecast horizon         |
 | `event → icon_size`          | string  | `14px`                      | Size of weather icons in event column                                                       |
 | `event → font_size`          | string  | `12px`                      | Size of weather text in event column                                                        |
 | `event → color`              | string  | `var(--primary-text-color)` | Color of weather text and icons in event column                                             |
@@ -926,6 +927,14 @@ You can choose where weather information appears in your calendar:
 - `date`: Shows daily forecasts in the date column (left side)
 - `event`: Shows hourly forecasts next to event titles
 - `both`: Displays weather in both positions simultaneously
+
+> [!NOTE]
+> Home Assistant weather entities typically provide hourly forecasts for about two days
+> ahead, while daily forecasts reach much further (six days or more, depending on the
+> provider). Beyond the hourly horizon, timed events fall back to that day's daily
+> forecast so weather keeps appearing across the whole calendar. Set
+> `event → daily_forecast_fallback: false` if you would rather show nothing than a daily
+> value. All-day events always use the daily forecast.
 
 #### Position-Specific Configuration
 
@@ -948,6 +957,7 @@ Each display position can be customized independently with different content and
 - `show_temp`: Show temperature
 - `show_uv_index`: Show UV index
 - `uv_index_threshold`: Minimum UV index value to display (0 = always)
+- `daily_forecast_fallback`: Use the daily forecast for timed events beyond the hourly forecast horizon
 - `icon_size`: Weather icon size
 - `font_size`: Temperature text size
 - `color`: Text and icon color

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -128,6 +128,7 @@ export const DEFAULT_CONFIG: Types.Config = {
       show_temp: true,
       show_uv_index: false,
       uv_index_threshold: 0,
+      daily_forecast_fallback: true,
       icon_size: '14px',
       font_size: '12px',
       color: 'var(--primary-text-color)',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -149,6 +149,7 @@ export interface WeatherPositionConfig {
   show_temp?: boolean;
   show_uv_index?: boolean;
   uv_index_threshold?: number;
+  daily_forecast_fallback?: boolean;
   icon_size?: string;
   font_size?: string;
   color?: string;

--- a/src/rendering/editor.ts
+++ b/src/rendering/editor.ts
@@ -1498,6 +1498,10 @@ export class CalendarCardProEditor extends LitElement {
                                 this._getTranslation('uv_index_threshold'),
                               )
                             : nothing}
+                          ${this.addBooleanField(
+                            'weather.event.daily_forecast_fallback',
+                            this._getTranslation('daily_forecast_fallback'),
+                          )}
                           ${this.addTextField(
                             'weather.event.icon_size',
                             this._getTranslation('icon_size'),

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -1063,19 +1063,21 @@ function renderEventWeather(
     }
   }
 
+  // Get options from event-specific config
+  const eventConfig = config.weather?.event || {};
+
   // Find the appropriate forecast - pass both hourly and daily forecasts
   const forecast = Weather.findForecastForEvent(
     event,
     weatherForecasts.hourly,
     weatherForecasts.daily,
+    eventConfig.daily_forecast_fallback !== false,
   );
 
   if (!forecast) {
     return html``;
   }
 
-  // Get options from event-specific config
-  const eventConfig = config.weather?.event || {};
   const showConditions = eventConfig.show_conditions !== false;
   const showTemp = eventConfig.show_temp !== false;
   const showUvIndex =

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -236,6 +236,7 @@
     "show_temp": "Temperatur anzeigen",
     "show_uv_index": "UV-Index anzeigen",
     "uv_index_threshold": "UV-Index-Schwellenwert",
+    "daily_forecast_fallback": "Auf Tagesvorhersage zurückgreifen",
 
     "interactions": "Interaktionen",
     "tap_action": "Aktion antippen",

--- a/src/translations/languages/en-GB.json
+++ b/src/translations/languages/en-GB.json
@@ -228,6 +228,7 @@
     "show_temp": "Show temperature",
     "show_uv_index": "Show UV index",
     "uv_index_threshold": "UV index threshold",
+    "daily_forecast_fallback": "Use daily forecast as fallback",
     
     "interactions": "Interactions",
     "tap_action": "Tap Action",

--- a/src/translations/languages/en.json
+++ b/src/translations/languages/en.json
@@ -228,6 +228,7 @@
     "show_temp": "Show temperature",
     "show_uv_index": "Show UV index",
     "uv_index_threshold": "UV index threshold",
+    "daily_forecast_fallback": "Use daily forecast as fallback",
     
     "interactions": "Interactions",
     "tap_action": "Tap Action",

--- a/src/translations/languages/et.json
+++ b/src/translations/languages/et.json
@@ -247,6 +247,7 @@
     "show_temp": "Näita temperatuuri",
     "show_uv_index": "Näita UV-indeksit",
     "uv_index_threshold": "UV-indeksi künnis",
+    "daily_forecast_fallback": "Kasuta päevaprognoosi varuvariandina",
 
     "interactions": "Interaktsioonid",
     "tap_action": "Puudutuse tegevus",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -228,6 +228,7 @@
     "show_temp": "Mostra temperatura",
     "show_uv_index": "Mostra indice UV",
     "uv_index_threshold": "Soglia indice UV",
+    "daily_forecast_fallback": "Usa le previsioni giornaliere come alternativa",
 
     "interactions": "Interazioni",
     "tap_action": "Azione tap",

--- a/src/translations/languages/lt.json
+++ b/src/translations/languages/lt.json
@@ -234,6 +234,7 @@
     "show_temp": "Rodyti temperatūrą",
     "show_uv_index": "Rodyti UV indeksą",
     "uv_index_threshold": "UV indekso riba",
+    "daily_forecast_fallback": "Naudoti dienos prognozę kaip atsarginį variantą",
 
     "interactions": "Sąveikos",
     "tap_action": "Paliesti veiksmas",

--- a/src/translations/languages/lv.json
+++ b/src/translations/languages/lv.json
@@ -228,6 +228,7 @@
     "show_temp": "Rādīt temperatūru",
     "show_uv_index": "Rādīt UV indeksu",
     "uv_index_threshold": "UV indeksa slieksnis",
+    "daily_forecast_fallback": "Izmantot dienas prognozi kā rezerves variantu",
 
     "interactions": "Mijiedarbība",
     "tap_action": "Pieskāriena darbība",

--- a/src/translations/languages/nb.json
+++ b/src/translations/languages/nb.json
@@ -226,6 +226,7 @@
     "show_temp": "Vis temperatur",
     "show_uv_index": "Vis UV-indeks",
     "uv_index_threshold": "UV-indeks terskel",
+    "daily_forecast_fallback": "Bruk daglig værvarsel som reserve",
 
     "interactions": "Interaksjoner",
     "tap_action": "Trykkehandling",

--- a/src/translations/languages/pl.json
+++ b/src/translations/languages/pl.json
@@ -234,6 +234,7 @@
     "show_temp": "Pokaż Temperaturę",
     "show_uv_index": "Pokaż indeks UV",
     "uv_index_threshold": "Próg indeksu UV",
+    "daily_forecast_fallback": "Użyj prognozy dziennej jako zapasowej",
 
     "interactions": "Interakcje",
     "tap_action": "Akcja Dotknięcia",

--- a/src/translations/languages/sk.json
+++ b/src/translations/languages/sk.json
@@ -225,6 +225,7 @@
     "show_temp": "Zobraziť teplotu",
     "show_uv_index": "Zobraziť UV index",
     "uv_index_threshold": "Prah UV indexu",
+    "daily_forecast_fallback": "Použiť dennú predpoveď ako záložnú",
 
     "interactions": "Interakcie",
     "tap_action": "Akcia kliknutia",

--- a/src/translations/languages/sv.json
+++ b/src/translations/languages/sv.json
@@ -220,6 +220,7 @@
     "show_temp": "Visa temperatur",
     "show_uv_index": "Visa UV-index",
     "uv_index_threshold": "UV-indextröskel",
+    "daily_forecast_fallback": "Använd daglig prognos som reserv",
     "interactions": "Interaktioner",
     "tap_action": "Tryckåtgärd",
     "hold_action": "Hållåtgärd",

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -134,15 +134,23 @@ export function findDailyForecast(
  * Find the appropriate forecast for an event
  * Uses hourly forecast for timed events, daily forecast for all-day events
  *
+ * Home Assistant's hourly forecast typically only spans about two days, while the
+ * daily forecast reaches considerably further. When `dailyFallback` is enabled,
+ * timed events beyond the hourly horizon fall back to that date's daily forecast
+ * instead of rendering nothing. This also covers weather entities that provide no
+ * hourly forecast at all.
+ *
  * @param event Calendar event
  * @param hourlyForecasts Hourly forecasts record
  * @param dailyForecasts Daily forecasts record
+ * @param dailyFallback Whether timed events may fall back to the daily forecast
  * @returns Weather data for the event or undefined
  */
 export function findForecastForEvent(
   event: Types.CalendarEventData,
   hourlyForecasts: Record<string, Types.WeatherData>,
   dailyForecasts?: Record<string, Types.WeatherData>,
+  dailyFallback = false,
 ): Types.WeatherData | undefined {
   // For all-day events (with start.date but no start.dateTime)
   if (event.start.date && !event.start.dateTime && dailyForecasts) {
@@ -153,7 +161,7 @@ export function findForecastForEvent(
   }
 
   // For regular events with start.dateTime
-  if (!event.start.dateTime || !hourlyForecasts) {
+  if (!event.start.dateTime) {
     return undefined;
   }
 
@@ -162,38 +170,45 @@ export function findForecastForEvent(
   const eventDate = FormatUtils.getLocalDateKey(eventStart);
   const eventHour = eventStart.getHours();
 
-  // Try to find the exact hour
-  const exactMatch = hourlyForecasts[`${eventDate}_${eventHour}`];
-  if (exactMatch) {
-    return exactMatch;
-  }
+  if (hourlyForecasts) {
+    // Try to find the exact hour
+    const exactMatch = hourlyForecasts[`${eventDate}_${eventHour}`];
+    if (exactMatch) {
+      return exactMatch;
+    }
 
-  // Find the closest hour forecast
-  let closestHour = -1;
-  let minDiff = 24;
+    // Find the closest hour forecast
+    let closestHour = -1;
+    let minDiff = 24;
 
-  // Look through all hourly forecasts for this date
-  Object.keys(hourlyForecasts).forEach((key) => {
-    if (key.startsWith(eventDate)) {
-      // Extract hour from the key
-      const hourPart = key.split('_')[1];
-      const hour = parseInt(hourPart);
+    // Look through all hourly forecasts for this date
+    Object.keys(hourlyForecasts).forEach((key) => {
+      if (key.startsWith(eventDate)) {
+        // Extract hour from the key
+        const hourPart = key.split('_')[1];
+        const hour = parseInt(hourPart);
 
-      if (!isNaN(hour)) {
-        // Calculate difference, accounting for hour wrapping
-        const diff = Math.abs(hour - eventHour);
+        if (!isNaN(hour)) {
+          // Calculate difference, accounting for hour wrapping
+          const diff = Math.abs(hour - eventHour);
 
-        if (diff < minDiff) {
-          minDiff = diff;
-          closestHour = hour;
+          if (diff < minDiff) {
+            minDiff = diff;
+            closestHour = hour;
+          }
         }
       }
-    }
-  });
+    });
 
-  // Return the closest forecast if found
-  if (closestHour >= 0) {
-    return hourlyForecasts[`${eventDate}_${closestHour}`];
+    // Return the closest forecast if found
+    if (closestHour >= 0) {
+      return hourlyForecasts[`${eventDate}_${closestHour}`];
+    }
+  }
+
+  // No hourly data for this date - fall back to the daily forecast if enabled
+  if (dailyFallback && dailyForecasts) {
+    return dailyForecasts[eventDate];
   }
 
   return undefined;


### PR DESCRIPTION
## The problem

With `weather.position: event`, timed events stopped showing weather a couple of days out, while all-day events and empty-day placeholders on the *same* days kept showing it. On a card with `days_to_show: 14` that meant weather on roughly 2 of 14 days for timed events and 6 for everything else.

The reporter also saw a day with two events render two different readings and read that as one day "stealing" the next day's weather. That part is not a bug — see below.

## Root cause

`findForecastForEvent()` resolved weather by event type:

- **all-day** (`start.date`) → `dailyForecasts[dateKey]`
- **timed** (`start.dateTime`) → `hourlyForecasts['YYYY-MM-DD_H']`, else the closest hour **on that same date**, else `undefined`

There was no path from the timed branch to the daily forecast. Home Assistant's hourly forecast only spans about two days — verified against a live met.no entity: **48 hourly entries (2 days) vs 6 daily entries (6 days)**. So every timed event past the hourly horizon silently rendered nothing, even though the daily forecast for that date was already fetched and sitting in memory.

That is also why the reporter's day went blank the moment they added events to it: while empty it rendered a synthetic all-day placeholder (→ daily forecast), and adding a timed event switched it to the hourly path (→ miss → `undefined`).

## The fix

The hourly lookup is attempted first and the daily forecast becomes the tail return, so a timed event with no hourly data falls back to its day's forecast. This also covers weather entities that expose no hourly forecast at all.

Gated behind a new key:

| Key | Type | Default |
|---|---|---|
| `weather.event.daily_forecast_fallback` | boolean | `true` |

Default `true` fixes the issue out of the box. It exists as an **opt-out** for anyone who only wants hour-accurate readings and would rather see nothing than a daily high against an event at 09:00.

## Before / after

Verified on a live instance against `weather.forecast_home` (met.no), `days_to_show: 9`. Hourly ended Sun 9 Aug 21:00; daily ended Wed 12 Aug.

![Before and after: the released card on the left leaves Mon 10, Tue 11 and Wed 12 Aug blank; the patched card on the right shows 32 degrees, 31 degrees and 29 degrees for the same events](https://github.com/user-attachments/assets/5cefea36-6a70-49ba-8d82-53ae53ae2fed)

| Day | Event | Kind | Before | After |
|---|---|---|---|---|
| Sat 8 Aug | Disneyland Trip | all-day | ~28° | ~28°, unchanged |
| Sun 9 Aug 15:00 | Spring Cleaning | timed, within hourly | ~32° | ~32°, unchanged |
| **Mon 10 Aug 11:00** | Baby's Checkup | timed, past hourly | **blank** | **~32° — the fix** |
| **Tue 11 Aug 19:30** | Movie Night | timed, past hourly | **blank** | **~31° — the fix** |
| **Wed 12 Aug 18:00** | Grocery Shopping | timed, past hourly | **blank** | **~29° — the fix** |
| Sat 15 Aug | Disneyland Trip | all-day, past daily | blank | blank, unchanged |

The last row matters: the fallback does not invent data beyond the daily horizon either.

Setting `daily_forecast_fallback: false` reproduces the "before" column exactly.

## What is deliberately *not* changed

**Two readings on one day is correct behaviour.** With `position: event`, weather is rendered per event by design. A day with an all-day event and a timed event gets two readings, and they differ because one is the daily *high* and the other the temperature at that hour. Users who want one reading per day want `position: date`. I'll cover this in the issue reply.

**Past events still suppress weather** (`render.ts:1056`). With `show_past_events: true` those rows render without weather, which is why the reporter's screenshot had a blank first row. A forecast for something already finished is meaningless, so this stays.

**`renderEventWeather()`'s `!weatherForecasts?.hourly` guard** (`render.ts:1051`) is conceptually wrong — it gates *all* event weather, including all-day, on hourly data existing. In practice it never fires because `hourly` defaults to `{}`, so it does not affect this fix. Left for its own PR rather than widening this one.

## Files touched

Adding a config key is never a one-file change:

- `src/utils/weather.ts` — the fallback, plus a 4th `dailyFallback` parameter defaulting to `false` so the pure function's behaviour is unchanged for any other caller
- `src/config/types.ts` — `daily_forecast_fallback?: boolean` on `WeatherPositionConfig`
- `src/config/config.ts` — default `true` in the `weather.event` block only, not `weather.date`
- `src/rendering/render.ts` — passes `eventConfig.daily_forecast_fallback !== false`, matching the house idiom used for `show_conditions` / `show_temp`
- `src/rendering/editor.ts` — boolean field between *UV index threshold* and *Icon size*
- **11 translation files** — `de, en-GB, en, et, it, lt, lv, nb, pl, sk, sv`, the only ones carrying an `editor` section. Real translations, not English copies. The other 24 stay without an `editor` section so they keep falling back to English wholesale via `hasEditorTranslations()`.
- `README.md` — options table, a note under Weather Display Positions, and the Event Weather reference

## Verification

- A throwaway harness against the real bundled source, fed live-shaped forecast data (48h hourly / 6d daily): **30/30 checks passed**, covering the reporter's case, both sides of the 48h boundary, the flag off restoring old behaviour exactly, exact-hour and closest-hour paths unchanged, the all-day path unchanged, and neither-hourly-nor-daily still returning `undefined`. Deleted afterwards — there's no test framework in this repo.
- Live A/B on Home Assistant with a dev build beside the released one: the three previously-blank rows now render, everything else is byte-identical.
- Visual editor driven with Playwright: the toggle renders in the right place, `ha-input` resolves, and the German card reads **"Auf Tagesvorhersage zurückgreifen"** rather than a raw key name — the failure mode a partial `editor` section would have caused.
- `npx tsc --noEmit`, `npm run lint`, `npm run build` all clean.

Fixes #336
