### PR TITLE
docs: repoint deep links to the documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ If you find **Calendar Card Pro** useful, consider supporting its development:
 
 ## 📖 Documentation
 
-**The full documentation lives at [calendar-card-pro.alexpfau.com](https://calendar-card-pro.alexpfau.com).**
+[![Read the Documentation](https://img.shields.io/badge/%F0%9F%93%96_Read_the_Documentation-calendar--card--pro.alexpfau.com-6a2654?style=for-the-badge&labelColor=3a2a6e)](https://calendar-card-pro.alexpfau.com)
 
-This README covers installation and a quick start. Everything else — every configuration
-option, all features and worked examples — is documented on the site, which is searchable
-and always matches the latest release.
+This README covers installation and a quick start. **Everything else** — every configuration
+option, all features and worked examples — lives on the
+**[documentation site](https://calendar-card-pro.alexpfau.com)**, which is searchable and
+always matches the latest release.
 
 | | |
 | --- | --- |

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -529,7 +529,7 @@ weather:
     show_temp: true
 ```
 
-For full parameter documentation including styling options, see our [GitHub README](https://github.com/alexpfau/calendar-card-pro/blob/main/README.md#weather-integration).
+For full parameter documentation including styling options, see the [Weather Integration docs](https://calendar-card-pro.alexpfau.com/features/weather).
 
 </details>
 
@@ -1147,7 +1147,7 @@ Thank you to everyone who contributed bug reports, feature requests, translation
 
 **Calendar filtering and customization, redefined.** This release focuses on giving you precise control over which events appear on your dashboard and how they're displayed, with powerful filtering capabilities and enhanced visual options.
 
-→→→ Please see the [🆕 What's New](#2️⃣-whats-new) section in the README for an overview of v2.2 features with links to their detailed documentation. ←←←
+→→→ Please see the [🆕 What's New](https://calendar-card-pro.alexpfau.com/guide/whats-new) page in the documentation for an overview of v2.2 features with links to their detailed documentation. ←←←
 
 ## 🎉 New Features
 
@@ -1777,8 +1777,8 @@ Available through HACS (recommended) or manual installation:
 
 For complete documentation including configuration options, examples, and customization:
 
-- See the [README](https://github.com/alexpfau/calendar-card-pro/blob/main/README.md) for detailed usage instructions
-- Check out the [Examples](https://github.com/alexpfau/calendar-card-pro/blob/main/README.md#5️⃣-examples) section for configuration samples
+- See the [documentation](https://calendar-card-pro.alexpfau.com/) for detailed usage instructions
+- Check out the [Examples](https://calendar-card-pro.alexpfau.com/reference/examples) section for configuration samples
 
 ## 🙏 Acknowledgements
 

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -10,7 +10,7 @@
  * @version vPLACEHOLDER
  *
  * Project Home: https://github.com/alexpfau/calendar-card-pro
- * Documentation: https://github.com/alexpfau/calendar-card-pro/blob/main/README.md
+ * Documentation: https://calendar-card-pro.alexpfau.com
  *
  * Design inspired by Home Assistant community member @GHA_Steph's button-card calendar design
  * https://community.home-assistant.io/t/calendar-add-on-some-calendar-designs/385790


### PR DESCRIPTION
Ships #385 to production. Documentation-only; no code changes.

Follow-up to the README carve-out in #383 — several deep links still pointed at README anchors that no longer exist after the manual moved to the documentation site.

- **`docs/RELEASE_NOTES.md`** — four links repointed to `calendar-card-pro.alexpfau.com` (`/features/weather`, `/guide/whats-new`, `/`, `/reference/examples`), with the surrounding prose reworded to match.
- **`README.md`** — the plain-text "full documentation lives at ..." sentence is now a badge in the favicon's own gradient colours, so the landing page's most important link is not buried in prose.
- **`src/calendar-card-pro.ts`** — the `Documentation:` header URL. Source hygiene only; terser strips comments, so it never reaches the bundle.

Merging deploys the updated `RELEASE_NOTES` page to the docs site via Cloudflare Pages.

Verified: 19/19 README docs links resolve (page + anchor, against the live site), four repointed `RELEASE_NOTES` URLs return 200, and `tsc --noEmit` / `lint` / `build` all pass.
