### PR TITLE
build: stop emitting sourcemap references in the bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,19 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      # A sourceMappingURL comment in the bundle points at a .map that is never shipped
+      # (release.yml attaches only the .js, hacs.json pins that one filename), so every
+      # user's browser resolves it to a 404. This shipped for several releases before
+      # anyone traced it (#315, #358); the check is cheap, the symptom is silent.
+      - name: Verify no sourcemap references in bundle
+        run: |
+          if grep -q 'sourceMappingURL' dist/calendar-card-pro.js; then
+            echo "::error::dist/calendar-card-pro.js contains a sourceMappingURL comment. The .map file is not distributed, so this 404s in every user's browser. Check output.sourcemap in rollup.config.mjs."
+            exit 1
+          fi
+          if compgen -G 'dist/*.map' > /dev/null; then
+            echo "::error::Build emitted a sourcemap into dist/. Sourcemaps are not distributed; check output.sourcemap in rollup.config.mjs."
+            exit 1
+          fi
+          echo "Bundle is free of sourcemap references."

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -22,7 +22,12 @@ export default {
     format: 'es',
     // Use the dynamic filename based on NODE_ENV
     entryFileNames: outputFilename,
-    sourcemap: true,
+    // Sourcemaps are deliberately disabled. The release workflow attaches only
+    // dist/calendar-card-pro.js and hacs.json pins that single filename, so a .map is
+    // never published to /hacsfiles/. Emitting one anyway leaves a sourceMappingURL
+    // comment in the bundle that every user's browser resolves to a 404 (#315, #358).
+    // Do not re-enable without also shipping and serving the map.
+    sourcemap: false,
   },
   plugins: [
     replace({
@@ -42,7 +47,9 @@ export default {
     esbuild({
       tsconfig: 'tsconfig.json',
       target: 'es2017',
-      sourceMap: true,
+      // Kept in step with output.sourcemap above; input maps would only be built and
+      // then discarded.
+      sourceMap: false,
       // Define NODE_ENV as production to ensure Lit uses production builds
       define: {
         'process.env.NODE_ENV': JSON.stringify('production'),


### PR DESCRIPTION
Fixes #358 (and the never-actually-fixed #315).

## Problem

Every user with devtools open sees a 404:

```
Source map error: Error: request failed with status 404
Resource URL: https://…/hacsfiles/calendar-card-pro/calendar-card-pro.js?hacstag=…
Source Map URL: calendar-card-pro.js.map
```

## Root cause

`rollup.config.mjs` set `output.sourcemap: true` unconditionally, so every build appended `//# sourceMappingURL=calendar-card-pro.js.map` to the bundle. But `release.yml` attaches only `dist/calendar-card-pro.js`, and `hacs.json` pins that single filename — the `.map` is never published and never reaches `/hacsfiles/`. The browser reads the comment, requests the map, gets a 404.

Confirmed against the shipped artifact:

```console
$ curl -sL .../releases/download/v3.3.0/calendar-card-pro.js | tail -c 45
//# sourceMappingURL=calendar-card-pro.js.map
```

This is not a regression. #315 was closed as fixed in v3.2.0, but `git log v3.1.0..v3.2.0 -- rollup.config.mjs` shows the config was never touched — a second reporter on that thread said as much at the time.

## Fix

Sourcemaps aren't used by this project, aren't shipped, and can't be served through HACS without restructuring the release asset, so they're now off in both builds:

- `output.sourcemap: false`
- esbuild `sourceMap: false` — with rollup no longer emitting a map, those input maps were built and immediately discarded

Both carry a comment explaining why, so they don't get re-enabled as a perceived improvement.

Also adds a CI step that fails if a `sourceMappingURL` comment or a `dist/*.map` ever reappears. The symptom is silent and user-visible, and it already survived one claimed fix.

## Validation

- Production bundle is **byte-identical** to the pre-change build minus the 46-byte trailing comment — dropping the esbuild input maps changed no codegen.
- `dist/calendar-card-pro.js` and `dist/calendar-card-pro-dev.js` both contain zero `sourceMappingURL` matches; no `.map` files emitted. (Previously a 3.4 MB map was generated on every build for nothing.)
- Guard tested both ways: passes on a clean `dist/`, fails when a comment and `.map` are reintroduced.
- `npx tsc --noEmit`, `npm run lint`, `npm run format` all clean.

Build configuration only — no source files touched.