### PR TITLE
fix: keep the card visible and honest when a calendar fails to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,7 +742,9 @@ If you would rather the card disappear completely instead of showing "No upcomin
 Hiding takes precedence over anything that only decorates an empty day: `show_empty_days` fills the range with "No events" placeholders, but those placeholders are not events, so a card with nothing but empty days still hides.
 
 > [!NOTE]
-> Compact mode limits never trigger hiding — a card limited to zero events with `compact_events_to_show: 0` stays visible so it can still be expanded. Configuration errors, such as a missing calendar entity, also remain visible so problems are not hidden silently. The same applies when a calendar cannot be reached: a failed request leaves the event list empty, but the card stays on screen rather than vanishing because of a temporary outage.
+> Compact mode limits never trigger hiding — a card limited to zero events with `compact_events_to_show: 0` stays visible so it can still be expanded. Configuration errors, such as a missing calendar entity, also remain visible so problems are not hidden silently.
+>
+> The same applies when a calendar cannot be reached. A failed request leaves the event list empty, but that is not the same thing as an empty calendar, so the card never vanishes because of a temporary outage. If events are already on screen they stay there until a refresh succeeds, and if there is nothing to fall back on the card reports the problem instead of claiming there are no upcoming events.
 
 #### ⏱️ Time & Location Information
 

--- a/README.md
+++ b/README.md
@@ -739,8 +739,10 @@ The new `empty_day_color` parameter lets you customize the color of this message
 
 If you would rather the card disappear completely instead of showing "No upcoming events", set `hide_when_empty: true`. The card removes itself from the dashboard whenever it has no events to display, and surrounding cards close the gap. It reappears automatically as soon as an event shows up, and always stays visible while you are editing the dashboard so you can still select and configure it.
 
+Hiding takes precedence over anything that only decorates an empty day: `show_empty_days` fills the range with "No events" placeholders, but those placeholders are not events, so a card with nothing but empty days still hides.
+
 > [!NOTE]
