### PR TITLE
fix: restore card title typography lost to removed Polymer variables

### DIFF
--- a/src/rendering/styles.ts
+++ b/src/rendering/styles.ts
@@ -175,17 +175,16 @@ export const cardStyles = css`
     margin: 0 0 16px 8px;
     padding: 0;
 
-    /* Typography */
+    /* Typography
+     * The literal fallbacks are load-bearing: Home Assistant removed the
+     * --paper-font-headline_-_* variables, and a var() that references an
+     * undefined property without a fallback is invalid at computed-value time,
+     * which silently downgraded the title to inherited body text. */
     color: var(--calendar-card-color-title, var(--primary-text-color));
-    font-size: var(--calendar-card-font-size-title, var(--paper-font-headline_-_font-size));
-    font-weight: var(--paper-font-headline_-_font-weight);
-    letter-spacing: var(--paper-font-headline_-_letter-spacing);
-    line-height: var(--paper-font-headline_-_line-height);
-
-    /* Additional Typography */
-    -webkit-font-smoothing: var(--paper-font-headline_-_-webkit-font-smoothing);
-    text-rendering: var(--paper-font-common-expensive-kerning_-_text-rendering);
-    opacity: var(--dark-primary-opacity);
+    font-size: var(--calendar-card-font-size-title, var(--ha-card-header-font-size, 24px));
+    font-weight: var(--ha-font-weight-normal, 400);
+    letter-spacing: -0.012em;
+    line-height: 1.33;
   }
 
   /* ===== WEEK NUMBER & SEPARATOR STYLES ===== */


### PR DESCRIPTION
Fixes #369.

## What was broken

`.card-header` styled the title entirely through Polymer `--paper-font-headline_-_*` custom properties. Home Assistant no longer defines them, and the `var()` references carried **no fallback**, so the declarations were [invalid at computed-value time](https://www.w3.org/TR/css-variables-1/#invalid-variables).

`font-size`, `font-weight`, `letter-spacing` and `line-height` are all *inherited* properties, so that resolved to `inherit` — and because these are author-level declarations they also beat the UA stylesheet's `<h1>` defaults. The title rendered as ordinary body text with no visual hierarchy.

Not a regression from anything recent: it reproduces identically on the released HACS build. `title_font_size` defaults to `undefined`, so the dead paper fallback was the live path for every user who had not set it explicitly.

## Measured, HA 2026.8.1

Released `calendar-card-pro` and patched `calendar-card-pro-dev`, side by side on the same dashboard:

| | before | after | native `hui-entities-card` |
|---|---|---|---|
| `font-size` | **14px** | 24px | 24px |
| `font-weight` | 400 | 400 | 400 |
| `line-height` | **22.4px** | 31.92px | 48px |
| `letter-spacing` | **normal** | −0.288px | −0.288px |
| `opacity` | 0.87 | 1 | 1 |
| top inset | 17px | 17px | 25px |
| left inset | 17px | 17px | 17px |

Geometry is untouched — the header still sits at 17px/17px, which is exactly where a native HA card header sits horizontally. The compact vertical rhythm (`line-height` well under native's 48px) is kept deliberately.

## Two deviations from the diff filed in #369

**1. `line-height: 1.33`, not a literal `32px`.** A unitless multiplier scales with `title_font_size`; a fixed `32px` would clip or overlap at larger sizes. Verified live: `16px → 21.28px`, `40px → 53.2px`. At the default it is 31.92px, visually identical to the 32px the issue proposed.

**2. `opacity: var(--dark-primary-opacity)` is removed, and #369 was wrong to call it dead.** It still resolves — to `.87` — so this is a real visual change, not a cleanup. Keeping it would mean the title renders washed out and a configured `title_color` can never be shown as specified. Native HA card headers apply no opacity, and our own event titles render at full opacity, so 0.87 inverted the colour hierarchy. Easy one-line revert if you disagree.

`-webkit-font-smoothing` and `text-rendering` are also dropped, but those genuinely were dead: both already resolved to `inherit`, so removal is behaviour-neutral.

## Release note

Titled cards get **~10px taller** and titles become noticeably larger. Worth a line in the 3.5.0 notes.

## Validation

`npx tsc --noEmit`, `npm run lint`, `npx prettier --check 'src/**/*.ts'`, `npm run build` all clean. Deployed to the live instance as `?v=243` and verified against the released build on the same dashboard. No version bump.

