### PR TITLE
feat: suggest the card in the picker for calendar entities

### DIFF
--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -974,4 +974,7 @@ window.customCards.push({
   preview: true,
   description: 'A calendar card that supports multiple calendars with individual styling.',
   documentationURL: 'https://github.com/alexpfau/calendar-card-pro',
+  // Offer this card in the picker's community suggestions for calendar entities.
+  // Ignored by Home Assistant versions older than 2026.6.
+  getEntitySuggestion: Config.getEntitySuggestion,
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -377,17 +377,102 @@ export function findCalendarEntity(hass: Record<string, { state: string }>): str
 }
 
 /**
+ * Grid layout hint attached to the card picker suggestion.
+ *
+ * A sections view falls back to the card's own default footprint when a suggested
+ * config omits `grid_options`, which misrepresents a list-shaped card like this
+ * one. Half width with room for a few days is a better starting point, and the
+ * user can resize the card afterwards like any other.
+ */
+const SUGGESTION_GRID_OPTIONS = {
+  columns: 6,
+  rows: 4,
+};
+
+/**
+ * Build the opinionated starting configuration for a set of calendar entities.
+ *
+ * Shared by the card picker preview (`getStubConfig`) and the entity suggestion so
+ * the two recipes cannot drift apart. Entities are emitted in the simplest valid
+ * form — a plain array of entity IDs — rather than the object form used for
+ * per-calendar styling.
+ *
+ * The `-dev` suffix on the element name is intentional and must stay a plain
+ * string literal: the build rewrites that exact literal to the production element
+ * name, so a computed or pre-stripped name would break one of the two bundles.
+ *
+ * @param entities - Calendar entity IDs to pre-fill
+ * @returns A ready-to-use card configuration
+ */
+function buildDefaultCardConfig(entities: ReadonlyArray<string>): Record<string, unknown> {
+  return {
+    type: 'custom:calendar-card-pro-dev',
+    entities: [...entities],
+    days_to_show: 3,
+    show_location: true,
+  };
+}
+
+/**
  * Generate a stub configuration for the card editor
  */
 export function getStubConfig(hass: Record<string, { state: string }>): Record<string, unknown> {
   const calendarEntity = findCalendarEntity(hass);
   return {
-    type: 'custom:calendar-card-pro-dev',
-    entities: calendarEntity ? [calendarEntity] : [],
-    days_to_show: 3,
-    show_location: true,
+    ...buildDefaultCardConfig(calendarEntity ? [calendarEntity] : []),
     _description: !calendarEntity
       ? 'A calendar card that displays events from multiple calendars with individual styling. Add a calendar integration to Home Assistant to use this card.'
       : undefined,
   };
+}
+
+/**
+ * Offer this card for an entity picked in the Home Assistant card picker.
+ *
+ * Home Assistant (2026.6+) calls this synchronously for every entity a user
+ * selects, and discards the entire community suggestion list — including entries
+ * contributed by other custom cards — if any implementation throws. The body is
+ * therefore deliberately trivial and total: every input is treated as untrusted,
+ * nothing is assumed about the shape of `hass`, and anything unexpected returns
+ * `null` (never an empty array).
+ *
+ * The domain check is the whole filter. A calendar entity carries no capability
+ * signal worth testing: there is no meaningful device class, no relevant
+ * `supported_features`, and its state only reports whether an event is currently
+ * running, which says nothing about whether this card suits it.
+ *
+ * Exactly one suggestion is returned, unlabelled. The picker mounts every returned
+ * suggestion as a live card without virtualization, and every live instance of
+ * this card fetches calendar events on setup, so each extra variant would cost a
+ * real calendar API request every time anyone picks a calendar entity.
+ *
+ * @param hass - Home Assistant instance, treated as possibly absent or malformed
+ * @param entityId - Entity ID selected in the card picker
+ * @returns A single-entry suggestion list, or `null` when nothing should be offered
+ */
+export function getEntitySuggestion(
+  hass: Types.Hass | null | undefined,
+  entityId: string,
+): Types.EntitySuggestion[] | null {
+  if (typeof entityId !== 'string' || entityId.split('.')[0] !== 'calendar') {
+    return null;
+  }
+
+  if (!hass || typeof hass !== 'object') {
+    return null;
+  }
+
+  const states = hass.states;
+  if (!states || typeof states !== 'object' || !states[entityId]) {
+    return null;
+  }
+
+  return [
+    {
+      config: {
+        ...buildDefaultCardConfig([entityId]),
+        grid_options: { ...SUGGESTION_GRID_OPTIONS },
+      },
+    },
+  ];
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -379,19 +379,27 @@ export function findCalendarEntity(hass: Record<string, { state: string }>): str
 /**
  * Grid layout hint attached to the card picker suggestion.
  *
- * A sections view falls back to the card's own default footprint when a suggested
- * config omits `grid_options`, which misrepresents a list-shaped card like this
- * one. Half width suits that shape and the user can resize afterwards like any
- * other card.
+ * Full width, because this card is a text-heavy list: every row carries a date,
+ * a title, a time and optionally a location. A section has a capped maximum
+ * width, so half of one lands around 230-250px on any screen, and below roughly
+ * 250px those fields wrap aggressively - a long location can spill over several
+ * lines. That makes the card harder to read *and* taller than the full-width
+ * equivalent showing the same events, so half width costs horizontal space
+ * without buying anything back.
  *
  * The row count is deliberately left to the content. A numeric `rows` pins the
  * card to a fixed height rather than a minimum, and this card's height is not
  * knowable at suggestion time: `days_to_show` says nothing about how many events
  * fall in those days. A fixed height would leave dead space on a quiet calendar
  * and silently truncate a busy one. `'auto'` avoids both.
+ *
+ * These values match what Home Assistant assigns a card that declares no grid
+ * options of its own. They are stated explicitly rather than left out so the
+ * intent is legible at the call site, and so a future change to that platform
+ * default cannot quietly move the suggestion with it.
  */
 const SUGGESTION_GRID_OPTIONS = {
-  columns: 6,
+  columns: 12,
   rows: 'auto',
 };
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -381,12 +381,18 @@ export function findCalendarEntity(hass: Record<string, { state: string }>): str
  *
  * A sections view falls back to the card's own default footprint when a suggested
  * config omits `grid_options`, which misrepresents a list-shaped card like this
- * one. Half width with room for a few days is a better starting point, and the
- * user can resize the card afterwards like any other.
+ * one. Half width suits that shape and the user can resize afterwards like any
+ * other card.
+ *
+ * The row count is deliberately left to the content. A numeric `rows` pins the
+ * card to a fixed height rather than a minimum, and this card's height is not
+ * knowable at suggestion time: `days_to_show` says nothing about how many events
+ * fall in those days. A fixed height would leave dead space on a quiet calendar
+ * and silently truncate a busy one. `'auto'` avoids both.
  */
 const SUGGESTION_GRID_OPTIONS = {
   columns: 6,
-  rows: 4,
+  rows: 'auto',
 };
 
 /**

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -376,6 +376,18 @@ export interface HassEntity {
 }
 
 /**
+ * A single card recipe offered by the Home Assistant card picker after the user
+ * selects an entity.
+ *
+ * The first entry of a suggestion list is the canonical recipe and carries no
+ * `label`; any further entry is a labelled variant.
+ */
+export interface EntitySuggestion {
+  label?: string;
+  config: Record<string, unknown>;
+}
+
+/**
  * Custom card registration interface for Home Assistant
  */
 export interface CustomCard {
@@ -384,6 +396,16 @@ export interface CustomCard {
   preview: boolean;
   description: string;
   documentationURL?: string;
+  /**
+   * Optional hook (Home Assistant 2026.6+) that offers this card for a picked
+   * entity. Must be synchronous and must never throw: Home Assistant discards
+   * the whole community suggestion list — including entries contributed by other
+   * custom cards — when a single implementation raises. Returns `null`, never an
+   * empty array, when there is nothing to offer.
+   *
+   * Older Home Assistant versions ignore this key.
+   */
+  getEntitySuggestion?: (hass: Hass, entityId: string) => EntitySuggestion[] | null;
 }
 
 /**


### PR DESCRIPTION
Closes #373.

Home Assistant 2026.6 lets a custom card offer itself for an entity the user picks in the card picker, listed under a **Community** section. This card consumes `calendar.*` entities and nothing else, so it is the clean case rather than the noisy one — today a user has to already know this card exists and hunt for it in the full card list.

## What changed

`getEntitySuggestion` is added to the `window.customCards` entry. For any `calendar.*` entity present in the state machine it returns one suggestion:

```yaml
type: custom:calendar-card-pro
entities:
  - calendar.family_holidays
days_to_show: 3
show_location: true
grid_options:
  columns: 12
  rows: auto
```

For anything else it returns `null`.

The default config is now produced by a single helper shared with `getStubConfig`, so the picker preview and the suggestion cannot drift apart. `getStubConfig`'s own output is unchanged.

## Why it is shaped this way

- **It must never throw.** Home Assistant discards the *entire* community suggestion list — including entries contributed by other custom cards — if a single implementation raises. The body is deliberately trivial and total: `hass`, `hass.states` and `entityId` are all treated as untrusted, and anything unexpected returns `null` (never an empty array).
- **One suggestion, unlabelled.** The picker mounts every returned suggestion as a live card with no virtualization, and every live instance of this card fetches calendar events on setup — so each extra labelled variant would fire a real calendar API request every time anyone picks a calendar entity. That cost rules out the variants idea from the issue's open question 1.
- **The domain check is the whole filter.** A calendar entity exposes no capability signal worth testing: no meaningful device class, no relevant `supported_features`, and its state only reports whether an event is currently running — which says nothing about whether this card suits it.
- **`grid_options` is included, at full width.** A sections view otherwise sizes the suggestion by whatever the grid defaults to, which leaves the emitted footprint implicit. This card is a text-heavy list — every row carries a date, a title, a time and often a location. A Home Assistant section caps its own maximum width, so half of one lands around 230-250 px on any screen size, and below that those fields wrap hard: a long address becomes a five-line paragraph under a two-line title. Half width therefore costs horizontal space *and* makes the card taller. `columns: 12` matches what Home Assistant assigns a card that declares no grid options of its own, so this follows the platform default rather than departing from it — it is stated explicitly rather than omitted so the footprint is legible at the call site and a future change to that default cannot silently move the suggestion. The user can still resize it like any other card.
- **`rows` is `'auto'`, not a number.** A numeric `rows` pins the card to a fixed height rather than a minimum — the sections grid applies a `fit-rows` class whenever `rows` is a number, and that class sets `height`, not `min-height`. This card's height is not knowable at suggestion time, because `days_to_show` bounds the range of dates rather than the number of events falling in it. Any fixed height is therefore wrong in one direction or the other: dead whitespace on a quiet calendar, or a clipped list on a busy one. Clipping is the worse failure, since the scroll container hides its scrollbars until hover and gives a touch user no hint that the list continues. `'auto'` is the documented string form that skips the numeric clamp and lets the row size to content. It is kept explicit rather than omitted so the intent survives a change to the grid default.
- **The element name stays the `-dev` literal**, which the `@rollup/plugin-replace` rule rewrites for the production bundle — same mechanism `getStubConfig` already relies on.

## Verification

`npx tsc --noEmit`, `npm run lint` and `npm run build` are all clean. There is no test suite, so the following were checked by hand with a throwaway harness against the real exported functions:

- The emitted config survives the `setConfig()` pipeline (`normalizeEntities` → `normalizeNumericOptions` → `generateDeterministicId` → `hasConfigChanged`) without throwing, and `days_to_show`/`entities` survive normalization intact.
- Walking the emitted config for every `entity`/`entity_id`/`entities` value yields exactly the entity that was passed in — plus a regex sweep of the serialized config for any stray entity id. This catches a hardcoded entity leaking in from copy-paste, which is invisible in review.
- 17 hostile or unsuitable inputs all return `null` rather than throwing: `undefined`/`null` `hass`, `hass` with no `states`, `states` that is `null` or a string, `hass` that is a string or a number, an unknown calendar entity, a non-calendar domain, a `calendarx.` domain lookalike, an empty/`undefined`/`null`/numeric/object entity id, a prototype-key probe (`calendar.constructor`), and a call with no arguments at all.
- Two different picked entities produce independent configs that share no object references.
- Both bundles were built and grepped: `dist/calendar-card-pro.js` contains `custom:calendar-card-pro` and zero occurrences of `custom:calendar-card-pro-dev`; `dist/calendar-card-pro-dev.js` keeps the `-dev` name. `getEntitySuggestion`, `grid_options` and `rows:"auto"` all survive minification in both.

## Compatibility

Purely additive. Older Home Assistant versions ignore unknown keys on the `window.customCards` entry, so this needs no minimum-version bump, no `hacs.json` change and no fallback path.



---

## Verified live in Home Assistant 2026.8.1

Deployed the dev bundle to a running instance (cache-buster `v=246`) and drove the real card picker.

![Card picker showing the Calendar Card Pro suggestion](https://github.com/user-attachments/assets/e6e768ed-b947-4472-ab48-ee93c71b88f5)

Picking `calendar.calendar_card_pro_personal` under **Add card → By entity** produces a **Community** section holding exactly one Calendar Card Pro tile, previewed with real events.

The config that reached the live card, after the card's own `setConfig` merged in its defaults:

```jsonc
{
  "type": "custom:calendar-card-pro-dev",
  "entities": [{ "entity": "calendar.calendar_card_pro_personal" }],
  "days_to_show": 3,
  "show_location": true,
  "grid_options": { "columns": 12, "rows": "auto" }
}
```

### `rows: auto` measured, not assumed

Three cards on a test dashboard, identical configs apart from `grid_options.rows`:

| Card | `rows` | Rendered height |
| --- | --- | --- |
| Suggestion config — 3 days, 1 calendar | `auto` | 398 px |
| 7 days, 3 calendars | `auto` | **1468 px** |
| 7 days, 3 calendars | `4` | **248 px** |

248 px is exactly `4 × (56 + 8) − 8`, the fixed height `hui-grid-section` applies via `fit-rows` for a numeric `rows`. With `rows: 4` that same content would have been clipped to 17 % of its height behind a scrollbar that stays hidden until hovered. `rows: 'auto'` removes the failure mode.

Also confirmed live: guard cases (missing/`null` `hass`, absent `states`, unknown entity, non-calendar domain, empty/non-string entity id) all return `null` rather than throwing; the result is not a Promise; every entity reference in the emitted config equals the entity passed in; and repeated calls do not share mutable state. No console or page errors on the test view.


### `columns: 12` measured, not assumed

Two cards on the same test dashboard, identical configs apart from `grid_options.columns`, measured in a real sections view:

![Full width versus half width, same config](https://github.com/user-attachments/assets/72a26531-4eb0-46f9-9820-300b4bec0b50)

| `columns` | Rendered width | Content height |
| --- | --- | --- |
| `12` | 436 px | **239 px** |
| `6` | 214 px | **473 px** |

Same three events either way. At half width every title wraps to two or three lines and `Children's Hospital Los Angeles, 4650 W Sunset Blvd, Los Angeles, CA 90027, USA` becomes a six-line paragraph, so the card ends up **98 % taller** while also being narrower. Full width is both more readable and more compact, which is why the suggestion ships as `columns: 12`.

(Heights above are the card's own content box. The outer element box is a misleading measure here, because the sections grid stretches a card to match the tallest item in its row.)
