### PR TITLE
Fix formatting of fullDaysOfWeek in de.json

### DIFF
--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -1,14 +1,6 @@
 {
   "daysOfWeek": ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
-  "fullDaysOfWeek": [
-    "Sonntag",
-    "Montag",
-    "Dienstag",
-    "Mittwoch",
-    "Donnerstag",
-    "Freitag",
-    "Samstag"
-  ],
+  "fullDaysOfWeek": ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"],
   "months": ["Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"],
   "allDay": "ganztägig",
   "multiDay": "bis",


### PR DESCRIPTION
Merged the "fullDaysOfWeek" variable into a single line (as in the other languages).

## Description

In earlier translations, the line modified here was spread across multiple lines.
To restore consistency with the other languages, these lines have now been merged into a single line.

## Motivation and Context

No actual problem is being fixed; instead, comparability with other languages ​​is simply being restored.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🌎 Translation (addition or update for a language)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies update)
- [ ] 📚 Documentation (fix or addition to documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have linted and formatted my code (`npm run lint` and `npm run format`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change in my local Home Assistant instance.
- [x] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.
