### PR TITLE
feat: add `hide_when_empty` option to hide card when there are no events

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,11 +728,19 @@ event_color: 'var(--primary-text-color)'
 # Empty days display
 show_empty_days: true # Show days with no events
 empty_day_color: 'var(--secondary-text-color)' # Color for "No events" text
+
+# Or remove the card entirely when there is nothing to show
+hide_when_empty: true
 ```
 
 When `show_empty_days` is set to `true`, days without events will display a "No events" message. This helps maintain visual consistency across your calendar, especially when showing longer date ranges.
 
 The new `empty_day_color` parameter lets you customize the color of this message to match your theme or stand out as needed.
+
+If you would rather the card disappear completely instead of showing "No upcoming events", set `hide_when_empty: true`. The card removes itself from the dashboard whenever it has no events to display, and surrounding cards close the gap. It reappears automatically as soon as an event shows up, and always stays visible while you are editing the dashboard so you can still select and configure it.
+
+> [!NOTE]
+> Compact mode limits never trigger hiding — a card limited to zero events with `compact_events_to_show: 0` stays visible so it can still be expanded. Configuration errors, such as a missing calendar entity, also remain visible so problems are not hidden silently.
 
 #### ⏱️ Time & Location Information
 
@@ -1224,6 +1232,7 @@ These examples demonstrate how Calendar Card Pro can be customized to match any 
 | `compact_events_to_show`                   | number            | -                                                  | Number of events to show in compact mode                                                                                                                                                                                                                    |
 | `compact_events_complete_days`             | boolean           | `false`                                            | When true, shows all events for days that have at least one event displayed                                                                                                                                                                                 |
 | `show_empty_days`                          | boolean           | `false`                                            | Whether to show days with no events (with "No events" message)                                                                                                                                                                                              |
+| `hide_when_empty`                          | boolean           | `false`                                            | Hide the entire card when there are no upcoming events to show                                                                                                                                                                                              |
 | `filter_duplicates`                        | boolean           | `false`                                            | Hide events whose title, start, end and location all match another event; the calendar listed first in `entities` wins                                                                                                                                      |
 | `split_multiday_events`                    | boolean           | `false`                                            | Display multi-day events on each day they cover                                                                                                                                                                                                             |
 | `language`                                 | string            | `System`, fallback `en`                            | Interface language (auto-detects from HA)                                                                                                                                                                                                                   |

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -88,6 +88,23 @@ class CalendarCardPro extends LitElement {
   };
 
   /**
+   * Set by Home Assistant's `hui-card` wrapper while the dashboard is in edit
+   * mode or the card is shown in the card picker. The card must never hide
+   * itself in these states, otherwise it becomes impossible to select and
+   * configure. `editMode` is the legacy alias used by older HA versions.
+   */
+  @property({ type: Boolean }) preview = false;
+  @property({ type: Boolean }) editMode = false;
+
+  /**
+   * Tells `hui-card` to keep this element in the DOM while it is hidden.
+   * Without this Home Assistant detaches the element, which runs
+   * `disconnectedCallback()` and tears down the refresh timer — the card would
+   * then never re-fetch events and stay hidden forever once it went empty.
+   */
+  public connectedWhileHidden = true;
+
+  /**
    * Static method that returns a new instance of the editor
    * This is how Home Assistant discovers and loads the editor
    */
@@ -106,6 +123,12 @@ class CalendarCardPro extends LitElement {
   private _weatherUnsubscribers: Array<() => void> = [];
   private _weatherSetupVersion = 0;
   private _weatherSetupPending = false;
+  private _visibleCountCache?: {
+    events: Types.CalendarEventData[];
+    config: Types.Config;
+    language: string;
+    count: number;
+  };
 
   // Interaction state
   private _activePointerId: number | null = null;
@@ -144,6 +167,47 @@ class CalendarCardPro extends LitElement {
       this.isExpanded,
       this.effectiveLanguage,
     );
+  }
+
+  /**
+   * Number of real events the card would show across its full configured range.
+   *
+   * Deliberately evaluated as if the card were expanded so that compact mode
+   * limits can never make the card look empty — `compact_events_to_show: 0` is
+   * a valid configuration meaning "show nothing until tapped", and a card
+   * hidden in that state could never be expanded again.
+   *
+   * Placeholder entries generated for empty days are excluded, so this counts
+   * only events that survive filtering (past events, blocklist/allowlist,
+   * duplicates) and therefore matches what the user actually sees.
+   *
+   * Memoized against the inputs it depends on, because `updated()` runs on
+   * every `hass` change and grouping the whole event list each time would be
+   * needless work.
+   */
+  get visibleEventCount(): number {
+    const language = this.effectiveLanguage;
+    const cache = this._visibleCountCache;
+
+    if (
+      cache &&
+      cache.events === this.events &&
+      cache.config === this.config &&
+      cache.language === language
+    ) {
+      return cache.count;
+    }
+
+    const count = this.events.length
+      ? EventUtils.groupEventsByDay(this.events, this.config, true, language).reduce(
+          (total, day) => total + day.events.filter((event) => !event._isEmptyDay).length,
+          0,
+        )
+      : 0;
+
+    this._visibleCountCache = { events: this.events, config: this.config, language, count };
+
+    return count;
   }
 
   //-----------------------------------------------------------------------------
@@ -243,11 +307,57 @@ class CalendarCardPro extends LitElement {
     if (hassJustAvailable || weatherConfigChanged) {
       this._scheduleWeatherSetup();
     }
+
+    // Hide or reveal the whole card when `hide_when_empty` is enabled
+    this._applyVisibility();
   }
 
   //-----------------------------------------------------------------------------
   // PRIVATE METHODS
   //-----------------------------------------------------------------------------
+
+  /**
+   * Hide the card entirely when it has no events and `hide_when_empty` is on.
+   *
+   * Home Assistant's `hui-card` wrapper watches its child for a
+   * `card-visibility-changed` event and mirrors `element.hidden` onto itself,
+   * which is what lets the surrounding grid or masonry column collapse rather
+   * than leaving an empty slot. The inline `display` is set as well so the card
+   * still disappears on older HA versions that predate that wrapper, and
+   * because the card's own `:host { display: block }` rule would otherwise
+   * override the browser default styling for the `hidden` attribute.
+   */
+  private _applyVisibility(): void {
+    // Missing hass or entities renders the error card — never hide that, or the
+    // user is left with no indication of why the card vanished. During the
+    // initial load neither is treated as an error yet (see `render()`).
+    const isErrorState =
+      !this.isInitialLoad && (!this.safeHass || this.config.entities.length === 0);
+
+    const shouldHide =
+      this.config.hide_when_empty === true &&
+      !this.preview &&
+      !this.editMode &&
+      !isErrorState &&
+      this.visibleEventCount === 0;
+
+    if (this.hidden === shouldHide) {
+      return;
+    }
+
+    Logger.debug(`hide_when_empty: ${shouldHide ? 'hiding' : 'revealing'} card`);
+
+    this.hidden = shouldHide;
+    this.style.display = shouldHide ? 'none' : '';
+
+    this.dispatchEvent(
+      new CustomEvent('card-visibility-changed', {
+        detail: { value: !shouldHide },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
 
   /**
    * Generate style properties from configuration

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -636,6 +636,11 @@ class CalendarCardPro extends LitElement {
         this._initialLoadRetryId = window.setTimeout(() => {
           this.updateEvents(true);
         }, 1500);
+      } else {
+        // Home Assistant is available but no entities are configured, so no data
+        // will ever arrive. Leave the initial load state so `render()` falls
+        // through to the error card instead of showing "loading" indefinitely.
+        this.isInitialLoad = false;
       }
       return;
     }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -22,6 +22,7 @@ export const DEFAULT_CONFIG: Types.Config = {
   compact_events_to_show: undefined,
   compact_events_complete_days: false,
   show_empty_days: false,
+  hide_when_empty: false,
   filter_duplicates: false,
   split_multiday_events: false,
   language: undefined,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -20,6 +20,7 @@ export interface Config {
   compact_events_to_show?: number;
   compact_events_complete_days?: boolean;
   show_empty_days: boolean;
+  hide_when_empty: boolean;
   filter_duplicates: boolean;
   split_multiday_events: boolean;
   language?: string;

--- a/src/rendering/editor.ts
+++ b/src/rendering/editor.ts
@@ -803,6 +803,8 @@ export class CalendarCardProEditor extends LitElement {
             <h3>${this._getTranslation('event_visibility')}</h3>
             ${this.addBooleanField('show_past_events', this._getTranslation('show_past_events'))}
             ${this.addBooleanField('show_empty_days', this._getTranslation('show_empty_days'))}
+            ${this.addBooleanField('hide_when_empty', this._getTranslation('hide_when_empty'))}
+            <div class="helper-text">${this._getTranslation('hide_when_empty_note')}</div>
             ${this.addBooleanField('filter_duplicates', this._getTranslation('filter_duplicates'))}
             <div class="helper-text">${this._getTranslation('filter_duplicates_note')}</div>
 

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -88,6 +88,8 @@
     "event_visibility": "Sichtbarkeit von Ereignissen",
     "show_past_events": "Vergangene Ereignisse anzeigen",
     "show_empty_days": "Leere Tage anzeigen",
+    "hide_when_empty": "Karte ausblenden, wenn leer",
+    "hide_when_empty_note": "Blendet die gesamte Karte aus, sobald keine anstehenden Ereignisse vorhanden sind. Beim Bearbeiten des Dashboards bleibt die Karte sichtbar.",
     "filter_duplicates": "Doppelte Ereignisse filtern",
     "filter_duplicates_note": "Entfernt Ereignisse mit gleichem Titel, gleicher Zeit und gleichem Ort. Die Kopie aus dem zuerst aufgeführten Kalender wird beibehalten, einschließlich Label und Farbe.",
     "language_time_formats": "Sprach- & Zeitformate",

--- a/src/translations/languages/en-GB.json
+++ b/src/translations/languages/en-GB.json
@@ -80,6 +80,8 @@
     "event_visibility": "Event Visibility",
     "show_past_events": "Show past events",
     "show_empty_days": "Show empty days",
+    "hide_when_empty": "Hide card when empty",
+    "hide_when_empty_note": "Hides the entire card whenever there are no upcoming events to show. The card stays visible while editing the dashboard.",
     "filter_duplicates": "Filter duplicate events",
     "filter_duplicates_note": "Removes events with the same title, time and location. The copy from the calendar listed first is kept, along with its label and colour.",
     "language_time_formats": "Language & Time Formats",

--- a/src/translations/languages/en.json
+++ b/src/translations/languages/en.json
@@ -80,6 +80,8 @@
     "event_visibility": "Event Visibility",
     "show_past_events": "Show past events",
     "show_empty_days": "Show empty days",
+    "hide_when_empty": "Hide card when empty",
+    "hide_when_empty_note": "Hides the entire card whenever there are no upcoming events to show. The card stays visible while editing the dashboard.",
     "filter_duplicates": "Filter duplicate events",
     "filter_duplicates_note": "Removes events with the same title, time and location. The copy from the calendar listed first is kept, along with its label and color.",
     "language_time_formats": "Language & Time Formats",

--- a/src/translations/languages/et.json
+++ b/src/translations/languages/et.json
@@ -101,6 +101,8 @@
     "event_visibility": "Sündmuste nähtavus",
     "show_past_events": "Näita möödunud sündmusi",
     "show_empty_days": "Näita tühje päevi",
+    "hide_when_empty": "Peida kaart, kui see on tühi",
+    "hide_when_empty_note": "Peidab kogu kaardi, kui pole ühtegi eelseisvat sündmust. Töölaua muutmise ajal jääb kaart nähtavaks.",
     "filter_duplicates": "Filtreeri duplikaadid",
     "filter_duplicates_note": "Eemaldab sündmused, millel on sama pealkiri, aeg ja asukoht. Alles jääb esimesena loetletud kalendri koopia koos selle sildi ja värviga.",
     "language_time_formats": "Keel ja ajavormingud",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -80,6 +80,8 @@
     "event_visibility": "Visibilità Eventi",
     "show_past_events": "Mostra eventi passati",
     "show_empty_days": "Mostra giorni vuoti",
+    "hide_when_empty": "Nascondi la scheda quando è vuota",
+    "hide_when_empty_note": "Nasconde l'intera scheda quando non ci sono eventi imminenti da mostrare. La scheda resta visibile durante la modifica della dashboard.",
     "filter_duplicates": "Filtra eventi duplicati",
     "filter_duplicates_note": "Rimuove gli eventi con lo stesso titolo, orario e luogo. Viene mantenuta la copia del calendario elencato per primo, con la sua etichetta e il suo colore.",
     "language_time_formats": "Lingua e Formati Orari",

--- a/src/translations/languages/lt.json
+++ b/src/translations/languages/lt.json
@@ -88,6 +88,8 @@
     "event_visibility": "Įvykių matomumas",
     "show_past_events": "Rodyti praėjusius įvykius",
     "show_empty_days": "Rodyti tuščias dienas",
+    "hide_when_empty": "Slėpti kortelę, kai ji tuščia",
+    "hide_when_empty_note": "Paslepia visą kortelę, kai nėra būsimų įvykių. Redaguojant skydelį kortelė lieka matoma.",
     "filter_duplicates": "Filtruoti dubliuotus įvykius",
     "filter_duplicates_note": "Pašalina įvykius, kurių pavadinimas, laikas ir vieta sutampa. Išsaugoma pirmojo sąraše nurodyto kalendoriaus kopija kartu su jo etikete ir spalva.",
     "language_time_formats": "Kalba ir laiko formatai",

--- a/src/translations/languages/lv.json
+++ b/src/translations/languages/lv.json
@@ -80,6 +80,8 @@
     "event_visibility": "Notikumu redzamība",
     "show_past_events": "Rādīt pagājušos notikumus",
     "show_empty_days": "Rādīt tukšas dienas",
+    "hide_when_empty": "Slēpt kartīti, kad tā ir tukša",
+    "hide_when_empty_note": "Paslēpj visu kartīti, kad nav gaidāmu notikumu. Rediģējot informācijas paneli, kartīte paliek redzama.",
     "filter_duplicates": "Filtrēt dublētos notikumus",
     "filter_duplicates_note": "Noņem notikumus ar vienādu nosaukumu, laiku un atrašanās vietu. Tiek saglabāta kopija no pirmā sarakstā norādītā kalendāra kopā ar tā etiķeti un krāsu.",
     "language_time_formats": "Valoda un laika formāti",

--- a/src/translations/languages/nb.json
+++ b/src/translations/languages/nb.json
@@ -80,6 +80,8 @@
     "event_visibility": "Hendelsessynlighet",
     "show_past_events": "Vis tidligere hendelser",
     "show_empty_days": "Vis tomme dager",
+    "hide_when_empty": "Skjul kortet når det er tomt",
+    "hide_when_empty_note": "Skjuler hele kortet når det ikke finnes kommende hendelser å vise. Kortet forblir synlig mens du redigerer dashbordet.",
     "filter_duplicates": "Filtrer duplikate hendelser",
     "filter_duplicates_note": "Fjerner hendelser med samme tittel, tid og sted. Kopien fra kalenderen som er oppført først beholdes, sammen med dens etikett og farge.",
     "language_time_formats": "Språk og tidsformater",

--- a/src/translations/languages/pl.json
+++ b/src/translations/languages/pl.json
@@ -88,6 +88,8 @@
     "event_visibility": "Widoczność Wydarzeń",
     "show_past_events": "Pokaż przeszłe wydarzenia",
     "show_empty_days": "Pokaż puste dni",
+    "hide_when_empty": "Ukryj kartę, gdy jest pusta",
+    "hide_when_empty_note": "Ukrywa całą kartę, gdy nie ma nadchodzących wydarzeń do wyświetlenia. Podczas edycji pulpitu karta pozostaje widoczna.",
     "filter_duplicates": "Filtruj zduplikowane wydarzenia",
     "filter_duplicates_note": "Usuwa wydarzenia o tym samym tytule, czasie i lokalizacji. Zachowywana jest kopia z kalendarza wymienionego jako pierwszy, wraz z jego etykietą i kolorem.",
     "language_time_formats": "Język i Formaty Czasu",

--- a/src/translations/languages/sk.json
+++ b/src/translations/languages/sk.json
@@ -79,6 +79,8 @@
     "event_visibility": "Viditeľnosť udalostí",
     "show_past_events": "Zobrazovať udalosti, ktoré už prebehli",
     "show_empty_days": "Zobrazovať prázdne dni",
+    "hide_when_empty": "Skryť kartu, keď je prázdna",
+    "hide_when_empty_note": "Skryje celú kartu, keď nie sú žiadne nadchádzajúce udalosti. Počas úprav nástenky zostáva karta viditeľná.",
     "filter_duplicates": "Filtrovať duplicitné udalosti",
     "filter_duplicates_note": "Odstráni udalosti s rovnakým názvom, časom a miestom. Zachová sa kópia z kalendára uvedeného ako prvý, vrátane jeho menovky a farby.",
     "language_time_formats": "Jazyk a formát času",

--- a/src/translations/languages/sv.json
+++ b/src/translations/languages/sv.json
@@ -78,6 +78,8 @@
     "event_visibility": "Händelsevisning",
     "show_past_events": "Visa tidigare händelser",
     "show_empty_days": "Visa tomma dagar",
+    "hide_when_empty": "Dölj kortet när det är tomt",
+    "hide_when_empty_note": "Döljer hela kortet när det inte finns några kommande händelser att visa. Kortet förblir synligt när du redigerar panelen.",
     "filter_duplicates": "Filtrera dubbletter",
     "filter_duplicates_note": "Tar bort händelser med samma titel, tid och plats. Kopian från kalendern som anges först behålls, tillsammans med dess etikett och färg.",
     "language_time_formats": "Språk & tidsformat",


### PR DESCRIPTION
Closes #286

Adds a `hide_when_empty` boolean (default `false`) that removes the entire card from the dashboard when it has no upcoming events, so surrounding cards close the gap instead of leaving a "No upcoming events" placeholder. As the issue notes, a conditional card can't cover this because the card isn't backed by an entity.

### How the hiding works

Follows Home Assistant's own card visibility contract, as used by `hui-conditional-card`:

- The element sets `hidden` and fires `card-visibility-changed`, which is what makes the `hui-card` wrapper collapse its own layout slot — hiding only the inner element would leave an empty grid cell.
- It declares `connectedWhileHidden = true`, so HA keeps the element connected. Without it HA detaches the element, `disconnectedCallback()` tears down the refresh timer, and the card can never notice that events came back — it would stay hidden forever.
- An inline `display: none` is also set, both as a fallback for HA versions predating the wrapper and because the card's own `:host { display: block }` would otherwise beat the UA rule for `[hidden]`.

### Guards

- **Never hides in edit mode** — `preview` / `editMode` are honoured, so the card stays selectable in the dashboard editor and card picker.
- **Never hides the error state** — a missing `hass` or empty `entities` still renders the error card, so misconfiguration isn't silently swallowed.
- **Compact mode can't trigger it** — emptiness is evaluated against the fully expanded event set, so `compact_events_to_show: 0` (a valid "show nothing until tapped" config) doesn't hide a card that was only meant to be collapsed.
- Counting goes through `groupEventsByDay` rather than `events.length`, so past-event filtering, the date window, blocklists and duplicate filtering are all reflected. Empty-day placeholders don't count, so `show_empty_days` + `hide_when_empty` hides rather than showing a card full of "No events" rows.

The count is memoized against `events` / `config` / language, since `updated()` runs on every `hass` change.

### Epic context

`hide_when_empty` covers exactly one axis — *whether to render at all*. The other two `epic:empty-state` issues are separate axes and stay unblocked by this shape:

| axis | key | issue |
| --- | --- | --- |
| whether to render at all | `hide_when_empty` (this PR) | #286 |
| what an empty day says | `empty_day_text` (reserved) | #279 |
| what counts as empty | `empty_threshold` (reserved) | #295 |

Each composes with the others and nothing needs renaming later. A `hide_when_empty: boolean \| number` union was considered and rejected — it reads badly and a number field is far less discoverable than a toggle in the visual editor.

### Also included

- Editor toggle in the **Event Visibility** section, next to `show_empty_days` (the issue suggested Appearance & Layout, but it belongs beside the other visibility switches).
- Translations for all 11 languages that have an `editor` section; the other 24 correctly fall back to English wholesale.
- README: config table row, prose, and a note on the compact-mode/error interactions.

### Validation

`npx tsc --noEmit`, `npm run lint`, `npm run format` and `npm run build` all pass.

Verified on a live HA instance with a dev build across seven cases: the A/B hide + layout collapse, the has-events control, `hide_when_empty: false` as a no-regression check, the `show_empty_days` interaction, `compact_events_to_show: 0`, both error cases, and the editor toggle in English and German. Edit mode reveals every hidden card, so none of them become unreachable.

That pass turned up one bug, fixed in the second commit.

### Bonus fix: `entities: []` was stuck on "Loading calendar events..."

`updateEvents()` returns early when a card has no entities, but never cleared `isInitialLoad`. The card stayed pinned in the loading state permanently, which made the error branch in `render()` **unreachable dead code** — a card with no entities has never shown the "please define entities" error on any released version, it just shows the loading message forever.

That's pre-existing, but it also broke this PR's "never hide an error state" guard, which keys off the same flag: the card wasn't considered to be in an error state, had zero events, and hid itself silently.

`updateEvents()` now clears `isInitialLoad` when `hass` is connected but no entities are configured. The `!safeHass` path is untouched and still retries, so a card waiting for `hass` to initialise keeps showing the loading state rather than flashing an error at startup.

> [!NOTE]
> One deliberate limitation, flagged for a call rather than fixed: a calendar entity that **fails to fetch** leaves the card with zero events, which is indistinguishable from a genuinely empty calendar, so it hides. The reason is logged at debug level. Separating fetch failure from emptiness would need real error-state tracking; happy to do it if you'd rather the card stayed visible.