-> Compact mode limits never trigger hiding — a card limited to zero events with `compact_events_to_show: 0` stays visible so it can still be expanded. Configuration errors, such as a missing calendar entity, also remain visible so problems are not hidden silently.
+> Compact mode limits never trigger hiding — a card limited to zero events with `compact_events_to_show: 0` stays visible so it can still be expanded. Configuration errors, such as a missing calendar entity, also remain visible so problems are not hidden silently. The same applies when a calendar cannot be reached: a failed request leaves the event list empty, but the card stays on screen rather than vanishing because of a temporary outage.
 
 #### ⏱️ Time & Location Information
 

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -123,6 +123,13 @@ class CalendarCardPro extends LitElement {
   private _weatherUnsubscribers: Array<() => void> = [];
   private _weatherSetupVersion = 0;
   private _weatherSetupPending = false;
+  /**
+   * True when the most recent fetch could not read at least one calendar.
+   *
+   * Kept separate from `events` because a failed request and an empty calendar
+   * both leave the event list empty — see `_applyVisibility`.
+   */
+  private _hasFetchError = false;
   private _visibleCountCache?: {
     events: Types.CalendarEventData[];
     config: Types.Config;
@@ -180,6 +187,12 @@ class CalendarCardPro extends LitElement {
    * Placeholder entries generated for empty days are excluded, so this counts
    * only events that survive filtering (past events, blocklist/allowlist,
    * duplicates) and therefore matches what the user actually sees.
+   *
+   * That exclusion is the mechanism behind a deliberate precedence rule:
+   * hiding wins over anything that merely *decorates* an empty day. Neither
+   * `show_empty_days` nor any future custom empty-day text (#279) makes a card
+   * count as non-empty — a placeholder is not content. Anything added to the
+   * empty-day placeholder must stay filtered out here.
    *
    * Memoized against the inputs it depends on, because `updated()` runs on
    * every `hass` change and grouping the whole event list each time would be
@@ -334,11 +347,16 @@ class CalendarCardPro extends LitElement {
     const isErrorState =
       !this.isInitialLoad && (!this.safeHass || this.config.entities.length === 0);
 
+    // A calendar that could not be read looks identical to an empty one: both
+    // leave `events` empty. Hiding on that would make a transient API error
+    // silently delete the card from the dashboard, so a failed fetch keeps the
+    // card on screen and only a genuine empty result hides it.
     const shouldHide =
       this.config.hide_when_empty === true &&
       !this.preview &&
       !this.editMode &&
       !isErrorState &&
+      !this._hasFetchError &&
       this.visibleEventCount === 0;
 
     if (this.hidden === shouldHide) {
@@ -651,12 +669,17 @@ class CalendarCardPro extends LitElement {
       await this.updateComplete;
 
       // Get event data (from cache or API) using modularized function
-      const eventData = await EventUtils.fetchEventData(
+      const { events: eventData, failedEntities } = await EventUtils.fetchEventData(
         this.safeHass,
         this.config,
         this._instanceId,
         force,
       );
+
+      this._hasFetchError = failedEntities.length > 0;
+      if (this._hasFetchError) {
+        Logger.warn(`Could not load calendar(s): ${failedEntities.join(', ')}`);
+      }
 
       this.isLoading = false;
       this.isInitialLoad = false;
@@ -669,6 +692,7 @@ class CalendarCardPro extends LitElement {
       Logger.info('Event update completed successfully');
     } catch (error) {
       Logger.error('Failed to update events:', error);
+      this._hasFetchError = true;
       this.isLoading = false;
       this.isInitialLoad = false;
     }

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -116,6 +116,14 @@ class CalendarCardPro extends LitElement {
 
   // Private, non-reactive properties
   private _instanceId = Helpers.generateInstanceId();
+  /**
+   * The `_instanceId` the events currently held in `events` were fetched for.
+   *
+   * Lets a failed refresh tell "these events are a few minutes old" apart from
+   * "these events answer a question the card is no longer asking", so previous
+   * events are only ever preserved for an unchanged configuration.
+   */
+  private _eventsInstanceId = '';
   private _language = '';
   private _refreshTimerId?: number;
   private _lastUpdateTime = 0;
@@ -127,7 +135,11 @@ class CalendarCardPro extends LitElement {
    * True when the most recent fetch could not read at least one calendar.
    *
    * Kept separate from `events` because a failed request and an empty calendar
-   * both leave the event list empty — see `_applyVisibility`.
+   * both leave the event list empty, yet they mean opposite things. This flag is
+   * what lets the card tell them apart, and it drives three behaviours:
+   * keeping the card visible under `hide_when_empty` (`_applyVisibility`),
+   * keeping already-rendered events instead of blanking them (`updateEvents`),
+   * and showing the error state rather than "no upcoming events" (`render`).
    */
   private _hasFetchError = false;
   private _visibleCountCache?: {
@@ -685,11 +697,38 @@ class CalendarCardPro extends LitElement {
       this.isInitialLoad = false;
       await this.updateComplete;
 
-      // Finally set events data
-      this.events = [...eventData];
-      this._lastUpdateTime = Date.now();
+      // Keep whatever is already on screen when a refresh could not read any
+      // calendar and came back empty. Replacing good data with a blank card is a
+      // worse outcome than showing events that are a few minutes stale, and the
+      // next successful refresh overwrites them anyway. An empty result is only
+      // taken at face value when every calendar actually answered.
+      //
+      // Preserving is only valid while the events still answer the current
+      // question: `_instanceId` covers the entities, date range and past-event
+      // settings, so a config change makes the previous events stop counting as
+      // stale and start counting as wrong. Without that check, pointing a card at
+      // a broken entity would leave the old entity's events on screen forever.
+      const eventsMatchCurrentQuery = this._eventsInstanceId === this._instanceId;
+      const keepPreviousEvents =
+        this._hasFetchError &&
+        eventData.length === 0 &&
+        this.events.length > 0 &&
+        eventsMatchCurrentQuery;
 
-      Logger.info('Event update completed successfully');
+      if (keepPreviousEvents) {
+        Logger.warn('Refresh failed and returned nothing — keeping previously loaded events');
+      } else {
+        this.events = [...eventData];
+        this._eventsInstanceId = this._instanceId;
+      }
+
+      // Only a clean fetch counts as a completed update. Leaving the timestamp
+      // alone after a failure lets the visibility handler retry straight away
+      // instead of waiting out the refresh threshold.
+      if (!this._hasFetchError) {
+        this._lastUpdateTime = Date.now();
+        Logger.info('Event update completed successfully');
+      }
     } catch (error) {
       Logger.error('Failed to update events:', error);
       this._hasFetchError = true;
@@ -765,6 +804,12 @@ class CalendarCardPro extends LitElement {
       content = Render.renderCardContent('loading', this.effectiveLanguage);
     } else if (!this.safeHass || !this.config.entities.length) {
       // Error state - missing entities
+      content = Render.renderCardContent('error', this.effectiveLanguage);
+    } else if (this.events.length === 0 && this._hasFetchError) {
+      // Calendars could not be read and there is nothing to fall back on.
+      // "No upcoming events" would be a claim about the calendar's contents,
+      // which is precisely what the card failed to find out — so say that the
+      // calendar could not be read instead.
       content = Render.renderCardContent('error', this.effectiveLanguage);
     } else if (this.events.length === 0) {
       // Even with no events, use the regular groupEventsByDay function

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -226,6 +226,20 @@ export interface CalendarEventData {
 }
 
 /**
+ * Result of a calendar fetch, including which entities failed.
+ *
+ * Per-entity fetch errors are tolerated so that one broken calendar cannot
+ * blank out the others, which means an empty `events` array on its own is
+ * ambiguous — it is either a genuinely empty calendar or a failed request.
+ * `failedEntities` is what lets callers tell those two apart.
+ */
+export interface EventFetchResult {
+  events: CalendarEventData[];
+  /** Entity IDs whose calendar could not be retrieved during this fetch. */
+  failedEntities: string[];
+}
+
+/**
  * Grouped events by day
  */
 export interface EventsByDay {

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -31,7 +31,7 @@ export async function fetchEventData(
   config: Types.Config,
   instanceId: string,
   force = false,
-): Promise<Types.CalendarEventData[]> {
+): Promise<Types.EventFetchResult> {
   // Generate cache key based on configuration
   const cacheKey = getBaseCacheKey(
     instanceId,
@@ -48,7 +48,7 @@ export async function fetchEventData(
     const cachedEvents = getCachedEvents(cacheKey, config, isManualPageReload);
     if (cachedEvents) {
       Logger.info(`Using ${cachedEvents.length} events from cache`);
-      return [...cachedEvents];
+      return { events: [...cachedEvents], failedEntities: [] };
     }
   }
 
@@ -59,7 +59,7 @@ export async function fetchEventData(
   );
 
   const timeWindow = getTimeWindow(config.days_to_show, config.start_date);
-  const fetchedEvents = await fetchEvents(hass, entities, timeWindow);
+  const { events: fetchedEvents, failedEntities } = await fetchEvents(hass, entities, timeWindow);
 
   // Process events according to configuration rules
   let processedEvents = processEvents(fetchedEvents, config);
@@ -90,6 +90,14 @@ export async function fetchEventData(
   // Cache and return the processed results
   if (processedEvents.length > 0) {
     cacheEvents(cacheKey, processedEvents);
+  } else if (failedEntities.length > 0) {
+    // Every event we might have had could be sitting behind a failed request.
+    // Caching this empty result would make a transient outage look like a
+    // genuinely empty calendar for the whole TTL, so leave the cache alone and
+    // let the next refresh retry the API.
+    Logger.warn(
+      `No events returned and ${failedEntities.length} calendar(s) failed to load; not caching empty result`,
+    );
   } else {
     const emptyTtlMs = Constants.CACHE.EMPTY_RESULTS_CACHE_DURATION_SECONDS * 1000;
     Logger.info(
@@ -98,7 +106,7 @@ export async function fetchEventData(
     cacheEvents(cacheKey, processedEvents, emptyTtlMs);
   }
 
-  return processedEvents;
+  return { events: processedEvents, failedEntities };
 }
 
 /**
@@ -1104,14 +1112,21 @@ export function calculateEventProgress(event: Types.CalendarEventData): number |
 
 /**
  * Fetch calendar events from Home Assistant API
+ *
+ * A failure on one entity is logged and skipped rather than aborting the whole
+ * fetch, so a single broken calendar cannot blank out the others. The entity
+ * IDs that failed are returned alongside the events so callers can distinguish
+ * "this calendar is empty" from "this calendar could not be read".
+ *
  * @private Internal utility used by fetchEventData
  */
 export async function fetchEvents(
   hass: Types.Hass,
   entities: Array<Types.EntityConfig>,
   timeWindow: { start: Date; end: Date },
-): Promise<ReadonlyArray<Types.CalendarEventData>> {
+): Promise<Types.EventFetchResult> {
   const allEvents: Types.CalendarEventData[] = [];
+  const failedEntities: string[] = [];
 
   // Create a Set to track which entity IDs we've already fetched
   const fetchedEntityIds = new Set<string>();
@@ -1130,6 +1145,7 @@ export async function fetchEvents(
 
       if (!events || !Array.isArray(events)) {
         Logger.warn(`Invalid response for ${entityConfig.entity}`);
+        failedEntities.push(entityConfig.entity);
         continue;
       }
 
@@ -1146,6 +1162,7 @@ export async function fetchEvents(
       fetchedEntityIds.add(entityConfig.entity);
     } catch (error) {
       Logger.error(`Failed to fetch events for ${entityConfig.entity}:`, error);
+      failedEntities.push(entityConfig.entity);
 
       try {
         Logger.info(
@@ -1158,7 +1175,7 @@ export async function fetchEvents(
     }
   }
 
-  return allEvents;
+  return { events: allEvents, failedEntities };
 }
 
 /**


### PR DESCRIPTION
Follow-up to #362, which added `hide_when_empty`. Shipping that option surfaced a
pre-existing problem it made worse: **a failed fetch and an empty calendar are
indistinguishable to the card**, because both leave the event list empty.

That conflation had three consequences, each fixed by one commit here.

## 1. A failed fetch could hide the card entirely

With `hide_when_empty: true`, a calendar that could not be read produced zero
events, which the visibility check read as "nothing to show" — so the card
removed itself. An unreachable integration silently deleted a card from the
dashboard, with nothing left on screen to indicate anything was wrong.

`fetchEvents()` now reports *which* entities failed rather than just returning
whatever it managed to collect, via a new `EventFetchResult { events, failedEntities }`.
The card records that in `_hasFetchError` and refuses to hide while it is set.

The same signal fixed a cache bug found along the way: an empty result was
cached unconditionally, so a transient outage could persist an empty result and
keep serving it after the calendar recovered. Empty results are no longer cached
when any entity failed.

## 2. It then claimed there were no upcoming events

Having stayed visible, the card rendered its empty state — stating as fact that
the calendar was empty when it had never actually been read. It now renders the
error state instead when a fetch has failed and there is nothing to fall back on.

## 3. A failed refresh wiped events that were already on screen

Every fetch replaced `events` wholesale, so one failed poll turned a populated
card blank until the next successful one. Events are now kept when a refresh
fails.

**Preserving them is only correct while they still answer the question the card
is asking.** `setConfig` re-runs the fetch on every config change, so
unconditional preservation would mean that pointing a card at a mistyped entity
kept the *previous* calendar's events on screen indefinitely — worse than
blanking, because it looks correct. Preservation is scoped to `_instanceId`,
which already covers entities, date range and past-event settings, so a config
change drops the old events and reports the problem.

## Resulting behaviour

| Fetch | Events available | Result |
|---|---|---|
| ok | any | normal render (empty state if genuinely empty) |
| failed | ≥1 (fresh, partial, or preserved) | render those events |
| failed | none, or preserved events belong to a different config | error state, card stays visible |

The three fixes compose rather than compete: preserving events reduces how often
the error state is reached, so it is genuinely the last resort.

## Notes

- **`_lastUpdateTime` is deliberately left unstamped after a failure.** It is
  read only by the visibility handler, never by a timer, so a stale value makes
  returning to the tab retry immediately instead of treating a failed attempt as
  a completed update. No refresh-loop risk.
- **The error state reuses the existing `error` translation key** rather than
  adding a new one. `getTranslations()` falls back per *language*, not per key,
  so a key present only in `en.json` renders `undefined` in the other 34
  languages. The existing wording ("Error: Calendar entity not found or
  improperly configured") is accurate for the dominant cause. A dedicated
  "could not load calendar" string would be a nice refinement — but it needs all
  35 files in one pass, so it belongs in its own PR.

## Testing

Verified against a live Home Assistant instance across seven scenarios: broken
entity with and without `hide_when_empty`, a genuinely empty calendar, a mixed
working/broken pair, `show_empty_days` interaction, an unmodified control, and —
for the config-change guard — editing a working card's entity to a broken one
and confirming it drops the stale events rather than keeping them.

`npx tsc --noEmit`, `npm run lint` and `npm run build` all clean.

Refs #286