### PR TITLE
feat: support Home Assistant templates in the card title

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,75 @@ days_to_show: 7 # Shows a 7-day window starting one week from today
 - **Fixed date range**: Using a specific date for `start_date` creates a static calendar view that always shows the same range
 - **Dynamic date range**: Using relative offsets creates a "floating" window that automatically adjusts as time passes
 
+### Dynamic Titles with Templates
+
+The `title` accepts [Home Assistant templates](https://www.home-assistant.io/docs/configuration/templating/), so the card heading can show live data instead of a fixed string:
+
+```yaml
+title: "{{ now().strftime('%-d %B %Y') }}" # 14 March 2025
+```
+
+No separate option enables this. Any title containing `{{` or `{%` is rendered as a template; everything else is used exactly as written.
+
+#### 🧩 What you can do with it
+
+- **Show the current date or time**
+
+  ```yaml
+  title: "{{ now().strftime('%A, %-d %B') }}" # Friday, 14 March
+  ```
+
+- **Show a sensor value**
+
+  ```yaml
+  title: 'Calendar — {{ states("sensor.outside_temperature") }}°C'
+  ```
+
+- **Change the title conditionally**
+
+  ```yaml
+  title: >-
+    {% if is_state('binary_sensor.workday_sensor', 'on') %}
+      Work Week
+    {% else %}
+      Weekend
+    {% endif %}
+  ```
+
+- **Count today's events from a calendar entity**
+
+  ```yaml
+  title: '{{ state_attr("calendar.family", "message") or "Nothing scheduled" }}'
+  ```
+
+> [!TIP]
+> Test a template in **Developer Tools → Template** first. What renders there is exactly what the card will show.
+
+#### 🔁 How updates work
+
+Home Assistant renders the template on its own and pushes a new value to the card whenever something the template depends on changes — there is no polling interval to configure and no need to reload the dashboard.
+
+- **Templates that read entities** update the moment that entity changes state.
+- **Templates that use `now()`** are re-evaluated by Home Assistant on a timer, so a title showing the current time keeps itself up to date.
+
+The rest of the card is unaffected: a title change never triggers a calendar refresh, and the events shown are exactly the same as with a static title.
+
+> [!NOTE]
+> The heading is briefly empty on first paint while Home Assistant renders the template. The card never displays the raw template text.
+
+#### ⚠️ When a template fails
+
+Errors are reported where you can act on them, and the card itself stays usable:
+
+- **In the visual editor**, an invalid template shows Home Assistant's own error message directly under the Title field as you type.
+- **In the browser console**, the error is logged with the template that produced it.
+- **On the card**, the last value that rendered successfully stays on screen. A card that has never rendered successfully shows no title rather than an error.
+
+Error reporting for templates that fail _after_ they were accepted requires Home Assistant 2023.9 or newer. On older versions templating still works, but a template that starts failing later will simply stop updating.
+
+> [!NOTE]
+> Because templates are detected by looking for `{{` and `{%`, a title that contains those characters literally will be treated as a template. This is the one trade-off of not requiring a separate option, and a literal `{{` in a card title is not something the card supports.
+
 ### Layout & Appearance
 
 #### 📐 Card Dimensions & Scrolling
@@ -1317,7 +1386,7 @@ These examples demonstrate how Calendar Card Pro can be customized to match any 
 | `split_multiday_events`                    | boolean           | `false`                                            | Display multi-day events on each day they cover                                                                                                                                                                                                             |
 | `language`                                 | string            | `System`, fallback `en`                            | Interface language (auto-detects from HA)                                                                                                                                                                                                                   |
 | **Header**                                 |                   |                                                    |                                                                                                                                                                                                                                                             |
-| `title`                                    | string            | -                                                  | Card title                                                                                                                                                                                                                                                  |
+| `title`                                    | string            | -                                                  | Card title. Accepts a [Home Assistant template](#dynamic-titles-with-templates) — any value containing `{{` or `{%` is rendered by Home Assistant and updates automatically                                                                                  |
 | `title_font_size`                          | string            | `--calendar-card-font-size-title`                  | Card title font size                                                                                                                                                                                                                                        |
 | `title_color`                              | string            | `--calendar-card-color-title`                      | Card title font color                                                                                                                                                                                                                                       |
 | **Layout and Spacing**                     |                   |                                                    |                                                                                                                                                                                                                                                             |

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -39,6 +39,7 @@ import * as Styles from './rendering/styles';
 import * as Feedback from './interaction/feedback';
 import * as Render from './rendering/render';
 import * as Weather from './utils/weather';
+import * as Templates from './utils/templates';
 import * as Editor from './rendering/editor';
 
 //-----------------------------------------------------------------------------
@@ -88,6 +89,16 @@ class CalendarCardPro extends LitElement {
   };
 
   /**
+   * Latest value rendered by Home Assistant for a templated `title`.
+   *
+   * Only meaningful when `config.title` contains a template. Undefined until
+   * the first render arrives, and deliberately left at its last good value when
+   * a later render fails, so a transient template error does not blank the
+   * heading.
+   */
+  @property({ attribute: false }) renderedTitle?: string;
+
+  /**
    * Set by Home Assistant's `hui-card` wrapper while the dashboard is in edit
    * mode or the card is shown in the card picker. The card must never hide
    * itself in these states, otherwise it becomes impossible to select and
@@ -131,6 +142,13 @@ class CalendarCardPro extends LitElement {
   private _weatherUnsubscribers: Array<() => void> = [];
   private _weatherSetupVersion = 0;
   private _weatherSetupPending = false;
+  /**
+   * Subscription that keeps `renderedTitle` in step with a templated `title`.
+   *
+   * Created lazily so cards with a plain string title never open a websocket
+   * subscription at all.
+   */
+  private _titleSubscription?: Templates.TemplateSubscription;
   /**
    * True when the most recent fetch could not read at least one calendar.
    *
@@ -186,6 +204,30 @@ class CalendarCardPro extends LitElement {
       this.isExpanded,
       this.effectiveLanguage,
     );
+  }
+
+  /**
+   * Title to display, with templates resolved.
+   *
+   * A templated title renders as empty until Home Assistant returns its first
+   * value, so raw Jinja is never shown to the user.
+   */
+  get effectiveTitle(): string | undefined {
+    if (!Templates.isTemplate(this.config.title)) {
+      return this.config.title;
+    }
+
+    return this.renderedTitle ?? '';
+  }
+
+  /**
+   * True while a templated title is waiting for its first rendered value.
+   *
+   * Lets the header keep a stable element identity across the round-trip
+   * instead of swapping the placeholder for an `h1` once the value lands.
+   */
+  get isTitlePending(): boolean {
+    return Templates.isTemplate(this.config.title) && this.renderedTitle === undefined;
   }
 
   /**
@@ -266,6 +308,9 @@ class CalendarCardPro extends LitElement {
     // Set up weather subscriptions if configured
     this._scheduleWeatherSetup();
 
+    // Resolve the title if it contains a template
+    this._updateTitleSubscription();
+
     // Set up visibility listener
     document.addEventListener('visibilitychange', this._handleVisibilityChange);
   }
@@ -279,6 +324,10 @@ class CalendarCardPro extends LitElement {
 
     // Clean up weather subscriptions
     this._cleanupWeatherSubscriptions();
+
+    // Clean up the title template subscription
+    this._titleSubscription?.destroy();
+    this._titleSubscription = undefined;
 
     // Clean up timers
     if (this._refreshTimerId) {
@@ -333,6 +382,11 @@ class CalendarCardPro extends LitElement {
       this._scheduleWeatherSetup();
     }
 
+    // Keep the title template subscription in step with hass and config
+    if (changedProps.has('hass') || changedProps.has('config')) {
+      this._updateTitleSubscription();
+    }
+
     // Hide or reveal the whole card when `hide_when_empty` is enabled
     this._applyVisibility();
   }
@@ -340,6 +394,49 @@ class CalendarCardPro extends LitElement {
   //-----------------------------------------------------------------------------
   // PRIVATE METHODS
   //-----------------------------------------------------------------------------
+
+  /**
+   * Keep the title template subscription aligned with the current config.
+   *
+   * `title` is deliberately absent from `hasConfigChanged`'s data-affecting
+   * keys, so changing it never triggers a re-fetch — this is the only thing
+   * that has to react to it. The subscription itself no-ops unless the template
+   * text or the connection actually changed, so this is safe to call on every
+   * `hass` update.
+   */
+  private _updateTitleSubscription(): void {
+    const isTemplated = Templates.isTemplate(this.config.title);
+
+    if (!isTemplated) {
+      // Drop a stale rendered value so switching back to a plain title, or
+      // clearing the field entirely, does not leave the old heading on screen
+      if (this._titleSubscription) {
+        this._titleSubscription.destroy();
+        this._titleSubscription = undefined;
+      }
+
+      this.renderedTitle = undefined;
+      return;
+    }
+
+    if (!this._titleSubscription) {
+      this._titleSubscription = new Templates.TemplateSubscription({
+        onResult: (result) => {
+          this.renderedTitle = result;
+        },
+        onError: () => {
+          // Keep the last good value rather than blanking the heading; the
+          // error itself is logged by the template utility and surfaced in the
+          // visual editor, which is where a user can act on it.
+          if (this.renderedTitle === undefined) {
+            this.renderedTitle = '';
+          }
+        },
+      });
+    }
+
+    this._titleSubscription.update(this.hass, this.config.title);
+  }
 
   /**
    * Hide the card entirely when it has no events and `hide_when_empty` is on.
@@ -841,11 +938,12 @@ class CalendarCardPro extends LitElement {
     // Render main card structure with content
     return Render.renderMainCardStructure(
       customStyles,
-      this.config.title,
+      this.effectiveTitle,
       content,
       handlers,
       false,
       this.isLoading,
+      this.isTitlePending,
     );
   }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -305,8 +305,8 @@ export interface Hass {
   };
   connection?: {
     subscribeEvents: (callback: (event: unknown) => void, eventType: string) => Promise<() => void>;
-    subscribeMessage: (
-      callback: (message: WeatherForecastMessage) => void,
+    subscribeMessage: <T = WeatherForecastMessage>(
+      callback: (message: T) => void,
       options: SubscribeMessageOptions,
     ) => Promise<() => void>;
   };
@@ -327,9 +327,37 @@ export interface WeatherForecastMessage {
  */
 export interface SubscribeMessageOptions {
   type: string;
-  entity_id: string;
+  /** Required by `weather/subscribe_forecast`, absent from `render_template`. */
+  entity_id?: string;
   forecast_type?: string;
   [key: string]: unknown;
+}
+
+/**
+ * Successful `render_template` result pushed by Home Assistant.
+ *
+ * `result` is not necessarily a string: Home Assistant renders templates with
+ * native type parsing enabled, so `{{ 1 + 1 }}` arrives as the number `2`.
+ *
+ * `listeners.time` is true for templates that depend on the current time (for
+ * example `now()`), which Home Assistant re-renders on its own timer.
+ */
+export interface RenderTemplateResult {
+  result: unknown;
+  listeners?: {
+    all: boolean;
+    domains: string[];
+    entities: string[];
+    time: boolean;
+  };
+}
+
+/**
+ * Template error pushed by Home Assistant when `report_errors` is enabled.
+ */
+export interface RenderTemplateError {
+  error: string;
+  level: 'ERROR' | 'WARNING';
 }
 
 /**

--- a/src/rendering/editor.ts
+++ b/src/rendering/editor.ts
@@ -18,6 +18,7 @@ import * as Types from '../config/types';
 import * as Config from '../config/config';
 import * as Helpers from '../utils/helpers';
 import * as Localize from '../translations/localize';
+import * as Templates from '../utils/templates';
 
 // Import Material Design icons
 import {
@@ -97,6 +98,23 @@ export class CalendarCardProEditor extends LitElement {
   @property({ attribute: false }) hass?: Types.Hass;
   @property({ attribute: false }) _config?: Types.Config;
 
+  /**
+   * Home Assistant's raw error text for an invalid `title` template.
+   *
+   * Shown verbatim under the Title field: Home Assistant's own message names
+   * the offending construct, which is the part a user needs in order to fix it,
+   * and it needs no translation key of its own.
+   */
+  @property({ attribute: false }) private _titleTemplateError?: string;
+
+  /**
+   * Validates the `title` template as it is typed.
+   *
+   * Separate from the preview card's own subscription so the editor can report
+   * errors without the card having to surface them in its heading.
+   */
+  private _titleValidation?: Templates.TemplateSubscription;
+
   //-----------------------------------------------------------------------------
   // LIFECYCLE METHODS
   //-----------------------------------------------------------------------------
@@ -107,6 +125,56 @@ export class CalendarCardProEditor extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
     this._loadCustomElements();
+  }
+
+  /**
+   * Called when the editor is removed from the DOM.
+   *
+   * Home Assistant discards and recreates the editor element as the user moves
+   * between cards, so the validation subscription has to be closed here or it
+   * would outlive the element.
+   */
+  disconnectedCallback(): void {
+    this._titleValidation?.destroy();
+    this._titleValidation = undefined;
+    super.disconnectedCallback();
+  }
+
+  /**
+   * Keeps title template validation in step with the edited config.
+   */
+  updated(): void {
+    this._updateTitleValidation();
+  }
+
+  /**
+   * Subscribes to the current `title` value so template errors surface live.
+   *
+   * The subscription itself debounces and no-ops on an unchanged template, so
+   * this is safe to call from `updated()`, which runs on every keystroke.
+   */
+  private _updateTitleValidation(): void {
+    const title = this._config?.title;
+
+    if (!Templates.isTemplate(title)) {
+      this._titleValidation?.destroy();
+      this._titleValidation = undefined;
+      this._titleTemplateError = undefined;
+      return;
+    }
+
+    if (!this._titleValidation) {
+      this._titleValidation = new Templates.TemplateSubscription({
+        onResult: () => {
+          this._titleTemplateError = undefined;
+        },
+        onError: (error) => {
+          this._titleTemplateError = error;
+        },
+      });
+    }
+
+    this._titleValidation.update(this.hass, title);
   }
 
   /**
@@ -874,6 +942,9 @@ export class CalendarCardProEditor extends LitElement {
             <!-- Title Styling -->
             <h3>${this._getTranslation('title_styling')}</h3>
             ${this.addTextField('title', this._getTranslation('title'))}
+            ${this._titleTemplateError
+              ? html` <ha-alert alert-type="error">${this._titleTemplateError}</ha-alert> `
+              : nothing}
             ${this.addTextField('title_font_size', this._getTranslation('title_font_size'))}
             ${this.addTextField('title_color', this._getTranslation('title_color'))}
 

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -32,6 +32,8 @@ import * as Weather from '../utils/weather';
  * @param content Main card content (events or status)
  * @param handlers Event handler functions
  * @param maxHeightSet Flag to add max-height-set class
+ * @param isLoading Flag to mark the card as busy while events load
+ * @param titlePending True while a templated title awaits its first value
  * @returns TemplateResult for the complete card
  */
 export function renderMainCardStructure(
@@ -47,6 +49,7 @@ export function renderMainCardStructure(
   },
   maxHeightSet: boolean = false,
   isLoading: boolean = false,
+  titlePending: boolean = false,
 ): TemplateResult {
   return html`
     <ha-card
@@ -70,9 +73,11 @@ export function renderMainCardStructure(
           `
         : nothing}
 
-      <!-- Title is always rendered with the same structure, even if empty -->
+      <!-- Title is always rendered with the same structure, even if empty.
+           A templated title keeps the h1 from first paint so the element
+           identity does not change when its value arrives. -->
       <div class="header-container">
-        ${title
+        ${title || titlePending
           ? html`<h1 class="card-header">${title}</h1>`
           : html`<div class="card-header-placeholder"></div>`}
       </div>

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,0 +1,335 @@
+/* eslint-disable import/order */
+/**
+ * Template utilities for Calendar Card Pro
+ *
+ * Resolves Jinja2 templates through Home Assistant's `render_template` websocket
+ * subscription. Home Assistant renders templates server-side and pushes a new
+ * value whenever a referenced entity changes, so no polling is required here.
+ * Templates that depend on the current time (for example `now()`) set
+ * `listeners.time` and Home Assistant re-renders them on its own timer.
+ *
+ * This module is deliberately generic so other templated settings can adopt it
+ * without duplicating the subscription, debounce and teardown logic.
+ */
+
+import * as Types from '../config/types';
+import * as Logger from './logger';
+
+//-----------------------------------------------------------------------------
+// CONSTANTS
+//-----------------------------------------------------------------------------
+
+/**
+ * Delay before re-subscribing after a template changes.
+ *
+ * The visual editor fires a config update on every keystroke, so without this
+ * a user typing `{{ now() }}` would open a subscription per character, nearly
+ * all of them for invalid intermediate Jinja.
+ */
+const RESUBSCRIBE_DEBOUNCE_MS = 300;
+
+/** Error code Home Assistant returns when a command fails schema validation. */
+const ERR_INVALID_FORMAT = 'invalid_format';
+
+/**
+ * Whether this Home Assistant instance accepts the `report_errors` option.
+ *
+ * `report_errors` was added to `render_template` in Home Assistant 2023.9, and
+ * websocket command schemas reject unknown keys, so sending it to an older
+ * instance fails the entire subscription. We optimistically send it, then
+ * remember a schema rejection for the rest of the session and fall back to a
+ * subscription without it (losing runtime error reporting, but still working).
+ */
+let reportErrorsSupported = true;
+
+//-----------------------------------------------------------------------------
+// DETECTION
+//-----------------------------------------------------------------------------
+
+/**
+ * Determine whether a configuration value contains a Jinja2 template
+ *
+ * Matches both expression (`{{ ... }}`) and statement (`{% if %}`) delimiters.
+ * A literal `{{` in an otherwise static value would be misread as a template;
+ * this is documented and considered an acceptable trade-off for not adding a
+ * separate configuration key.
+ *
+ * @param value Value to test
+ * @returns True if the value should be rendered as a template
+ */
+export function isTemplate(value: unknown): value is string {
+  return typeof value === 'string' && (value.includes('{{') || value.includes('{%'));
+}
+
+//-----------------------------------------------------------------------------
+// SUBSCRIPTION
+//-----------------------------------------------------------------------------
+
+/**
+ * Callbacks invoked as template results and errors arrive
+ */
+export interface TemplateCallbacks {
+  /** Called with each rendered value pushed by Home Assistant */
+  onResult: (result: string) => void;
+  /** Called with Home Assistant's raw error text when rendering fails */
+  onError: (error: string) => void;
+}
+
+/**
+ * Normalize a rendered template result into a string
+ *
+ * Home Assistant renders with native type parsing, so results may arrive as
+ * numbers, booleans or lists rather than strings.
+ *
+ * @param result Raw result from Home Assistant
+ * @returns String representation, empty for null/undefined
+ */
+function normalizeResult(result: unknown): string {
+  if (result === null || result === undefined) {
+    return '';
+  }
+  return typeof result === 'string' ? result : String(result);
+}
+
+/**
+ * Determine whether a rejection was caused by schema validation
+ *
+ * @param error Rejection value from `subscribeMessage`
+ * @returns True if Home Assistant rejected the command's shape
+ */
+function isSchemaRejection(error: unknown): boolean {
+  return (error as { code?: string } | undefined)?.code === ERR_INVALID_FORMAT;
+}
+
+/**
+ * Subscribe to a Jinja2 template rendered by Home Assistant
+ *
+ * @param hass Home Assistant instance
+ * @param template Template string to render
+ * @param callbacks Handlers for results and errors
+ * @returns Unsubscribe function, or undefined if the subscription failed
+ */
+export async function subscribeToTemplate(
+  hass: Types.Hass | undefined,
+  template: string,
+  callbacks: TemplateCallbacks,
+): Promise<(() => void) | undefined> {
+  const connection = hass?.connection;
+  if (!connection || !template) {
+    return undefined;
+  }
+
+  const handleMessage = (message: Types.RenderTemplateResult | Types.RenderTemplateError) => {
+    // Errors arrive on the same channel as results when report_errors is on
+    if (message && 'error' in message) {
+      // Warnings are routine during startup (entities not yet available)
+      if (message.level === 'WARNING') {
+        Logger.debug('Template warning', { template, error: message.error });
+        return;
+      }
+
+      Logger.error('Template render error', { template, error: message.error });
+      callbacks.onError(message.error);
+      return;
+    }
+
+    if (message && 'result' in message) {
+      callbacks.onResult(normalizeResult(message.result));
+    }
+  };
+
+  const subscribe = (withReportErrors: boolean) =>
+    connection.subscribeMessage<Types.RenderTemplateResult | Types.RenderTemplateError>(
+      handleMessage,
+      {
+        type: 'render_template',
+        template,
+        ...(withReportErrors ? { report_errors: true } : {}),
+      },
+    );
+
+  try {
+    return await subscribe(reportErrorsSupported);
+  } catch (error) {
+    // An older Home Assistant rejects the unknown `report_errors` key outright.
+    // Retry without it so templating still works, minus runtime error reporting.
+    if (reportErrorsSupported && isSchemaRejection(error)) {
+      reportErrorsSupported = false;
+      Logger.warn(
+        'Home Assistant rejected the render_template `report_errors` option; ' +
+          'falling back to basic template rendering (requires 2023.9+ for error reporting)',
+      );
+
+      try {
+        return await subscribe(false);
+      } catch (fallbackError) {
+        Logger.error('Failed to subscribe to template', {
+          template,
+          error: fallbackError,
+        });
+        return undefined;
+      }
+    }
+
+    // A genuine template error (bad syntax) rejects at subscribe time
+    const message = (error as { message?: string } | undefined)?.message;
+    Logger.error('Failed to subscribe to template', { template, error });
+    callbacks.onError(message ?? String(error));
+
+    return undefined;
+  }
+}
+
+//-----------------------------------------------------------------------------
+// SUBSCRIPTION MANAGER
+//-----------------------------------------------------------------------------
+
+/**
+ * Manages the lifecycle of a single template subscription
+ *
+ * Handles debouncing, teardown and out-of-order resolution so callers only need
+ * to push the current template on every update and tear down on disconnect.
+ */
+export class TemplateSubscription {
+  private _template?: string;
+  private _connection?: Types.Hass['connection'];
+  private _unsubscribe?: () => void;
+  private _debounceId?: ReturnType<typeof setTimeout>;
+
+  /**
+   * Whether a Home Assistant connection has been seen before.
+   *
+   * The first update that has a connection subscribes immediately so the card
+   * paints its title without an artificial delay. Everything after it is
+   * debounced, which keeps a user typing `{{` in the editor from being shown a
+   * syntax error before they have finished writing the template.
+   */
+  private _hasConnected = false;
+
+  /** Incremented on every change so stale async resolutions can be discarded */
+  private _version = 0;
+
+  constructor(private readonly callbacks: TemplateCallbacks) {}
+
+  /**
+   * Push the current Home Assistant instance and template value
+   *
+   * Safe to call on every update: it compares the template text and connection
+   * rather than the `hass` object, which Home Assistant replaces on every state
+   * change, and does nothing when neither has changed.
+   *
+   * @param hass Home Assistant instance
+   * @param value Candidate template value (ignored if not a template)
+   */
+  update(hass: Types.Hass | undefined, value: unknown): void {
+    const template = isTemplate(value) ? value : undefined;
+    const connection = hass?.connection;
+
+    // The first update carrying a connection gets to subscribe without waiting
+    const isFirstConnection = !this._hasConnected && Boolean(connection);
+    if (connection) {
+      this._hasConnected = true;
+    }
+
+    if (template === this._template && connection === this._connection) {
+      return;
+    }
+
+    this._template = template;
+    this._connection = connection;
+
+    // Invalidate in-flight setups and drop the existing subscription
+    this._version++;
+    this._clearPending();
+    this._teardown();
+
+    if (!template || !hass) {
+      return;
+    }
+
+    // Subscribe immediately on the first connection so the initial paint
+    // resolves fast, then debounce so editor keystrokes do not open a
+    // subscription per character
+    if (isFirstConnection) {
+      void this._subscribe(hass, template, this._version);
+    } else {
+      this._debounceId = setTimeout(() => {
+        this._debounceId = undefined;
+        void this._subscribe(hass, template, this._version);
+      }, RESUBSCRIBE_DEBOUNCE_MS);
+    }
+  }
+
+  /**
+   * Tear down the subscription and cancel any pending work
+   */
+  destroy(): void {
+    this._version++;
+    this._template = undefined;
+    this._connection = undefined;
+    this._hasConnected = false;
+    this._clearPending();
+    this._teardown();
+  }
+
+  /**
+   * Open the subscription, discarding the result if it has been superseded
+   *
+   * @param hass Home Assistant instance
+   * @param template Template string to render
+   * @param version Version captured before the await
+   */
+  private async _subscribe(hass: Types.Hass, template: string, version: number): Promise<void> {
+    const unsubscribe = await subscribeToTemplate(hass, template, {
+      onResult: (result) => {
+        if (version === this._version) {
+          this.callbacks.onResult(result);
+        }
+      },
+      onError: (error) => {
+        if (version === this._version) {
+          this.callbacks.onError(error);
+        }
+      },
+    });
+
+    if (!unsubscribe) {
+      return;
+    }
+
+    // A newer template arrived while we were subscribing
+    if (version !== this._version) {
+      unsubscribe();
+      return;
+    }
+
+    this._unsubscribe = unsubscribe;
+  }
+
+  /**
+   * Cancel a debounced subscribe that has not fired yet
+   */
+  private _clearPending(): void {
+    if (this._debounceId) {
+      clearTimeout(this._debounceId);
+      this._debounceId = undefined;
+    }
+  }
+
+  /**
+   * Close the active subscription if there is one
+   */
+  private _teardown(): void {
+    if (!this._unsubscribe) {
+      return;
+    }
+
+    try {
+      this._unsubscribe();
+    } catch (error) {
+      Logger.warn('Failed to unsubscribe from template', error);
+    }
+
+    this._unsubscribe = undefined;
+  }
+}


### PR DESCRIPTION
Closes #303.

Adds Jinja templating support to the `title` config option, rendered server-side by Home Assistant and pushed live over the `render_template` websocket subscription.

## Approach

**Detected in place — no new config key.** A `title` containing `{{` or `{%` is treated as a template; anything else is passed through untouched. This is the same lever the start-date epic used in #366: extend the grammar of an existing key rather than adding a parallel one. It avoids the config-key trap (`types.ts` + `config.ts` + `editor.ts` + `README.md` + the `editor` section of all 11 editor-bearing language files, where a partial section fails silently as raw key names on screen).

**No new dependency.** Mushroom reaches this API via `custom-card-helpers`, which isn't a dependency here and mustn't become one — bundle size is an explicit design constraint. We already had the exact call shape in-house in `subscribeToWeatherForecast`, so `src/utils/templates.ts` follows it.

**Built as a shared mechanism, wired to one site.** `src/utils/templates.ts` is deliberately generic so #311's visibility conditions and #279's empty-day text can reuse it. Only `title` is wired up here.

## What's included

| File | |
| --- | --- |
| `src/utils/templates.ts` | **new** — `isTemplate()`, `subscribeToTemplate()`, `TemplateSubscription` |
| `src/config/types.ts` | genericised `connection.subscribeMessage`; added `RenderTemplateResult` / `RenderTemplateError` |
| `src/calendar-card-pro.ts` | subscription lifecycle, `effectiveTitle` / `isTitlePending` |
| `src/rendering/render.ts` | header renders while a template is pending |
| `src/rendering/editor.ts` | live `ha-alert` surfacing HA's raw error text under the Title field |
| `README.md` | new **Dynamic Titles with Templates** section + a note on the `title` row |

No translation files touched — the templating guidance lives in the README rather than as a `title_note` editor string, so this slice doesn't take on an all-or-nothing commitment across 11 language files.

## Details worth reviewing

**Error reporting is opt-in and version-guarded.** Without `report_errors`, a *runtime* render error makes HA's `_template_listener` return early and send nothing at all — the title would silently freeze on its last good value with no signal. So we pass `report_errors: true`. But that key only landed in HA **2023.9**, and HA's websocket schemas are voluptuous with `PREVENT_EXTRA`, so on older installs an unknown key rejects the *entire subscription* — a strictly worse failure than the one the flag prevents. `subscribeToTemplate()` therefore catches `invalid_format`, memoises the result module-wide, and retries once without the flag. Older installs get degraded error reporting instead of a broken title, and pay the extra round-trip once per session rather than per card.

**Only `level === 'ERROR'` is acted on.** Enabling `report_errors` also wires HA's `log_fn`, so WARNING-level noise arrives on the same channel; those are logged at debug and otherwise ignored.

**`result` is typed `unknown`, not `string`.** `{{ 1 + 1 }}` returns the number `2`. It's coerced explicitly.

**Errors keep the last good title.** A template that starts failing at runtime leaves the previously rendered value on screen rather than blanking the card. The editor alert is where the error text surfaces.

**Resubscribes are debounced 300ms — and this is load-bearing, not polish.** `addTextField` wires both `@input` and `@change` to `_valueChanged`, so typing a template character-by-character would otherwise open and tear down a subscription per keystroke, each one erroring on a half-written template. The first connection subscribes immediately so there's no paint delay on load. Resubscribes are gated on the template text and connection identity, never on `hass` object identity — HA replaces that object on every state update.

**Teardown** happens on `disconnectedCallback` in both the card and the editor, and a version guard discards results from superseded subscriptions.

## Verified live

Against HA 2026.8.1, on a dedicated test view:

- the reporter's `{{ now().strftime('%-d %B %Y %H:%M') }}` — self-refreshes with no timer code on our side, because HA sets `listeners.time` for `now()` templates and re-renders them on its own schedule (watched the clock advance 22:38 → 22:44)
- a sensor-state template updating live when the entity changed
- `{% if %}` block syntax detected, not just `{{ }}`
- a deliberate syntax error → `ha-alert` shows HA's raw error text in the editor
- an untemplated plain-string title — pixel-identical to before
- fast typing in the Title field — one subscription, not one per keystroke
- a subscription count probe: exactly 4 `render_template` subscriptions for 4 templated cards, none leaked across re-renders

## Notes

- Version deliberately left at 3.4.0.
- `Fixes #303` won't auto-close — closing keywords only fire on the default branch, which is `main`. It'll close with the release PR.
- A templated title that renders empty produces no line box, so the card sits one line shorter. That matches existing `title: ""` behaviour.

---

Unrelated pre-existing bug found while verifying this and filed separately as #369 rather than bundled here: `.card-header` still depends on Polymer `--paper-font-*` variables that HA has removed, so titles render at body-text size on current HA. It reproduces identically on the released HACS build.