### PR TITLE
fix(config): survive a null entry in the entities list

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -234,7 +234,11 @@ export function normalizeEntities(
           label_icon_color: undefined,
         };
       }
-      if (typeof item === 'object' && item.entity) {
+      // `typeof null === 'object'`, so a bare `-` list item in YAML — which parses
+      // as null — would reach `item.entity` and throw, taking down setConfig and
+      // with it the whole card. The `.filter(Boolean)` below already intends to
+      // drop malformed entries; this guard lets them reach it.
+      if (item && typeof item === 'object' && item.entity) {
         return {
           entity: item.entity,
           label: item.label,


### PR DESCRIPTION
## The bug

A bare `-` list item under `entities:` — which YAML parses as `null` — crashes the card
completely. `setConfig` throws, and Home Assistant replaces the card with a
`hui-error-card` reading **"Configuration error"**.

```yaml
type: custom:calendar-card-pro
entities:
  - calendar.family
  -                      # ← typo, trailing dash, or a commented-out entry
```

The cause is in `normalizeEntities` (`src/config/config.ts`): `typeof null === 'object'`
is `true`, so a `null` item passes the `typeof item === 'object'` check and then throws on
`item.entity`.

The `.filter(Boolean)` three lines below already intends to drop malformed entries — it
just never gets the chance, because the throw happens first. The fix lets them reach it.

## The fix

```diff
-      if (typeof item === 'object' && item.entity) {
+      if (item && typeof item === 'object' && item.entity) {
```

Plus a four-line comment recording *why* the guard is there, so it is not "simplified"
away later.

## Verified live in Home Assistant

Not argued from source — observed in a running instance, two independent ways.

**1. The deployed bundles differ in exactly the expected place.** Read out of each
minified artifact:

| Build | Minified guard |
| --- | --- |
| Production, HACS v3.4.0 | `:"object"==typeof e&&e.entity` |
| Dev, with this fix | `:e&&"object"==typeof e&&e.entity` |

**2. Identical config, side by side on one dashboard**, `entities: [null, calendar.family]`:

| Card | Result |
| --- | --- |
| `calendar-card-pro` (production) | **`hui-error-card` — "Configuration error"**, 246×56 |
| `calendar-card-pro-dev` (this fix) | renders normally, 500×327 |

## Impact

Three bytes in the bundle (`e&&`), measured by reverting the file and rebuilding:
347,940 → 347,943.

## Checks

`tsc --noEmit` clean · `lint` clean · `build` 347,943 bytes · guard confirmed present in
the minified output.
