### PR TITLE
docs: repoint deep links to the documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ If you find **Calendar Card Pro** useful, consider supporting its development:
 
 ## 📖 Documentation
 
-**The full documentation lives at [calendar-card-pro.alexpfau.com](https://calendar-card-pro.alexpfau.com).**
+[![Read the Documentation](https://img.shields.io/badge/%F0%9F%93%96_Read_the_Documentation-calendar--card--pro.alexpfau.com-6a2654?style=for-the-badge&labelColor=3a2a6e)](https://calendar-card-pro.alexpfau.com)
 
-This README covers installation and a quick start. Everything else — every configuration
-option, all features and worked examples — is documented on the site, which is searchable
-and always matches the latest release.
+This README covers installation and a quick start. **Everything else** — every configuration
+option, all features and worked examples — lives on the
+**[documentation site](https://calendar-card-pro.alexpfau.com)**, which is searchable and
+always matches the latest release.
 
 | | |
 | --- | --- |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -529,7 +529,7 @@ weather:
     show_temp: true
 ```
 
-For full parameter documentation including styling options, see our [GitHub README](https://github.com/alexpfau/calendar-card-pro/blob/main/README.md#weather-integration).
+For full parameter documentation including styling options, see the [Weather Integration docs](https://calendar-card-pro.alexpfau.com/features/weather).
 
 </details>
 
@@ -1147,7 +1147,7 @@ Thank you to everyone who contributed bug reports, feature requests, translation
 
 **Calendar filtering and customization, redefined.** This release focuses on giving you precise control over which events appear on your dashboard and how they're displayed, with powerful filtering capabilities and enhanced visual options.
 
-→→→ Please see the [🆕 What's New](#2️⃣-whats-new) section in the README for an overview of v2.2 features with links to their detailed documentation. ←←←
+→→→ Please see the [🆕 What's New](https://calendar-card-pro.alexpfau.com/guide/whats-new) page in the documentation for an overview of v2.2 features with links to their detailed documentation. ←←←
 
 ## 🎉 New Features
 
@@ -1777,8 +1777,8 @@ Available through HACS (recommended) or manual installation:
 
 For complete documentation including configuration options, examples, and customization:
 
-- See the [README](https://github.com/alexpfau/calendar-card-pro/blob/main/README.md) for detailed usage instructions
-- Check out the [Examples](https://github.com/alexpfau/calendar-card-pro/blob/main/README.md#5️⃣-examples) section for configuration samples
+- See the [documentation](https://calendar-card-pro.alexpfau.com/) for detailed usage instructions
+- Check out the [Examples](https://calendar-card-pro.alexpfau.com/reference/examples) section for configuration samples
 
 ## 🙏 Acknowledgements
 

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -10,7 +10,7 @@
  * @version vPLACEHOLDER
  *
  * Project Home: https://github.com/alexpfau/calendar-card-pro
- * Documentation: https://github.com/alexpfau/calendar-card-pro/blob/main/README.md
+ * Documentation: https://calendar-card-pro.alexpfau.com
  *
  * Design inspired by Home Assistant community member @GHA_Steph's button-card calendar design
  * https://community.home-assistant.io/t/calendar-add-on-some-calendar-designs/385790


### PR DESCRIPTION
Follow-up to #383 (README carve-out). Several deep links still pointed at README anchors that no longer exist, and the single most important link on the new landing page was buried in a plain sentence.

## Changes

**`docs/RELEASE_NOTES.md`** — four links repointed to the documentation site:

| Was | Now |
| --- | --- |
| `#weather-integration` | `https://calendar-card-pro.alexpfau.com/features/weather` |
| `#whats-new` | `https://calendar-card-pro.alexpfau.com/guide/whats-new` |
| README root | `https://calendar-card-pro.alexpfau.com/` |
| `#examples` | `https://calendar-card-pro.alexpfau.com/reference/examples` |

Surrounding prose reworded to match ("section in the README" → "page in the documentation").

**`README.md`** — the plain-text `The full documentation lives at ...` sentence is now a badge, using the favicon gradient's own colours so it reads as part of the project's identity rather than a bolt-on:

[![Read the Documentation](https://img.shields.io/badge/%F0%9F%93%96_Read_the_Documentation-calendar--card--pro.alexpfau.com-6a2654?style=for-the-badge&labelColor=3a2a6e)](https://calendar-card-pro.alexpfau.com)

Shields.io badges survive HACS's HTML sanitiser (GitHub alert syntax such as `> [!TIP]` does not, which is why that route was avoided). The existing six-row link table is unchanged.

**`src/calendar-card-pro.ts`** — the `Documentation:` URL in the file header. Source hygiene only: `rollup.config.mjs` runs terser with `format: { comments: false }`, so this comment is stripped and never reaches `dist/calendar-card-pro.js`.

## Verification

- All **19** docs links in the README resolve — page **and** anchor checked against the live site (13 distinct pages fetched).
- The four repointed `RELEASE_NOTES.md` URLs return HTTP 200.
- `npx tsc --noEmit`, `npm run lint`, `npm run build` all pass.

## Not included

Already-published GitHub Releases contain the same stale links and are immutable — no action possible there.
