### PR TITLE
fix(docs): Safari favicon + custom domain in wrangler config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -61,8 +61,13 @@ export default defineConfig({
   },
 
   head: [
+    // Favicon order matters. Browsers pick the best-matching <link rel="icon">
+    // and, on a tie, the last one — so SVG-capable browsers take the SVG below.
+    // The ICO must use a plain rel="icon": rel="alternate icon" is not in the
+    // WHATWG spec and Safari (which gained SVG favicon support only in 26.0)
+    // does not reliably fall back to it, leaving older Safari with no icon.
+    ['link', { rel: 'icon', href: '/favicon.ico', sizes: '32x32' }],
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
-    ['link', { rel: 'alternate icon', type: 'image/x-icon', href: '/favicon.ico', sizes: '48x48' }],
     ['link', { rel: 'apple-touch-icon', href: '/apple-touch-icon.png', sizes: '180x180' }],
     ['meta', { name: 'theme-color', content: '#03a9f4' }],
     ['meta', { property: 'og:type', content: 'website' }],

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,16 @@
   "$schema": "https://unpkg.com/wrangler/config-schema.json",
   "name": "calendar-card-pro",
   "compatibility_date": "2026-08-01",
+  // Declaring the custom domain here rather than only in the dashboard keeps the
+  // hostname binding in version control. Cloudflare provisions the DNS record and
+  // TLS certificate itself on deploy; never create a CNAME for this hostname by
+  // hand, as a Custom Domain cannot attach to a name that already has one.
+  "routes": [
+    {
+      "pattern": "calendar-card-pro.alexpfau.com",
+      "custom_domain": true
+    }
+  ],
   "assets": {
     "directory": "./docs/.vitepress/dist",
     "html_handling": "auto-trailing-slash",


### PR DESCRIPTION
Ships two small docs-site fixes to production.

### Safari favicon

The ICO fallback was declared as `rel="alternate icon"`, which is **not in the WHATWG spec** — it was a community workaround that browsers handle inconsistently. Safari only gained SVG favicon support in **26.0**, so on Safari 18.7 and earlier the SVG is unusable and the non-standard `alternate` link is not reliably picked up, leaving no icon at all.

Now uses the standard recipe — plain `rel="icon"` on the ICO, ordered before the SVG. Browsers pick the best match and, on a tie, the last one, so SVG-capable browsers still take the SVG while older Safari falls back to the ICO.

The favicon assets themselves were already correct and correctly served; only the markup was at fault.

### Custom domain as code

Declares `calendar-card-pro.alexpfau.com` in `wrangler.jsonc` via a `routes` entry with `custom_domain: true`, so the binding is version-controlled rather than dashboard-only state. Cloudflare provisions DNS and the certificate automatically on deploy.

---

Both changes verified in a local build: the emitted `<head>` is correct on every generated page, all three favicon assets are present in `dist/`, and no `alternate icon` remains anywhere in the output.
