### PR TITLE
docs: document the dev/main sync invariant and fix a stale language count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,39 @@ Because `main` is the default branch, `Fixes #123` in a PR merged to `dev` will 
 auto-close the issue — closing keywords only fire on the default branch. Issues close
 when the release PR merges, or close them manually.
 
+### `dev` must never fall behind `main`
+
+**Invariant: `dev` may be ahead of `main`, never behind it.** `dev` is the branch every
+feature branches from, so the moment it drifts behind, each new feature branch silently
+starts from stale history.
+
+The `dev` → `main` release PR is merged with a **merge commit** (`gh pr merge --merge
+--admin` — see _Release process_), and that merge commit is created **on `main` only**.
+`dev` never receives it, so every release leaves `dev` exactly one commit behind even
+though the file trees are byte-identical. This is why GitHub can show a branch as "merged
+into main" and "N commits behind main" at the same time — the gap is the merge commits
+themselves, not missing content.
+
+So **immediately after merging the release PR, fast-forward `dev` back onto `main`**:
+
+```bash
+git fetch origin
+git merge-base --is-ancestor origin/dev origin/main   # must pass — proves it is lossless
+git push origin origin/main:dev                       # fast-forward, no force, no rewrite
+git rev-list --count origin/dev..origin/main          # expect 0
+```
+
+Skipping this is what produced a four-commit gap across releases v3.5. Never "fix" the
+gap with a force-push; if `--is-ancestor` fails, `dev` has real unique commits and needs
+a normal `main` → `dev` PR instead.
+
+To check the true state of a branch, compare **tree** SHAs rather than trusting the
+GitHub branches page, which caches aggressively and keeps showing deleted branches:
+
+```bash
+git rev-parse origin/dev^{tree} origin/main^{tree}    # identical = no content missing
+```
+
 ## Documenting a change
 
 User-facing documentation lives on the **documentation site**,
@@ -119,9 +152,13 @@ age. Deep-link each bullet to the relevant docs page where one exists.
    substitutes it into the bundle header and into `constants.ts` via `@version
 vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements.
 2. Update `docs/RELEASE_NOTES.md` and the README's `## 4️⃣ What's New` section.
-3. Open a PR from `dev` into `main` and merge it.
-4. Tag `main` with `vX.Y.Z` and push the tag.
-5. `.github/workflows/release.yml` builds and creates a **draft** GitHub release with
+3. Open a PR from `dev` into `main` and merge it. `main`'s ruleset requires an approving
+   review that you cannot give yourself, so this needs `gh pr merge <n> --merge --admin`.
+4. **Fast-forward `dev` back onto `main`** — `git push origin origin/main:dev`. The merge
+   commit from step 3 exists only on `main`; without this, `dev` starts the next cycle a
+   commit behind. See _`dev` must never fall behind `main`_.
+5. Tag `main` with `vX.Y.Z` and push the tag.
+6. `.github/workflows/release.yml` builds and creates a **draft** GitHub release with
    `dist/calendar-card-pro.js` attached. Publish it manually.
 
 `hacs.json` pins the distributed filename to `calendar-card-pro.js` — do not rename it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ src/
 ├── translations/                 # Localization support
 │   ├── dayjs.ts                  # Day.js locale configuration
 │   ├── localize.ts               # Translation functions
-│   └── languages/                # Translation files (33 supported languages)
+│   └── languages/                # Translation files (35 supported languages)
 │       ├── en.json               # English translations
 │       ├── de.json               # German translations
 │       └── ...                   # Other language files


### PR DESCRIPTION
## Why

`dev` had drifted **4 commits behind `main`** with byte-identical file trees. The cause was mechanical, not a mistake in any individual merge:

`gh pr merge --merge` creates the merge commit **on `main` only**. `dev` never receives it, so every `dev` → `main` merge leaves `dev` one commit further behind. Because the *content* is identical, nothing looks broken — which is also why GitHub can show a branch as "merged from dev into main" and "N commits behind main" at the same time. The gap is the merge commits themselves, never missing content.

Four docs-only merges (#380, #382, #384, #386) went through outside the release workflow, so the existing "fast-forward `dev`" step in the release skill was never triggered. `dev` has since been fast-forwarded and is now identical to `main`.

This matters because **every feature branch starts from `dev`** — once it drifts, new work silently branches off stale history.

## What changed

**`AGENTS.md`**
- New _`dev` must never fall behind `main`_ section under _Branch model_ — states the invariant, explains the merge-commit mechanic, gives the fast-forward with its `--is-ancestor` safety assertion, and warns against force-pushing.
- _Release process_ gains an explicit re-sync step between merging and tagging, and now names `--merge --admin` (the `main` ruleset requires a review that cannot be self-granted).
- Documents the tree-SHA check that distinguishes a real content gap from bookkeeping commits — the GitHub branches page caches hard and kept listing an already-deleted branch as "14 ahead, 4 behind".

**`docs/architecture.md`**
- Corrected `33 supported languages` → `35`. The counts are prose, so nothing fails when they drift; this one had been stale for three releases.

## Verification

```
dev vs main after fast-forward:  status: identical  ahead_by: 0  behind_by: 0
tree SHAs:                       1850c4a6… on both
non-merge commits main has:      none
languages on disk:               35 total, 11 with editor translations
```

Docs-only; no source files touched.
