### PR TITLE
test: add Phase 0 safety net — i18n integrity check, Vitest suite, list-view DOM gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Check i18n integrity
         run: npm run check:i18n
 
+      # The card renders a red error box rather than degrading when setConfig throws,
+      # and the surrounding logic normalizes untyped YAML — so a value that merely
+      # coerces oddly (an editor-cleared field persisting as '', a bare `-` parsing as
+      # null) reaches a comparison and silently suppresses events, days, or the whole
+      # card. Neither tsc nor the build can see past the type boundary at setConfig.
+      # Runs before the build: a failing assertion is faster to read than a bundle.
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      # Adding a language touches four places and three of them fail silently: a missing
+      # top-level key renders as a raw key name, a partially translated `editor` section
+      # defeats the whole-language English fallback, and a missing supportedLocales entry in
+      # dayjs.ts quietly drops relative times back to English. Catalan and Romanian shipped
+      # with that last one for months. Nothing in lint, tsc or the build can see any of it.
+      - name: Check i18n integrity
+        run: npm run check:i18n
+
       - name: Build
         run: npm run build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,19 +9,28 @@ agent-facing summary plus the things that are easy to get wrong.
 Calendar Card Pro is a custom Lovelace card for Home Assistant, written in TypeScript
 with Lit 3 and bundled with Rollup into a single ES module. It is distributed via HACS.
 
-There is **no runtime and no framework beyond Lit** — no React, no test framework, no
-state library. Keep it that way; bundle size is a design constraint.
+There is **no runtime framework beyond Lit** — no React, no state library. Keep it that
+way; bundle size is a design constraint.
+
+That constraint is about **shipped bytes**, so it governs `dependencies`, not
+`devDependencies`. Build, docs and test tooling that never reaches `dist/` is not covered
+by it. Adding one still needs a reason, but "bundle size" is not the argument against it —
+measure the bundle instead. The Vitest suite below was added this way and moved the
+production bundle by 3 bytes, all of which were a bug fix.
 
 ## Build commands
 
-There are only four npm scripts for the card itself. Do not invent others.
+These are the npm scripts. Do not invent others — add one only when a command is run often
+enough that people will otherwise get it wrong.
 
-| Command          | Output                          | Element name            | Logging |
-| ---------------- | ------------------------------- | ----------------------- | ------- |
-| `npm run dev`    | `dist/calendar-card-pro-dev.js` | `calendar-card-pro-dev` | verbose |
-| `npm run build`  | `dist/calendar-card-pro.js`     | `calendar-card-pro`     | silent  |
-| `npm run lint`   | — (eslint, `--fix`)             |                         |         |
-| `npm run format` | — (prettier, `--write`)         |                         |         |
+| Command              | Output                          | Element name            | Logging |
+| -------------------- | ------------------------------- | ----------------------- | ------- |
+| `npm run dev`        | `dist/calendar-card-pro-dev.js` | `calendar-card-pro-dev` | verbose |
+| `npm run build`      | `dist/calendar-card-pro.js`     | `calendar-card-pro`     | silent  |
+| `npm run lint`       | — (eslint, `--fix`)             |                         |         |
+| `npm run format`     | — (prettier, `--write`)         |                         |         |
+| `npm test`           | — (vitest, single run)          |                         |         |
+| `npm run check:i18n` | — (translation wiring check)    |                         |         |
 
 Three further scripts build the documentation site (see _Documenting a change_):
 `docs:dev` (dev server), `docs:build` (static build into `docs/.vitepress/dist/`, the
@@ -37,13 +46,25 @@ testing — they need the `-dev` one.
 `npm run dev` runs `rollup -c --watch` and does not exit. For a one-shot dev build in
 automation, use `npx rollup -c` (same config, no watcher).
 
-There is **no test suite**. Validate changes with:
+There **is** a test suite — Vitest with happy-dom, in `tests/`. It does not aim at coverage;
+it pins the things that have actually broken (the translation wiring, config normalization)
+and the rendered list-view DOM, so a refactor that changes output fails loudly. Validate
+changes with:
 
 ```bash
 npx tsc --noEmit   # typecheck — not exposed as an npm script
 npm run lint
+npm test
+npm run check:i18n
 npm run build
 ```
+
+Two things to know before trusting it. `tests/list-dom.test.ts` snapshots serialized DOM, so
+an intentional markup change means **reading** the snapshot diff and committing it, not
+deleting the file. And the suite is built from **default config**, which means an option
+defaulting to `false` renders nothing and is invisible to it unless a test sets it — four
+branches were missed that way, including two the suite existed to protect. When you add a
+config option, add a test that turns it on.
 
 `node_modules` is absent in a fresh worktree; run `npm ci` first. `dist/` is gitignored.
 
@@ -203,6 +224,10 @@ Omitting the `supportedLocales` entry (3b) is a **silent failure**: the language
 everywhere except relative times, which quietly fall back to English. Catalan and
 Romanian shipped broken this way for months. If you add a locale import, add the array
 entry in the same edit.
+
+`npm run check:i18n` now catches all four wiring mistakes mechanically, including that one,
+and runs in CI. Run it before you claim a language is done — but note it verifies **wiring**,
+not translation quality, and it cannot tell you whether `pēc 2 dienām` is correct Latvian.
 
 Regional variants usually need no `dayjs.ts` change at all, because `mapLocale()`
 reduces them to their base code (`en-gb` → `en`). Only `zh-cn` / `zh-tw` are

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,10 @@ const compat = new FlatCompat();
 
 export default [
   {
-    files: ['src/**/*.ts'],
+    // Tests are linted with the same rules as src. They are devDependency-only and
+    // never enter the bundle (rollup follows the import graph from src/calendar-card-pro.ts),
+    // but they import from src, so they benefit from the same type-aware checks.
+    files: ['src/**/*.ts', 'tests/**/*.ts'],
     languageOptions: {
       parser: tsParser,
       parserOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,11 +32,13 @@
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.5.5",
+        "happy-dom": "^20.11.1",
         "prettier": "^3.8.1",
         "rollup": "^4.60.0",
         "rollup-plugin-esbuild": "^6.2.1",
         "typescript": "^5.9.3",
-        "vitepress": "^1.6.4"
+        "vitepress": "^1.6.4",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -1206,6 +1208,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha1-C0vXhB7z3SZ6aRhLl0UswLMT+1I=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -1218,6 +1230,269 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+      "integrity": "sha1-t9I11Fs4yE8miSrIBLtPF0OKu/4=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha1-kCHbIkFV8VpBq2mDMu2zADEY/c0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha1-f521YY0M5GP5sLuu7qSNGzC7lpw=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha1-X7uSUp+43XP+bJITqaC54f2LiuE=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha1-qDaq36OOp3i9xVCO79UDb1u/gFI=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha1-x321wkOoHYJBteTvapmoLIrPmkA=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha1-BuzpiHLrPFsSln+qjgfvKwPgLQY=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+      "integrity": "sha1-tvVbzIOFIID4R47F2g6IsuP5ptE=",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+      "integrity": "sha1-f6QW0sN69lTyi0MuJOW+lIO4nxk=",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha1-mu+mfnIkz9RGQ3OppPU4HNGcrjs=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha1-jNcWCutbS6wz/Orz1+DGegx4yh0=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+      "integrity": "sha1-DDkaCKOaCXlK+XPuznghbIDhRPY=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha1-aJUmXiRhZO0ugWLLqRwMP8K/NoQ=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha1-Nd7ZIEMvp7FoFukELTZ5z9GxKYo=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "29.0.2",
@@ -1831,6 +2106,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha1-p5tV26+GBIEvUtFAssmrQbwVC7g=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1841,6 +2123,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha1-jpzZ4cNYH6azQaWu1ViOsoW+C0o=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha1-M0MRlx06BxIefrkbaEpgXn7qnL0=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1944,6 +2244,23 @@
       "integrity": "sha1-UlQzx4Su2bRXqqDuPZKutx80a2M=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha1-5eBtzT6S1OYi7wEpY3cH1mwo1qQ=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha1-SEZOS/Ld/RfbE9hFRn9gcP/qSqk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
@@ -2714,6 +3031,92 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha1-eZwG/ES7DPfieEE3tifFzBcyhdQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha1-dVQucnOgjMEP1Nja1OPrHxbNlYw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha1-/r8KIakWhCFCLRlVNw5gb+q2A1U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha1-fj6f7H1NRyMuSTz9y9IXDeQ3HAQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha1-XAv6l7Vrup43QDyXbbd2/2q1b2U=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha1-/8cQVfGL/Msf0FhjZevCgkiS5AM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.40",
       "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
@@ -3174,6 +3577,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha1-9kGhlrM1aQsQcL8AtudZP+wZC/c=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3234,6 +3647,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha1-NX6Bc+lRztO1onhcaVmTqinbysQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -3304,6 +3730,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha1-rkG1LJrKh3NFBTYnF/MlX6zaNg4=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3394,6 +3830,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true,
       "license": "MIT"
     },
@@ -3592,6 +4035,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/devlop": {
@@ -4265,6 +4718,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha1-JO338MxppE0AhWe6RZSrlvPDo9Y=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4568,6 +5031,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha1-EbTrv8hZX06jbFYhe0/6/MOtl1M=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -5278,6 +5760,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha1-wIhn1xp5OFxuGQIU/XL+8+X5Xws=",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha1-mmhB+IrlD8g1ApA4krQa9BvCuQc=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha1-wPLDHAv9GfpN0/GOlXofGhUgl9Y=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha1-ywcFllrLU4xmg5Sc5pJfs833w2E=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha1-djU4gosmurJoDa2vzITueLDrUCs=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha1-aGLjF2ozGu297B7TUrTX0N0HhN4=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha1-xqOi7RUUHa9r3CYokw+OOb30c6o=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha1-f6EzSXH8goRfmCffbvigsgkUusY=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha1-i5J4YuqMK7xoMaRlCSRLUNmTblU=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha1-DFJbsHff2UQEwFnP5C2teX6Wrq8=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha1-hQ7hED2smJz6tQ46wi0aaeOU5j0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha1-40OuFS7tNgncbhGUnRo785oclG8=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lit": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
@@ -5658,6 +6413,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha1-kJDYpUilIlF5FdKqaq6QcZesbPg=",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",
       "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
@@ -5800,9 +6569,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6048,6 +6817,39 @@
       "integrity": "sha1-d492xPtzHZNBTo+SX77PZMzn9so=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rolldown/-/rolldown-1.2.2.tgz",
+      "integrity": "sha1-8oB2cWk2vO2gXg0FWVAqXOsKbp4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.2",
+        "@rolldown/binding-darwin-arm64": "1.2.2",
+        "@rolldown/binding-darwin-x64": "1.2.2",
+        "@rolldown/binding-freebsd-x64": "1.2.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
+        "@rolldown/binding-linux-arm64-musl": "1.2.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-musl": "1.2.2",
+        "@rolldown/binding-openharmony-arm64": "1.2.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
+        "@rolldown/binding-win32-x64-msvc": "1.2.2"
+      }
     },
     "node_modules/rollup": {
       "version": "4.60.0",
@@ -6365,6 +7167,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha1-MudscLeXJOO7Vny51UPrhYzPrzA=",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/smob": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
@@ -6433,6 +7242,20 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha1-Gsig2Ug4SNFpXkGLbQMaPDzmjjs=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha1-jr4OxgSFZoq0ciezEvQlTN+AydM=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6626,21 +7449,48 @@
         "node": ">=10"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha1-EDyfi6bXI3pHq23R3P93JRhjQms=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha1-qswdux1Ok+atjdZJROCfmtFHpHQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha1-wBaDh9PY1wtrPCwJNt5f7nOM6iA=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -7514,6 +8364,218 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha1-fpKF7+JksRZwULejp/80eI4bevw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha1-JBOYerTNf6HCthS0BMQHv2rR6tE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha1-W/LfBpmdu+XwBqX0ahH7n1t7ORs=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha1-Z8PlSexAKkh7T8GT0ZU6UkdSNA0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha1-kC/NPcAxL1U8hbbLxGJdysotjfg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.40",
       "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vue/-/vue-3.5.40.tgz",
@@ -7534,6 +8596,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha1-X6GnYjhn/xr2yj3HKta4pCCL66c=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -7641,6 +8713,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha1-o/aalxB/SUs83Dvd3Yg6fWXOvwQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7649,6 +8738,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha1-BFZQzUsSB4CedUcUYiPDgUqa9YY=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "dev": "rollup -c --watch",
     "build": "cross-env NODE_ENV=prod rollup -c",
-    "lint": "eslint 'src/**/*.ts' --fix --format stylish",
-    "format": "prettier --write 'src/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'tests/**/*.ts' --fix --format stylish",
+    "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "check:i18n": "node scripts/check-i18n.mjs",
+    "test": "vitest run",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"
@@ -50,11 +51,13 @@
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
+    "happy-dom": "^20.11.1",
     "prettier": "^3.8.1",
     "rollup": "^4.60.0",
     "rollup-plugin-esbuild": "^6.2.1",
     "typescript": "^5.9.3",
-    "vitepress": "^1.6.4"
+    "vitepress": "^1.6.4",
+    "vitest": "^4.1.10"
   },
   "dependencies": {
     "@material/web": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "cross-env NODE_ENV=prod rollup -c",
     "lint": "eslint 'src/**/*.ts' --fix --format stylish",
     "format": "prettier --write 'src/**/*.ts'",
+    "check:i18n": "node scripts/check-i18n.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -1,0 +1,478 @@
+#!/usr/bin/env node
+/**
+ * i18n integrity check for Calendar Card Pro.
+ *
+ * Adding a language touches four places, and three of the four fail *silently*:
+ *
+ *   1. src/translations/languages/<code>.json  — missing keys render as raw key names
+ *   2. src/translations/localize.ts            — import + a LOWERCASE TRANSLATIONS key
+ *   3. src/translations/dayjs.ts               — a locale import AND a supportedLocales entry
+ *   4. README.md                               — prose, not checked here
+ *
+ * Omitting 3b is the worst of them: everything works except relative times, which quietly
+ * fall back to English. Catalan and Romanian shipped that way for months. Nothing in the
+ * build, the type checker or the linter can see any of it, because every one of these is a
+ * runtime lookup with a fallback.
+ *
+ * This script has no dependencies and is not part of the bundle. Run it with:
+ *
+ *   node scripts/check-i18n.mjs            # errors are fatal, warnings are advisory
+ *   node scripts/check-i18n.mjs --strict   # warnings are fatal too
+ *
+ * Design note: the wiring in localize.ts and dayjs.ts is read out of the TypeScript source
+ * with regexes rather than by importing it, so the check stays dependency-free and needs no
+ * build step. That is only safe because every extraction below fails *loudly* when it cannot
+ * find what it expects — see assertFound(). A regex that silently matched nothing would
+ * report a clean run over an empty set, which is the one outcome worse than a false alarm.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const LANG_DIR = join(ROOT, 'src/translations/languages');
+const LOCALIZE_TS = join(ROOT, 'src/translations/localize.ts');
+const DAYJS_TS = join(ROOT, 'src/translations/dayjs.ts');
+const EDITOR_TS = join(ROOT, 'src/rendering/editor.ts');
+const REFERENCE_LANG = 'en.json';
+
+const STRICT = process.argv.includes('--strict');
+const IN_CI = Boolean(process.env.GITHUB_ACTIONS);
+
+const errors = [];
+const warnings = [];
+const error = (where, msg) => errors.push({ where, msg });
+const warn = (where, msg) => warnings.push({ where, msg });
+
+const read = (path) => readFileSync(path, 'utf-8');
+
+/**
+ * Guard against a stale regex silently matching nothing.
+ *
+ * Every extraction in this file goes through here. If the source is refactored such that a
+ * pattern no longer matches, the script says so and exits non-zero instead of reporting a
+ * clean run over an empty set.
+ */
+function assertFound(value, what, file) {
+  const empty = value === null || value === undefined || value.length === 0;
+  if (empty) {
+    console.error(
+      `\n  FATAL: could not find ${what} in ${basename(file)}.\n` +
+        `  The file was probably refactored and scripts/check-i18n.mjs needs updating.\n` +
+        `  Refusing to report a passing run over an empty set.\n`,
+    );
+    process.exit(2);
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+/** Language JSON files on disk, keyed by the lowercased code (en-GB.json -> 'en-gb'). */
+function readLanguageFiles() {
+  const files = readdirSync(LANG_DIR).filter((f) => f.endsWith('.json'));
+  assertFound(files, 'any language JSON files', LANG_DIR);
+
+  const out = new Map();
+  for (const file of files.sort()) {
+    let data;
+    try {
+      data = JSON.parse(read(join(LANG_DIR, file)));
+    } catch (err) {
+      error(file, `is not valid JSON: ${err.message}`);
+      continue;
+    }
+    out.set(basename(file, '.json').toLowerCase(), { file, data });
+  }
+  return out;
+}
+
+/** `import xTranslations from './languages/<file>.json'` plus the TRANSLATIONS map body. */
+function readLocalizeWiring() {
+  const src = read(LOCALIZE_TS);
+
+  const imports = new Map(); // identifier -> filename
+  for (const m of src.matchAll(/import\s+(\w+)\s+from\s+'\.\/languages\/([^']+\.json)'/g)) {
+    imports.set(m[1], m[2]);
+  }
+  assertFound([...imports.keys()], 'language JSON imports', LOCALIZE_TS);
+
+  const block = src.match(/export const TRANSLATIONS[^=]*=\s*\{([\s\S]*?)\n\};/);
+  assertFound(block, 'the TRANSLATIONS map', LOCALIZE_TS);
+
+  const entries = new Map(); // map key (as written) -> identifier
+  for (const m of block[1].matchAll(/^\s*'?([A-Za-z][A-Za-z-]*)'?\s*:\s*(\w+)\s*,/gm)) {
+    entries.set(m[1], m[2]);
+  }
+  assertFound([...entries.keys()], 'entries in the TRANSLATIONS map', LOCALIZE_TS);
+
+  return { imports, entries };
+}
+
+/** dayjs locale imports, the supportedLocales array, and mapLocale's special cases. */
+function readDayjsWiring() {
+  const src = read(DAYJS_TS);
+
+  const imports = new Set([...src.matchAll(/import\s+'dayjs\/locale\/([^']+)'/g)].map((m) => m[1]));
+  assertFound([...imports], 'dayjs locale imports', DAYJS_TS);
+
+  const block = src.match(/const supportedLocales\s*=\s*\[([\s\S]*?)\];/);
+  assertFound(block, 'the supportedLocales array', DAYJS_TS);
+
+  const supported = new Set([...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1]));
+  assertFound([...supported], 'entries in supportedLocales', DAYJS_TS);
+
+  // mapLocale() special-cases locales that keep their region (zh-cn, zh-tw). Read them from
+  // the source rather than hardcoding, so this script tracks mapLocale instead of drifting
+  // into a second, stale source of truth.
+  const fn = src.match(/function mapLocale\([\s\S]*?\n\}/);
+  assertFound(fn, 'the mapLocale function', DAYJS_TS);
+  const specialCased = new Set(
+    [...fn[0].matchAll(/lowerLocale\s*===\s*'([^']+)'/g)].map((m) => m[1]),
+  );
+  assertFound([...specialCased], "mapLocale's special-cased locales", DAYJS_TS);
+
+  return { imports, supported, specialCased };
+}
+
+/** Replicates mapLocale() from dayjs.ts: keep special cases whole, else take the base code. */
+function mapLocale(locale, specialCased) {
+  const lower = locale.toLowerCase();
+  return specialCased.has(lower) ? lower : lower.split('-')[0];
+}
+
+/**
+ * Editor translation keys referenced as string literals: `this._getTranslation('foo')` and
+ * `this._getTranslation('editor.foo')`, normalised to the bare key.
+ *
+ * Seven call sites pass a variable instead (`_getTranslation(name)` in the addXField helpers,
+ * where `name` is the config key). Those are unresolvable statically, so the config keys
+ * passed to those helpers are collected separately below and treated as reachable.
+ */
+function readEditorKeyUsage() {
+  const src = read(EDITOR_TS);
+
+  const literal = new Set(
+    [...src.matchAll(/_getTranslation\('([^']+)'/g)].map((m) => m[1].replace(/^editor\./, '')),
+  );
+  assertFound([...literal], '_getTranslation() calls', EDITOR_TS);
+
+  // First argument of the addXField helpers — the config key, which those helpers fall back
+  // to as a translation key when no explicit label is given.
+  const viaFieldName = new Set(
+    [...src.matchAll(/\bthis\.add[A-Za-z]*Field\(\s*'([^']+)'/g)].map((m) => m[1]),
+  );
+
+  return { literal, viaFieldName };
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Every language file must carry every top-level key in en.json, with matching value shapes.
+ *
+ * `editor` is the documented exception and is checked separately: it is all-or-nothing.
+ */
+function checkLanguageParity(languages) {
+  const reference = languages.get('en');
+  if (!reference) {
+    error(
+      REFERENCE_LANG,
+      'is missing — it is the reference every other language is checked against',
+    );
+    return;
+  }
+
+  const refKeys = Object.keys(reference.data).filter((k) => k !== 'editor');
+  const refEditorKeys = Object.keys(reference.data.editor ?? {});
+
+  if (refEditorKeys.length === 0) {
+    error(REFERENCE_LANG, 'has no `editor` section; it is the reference for all editor keys');
+  }
+
+  for (const [code, { file, data }] of languages) {
+    if (code === 'en') continue;
+
+    for (const key of refKeys) {
+      if (!(key in data)) {
+        error(file, `missing top-level key \`${key}\``);
+        continue;
+      }
+      const expected = reference.data[key];
+      const actual = data[key];
+
+      if (Array.isArray(expected)) {
+        if (!Array.isArray(actual)) {
+          error(file, `\`${key}\` must be an array, got ${typeof actual}`);
+        } else if (actual.length !== expected.length) {
+          // A short array is an out-of-range read at runtime, e.g. months[11] === undefined.
+          error(
+            file,
+            `\`${key}\` has ${actual.length} entries, expected ${expected.length} — ` +
+              `indexes past the end render as "undefined"`,
+          );
+        } else if (actual.some((v) => typeof v !== 'string' || v.trim() === '')) {
+          error(file, `\`${key}\` contains an empty or non-string entry`);
+        }
+      } else if (typeof actual !== 'string') {
+        error(
+          file,
+          `\`${key}\` must be a string, got ${Array.isArray(actual) ? 'array' : typeof actual}`,
+        );
+      } else if (actual.trim() === '') {
+        error(
+          file,
+          `\`${key}\` is empty — it will render as a blank string, not fall back to English`,
+        );
+      }
+    }
+
+    for (const key of Object.keys(data)) {
+      if (key !== 'editor' && !(key in reference.data)) {
+        warn(
+          file,
+          `has top-level key \`${key}\` which does not exist in ${REFERENCE_LANG} (typo, or dead key?)`,
+        );
+      }
+    }
+
+    checkEditorSection(file, data, refEditorKeys);
+  }
+}
+
+/**
+ * The `editor` section is all-or-nothing.
+ *
+ * hasEditorTranslations() returns true when the section has one *or more* keys, and
+ * _getTranslation() uses it to decide whether to swap the whole language to English. So a
+ * partially translated section defeats that fallback: the keys present render fine, and every
+ * key missing renders as its own raw name (`show_end_time`) in the UI. Omitting the section
+ * entirely is fully supported and correct — 24 of the language files do exactly that.
+ */
+function checkEditorSection(file, data, refEditorKeys) {
+  const editor = data.editor;
+  if (editor === undefined) return; // Supported: the whole language falls back to English.
+
+  if (typeof editor !== 'object' || editor === null || Array.isArray(editor)) {
+    error(file, '`editor` must be an object');
+    return;
+  }
+
+  const present = Object.keys(editor);
+  const missing = refEditorKeys.filter((k) => !(k in editor));
+
+  if (missing.length > 0) {
+    error(
+      file,
+      `\`editor\` is partially translated: ${missing.length} of ${refEditorKeys.length} keys ` +
+        `missing (${missing.slice(0, 5).join(', ')}${missing.length > 5 ? ', …' : ''}). ` +
+        `A partial section defeats the English fallback — each missing key renders as its own ` +
+        `raw key name. Either translate all ${refEditorKeys.length} or remove \`editor\` entirely.`,
+    );
+  }
+
+  const extra = present.filter((k) => !refEditorKeys.includes(k));
+  if (extra.length > 0) {
+    warn(
+      file,
+      `\`editor\` has ${extra.length} key(s) not in ${REFERENCE_LANG}: ` +
+        `${extra.slice(0, 5).join(', ')}${extra.length > 5 ? ', …' : ''}`,
+    );
+  }
+
+  const blank = present.filter((k) => typeof editor[k] !== 'string' || editor[k].trim() === '');
+  if (blank.length > 0) {
+    error(file, `\`editor\` has empty or non-string value(s): ${blank.slice(0, 5).join(', ')}`);
+  }
+}
+
+/** Every language file must be imported and registered under a lowercase key, and vice versa. */
+function checkLocalizeWiring(languages, { imports, entries }) {
+  const importedFiles = new Set([...imports.values()].map((f) => f.toLowerCase()));
+
+  for (const [code, { file }] of languages) {
+    if (!importedFiles.has(file.toLowerCase())) {
+      error('localize.ts', `${file} exists but is never imported — the language is unreachable`);
+      continue;
+    }
+    if (!entries.has(code)) {
+      const wrongCase = [...entries.keys()].find((k) => k.toLowerCase() === code);
+      if (wrongCase) {
+        // getEffectiveLanguage/getTranslations lowercase the requested code before lookup,
+        // so a non-lowercase map key can never match.
+        error(
+          'localize.ts',
+          `TRANSLATIONS key '${wrongCase}' must be lowercase ('${code}') — lookups lowercase ` +
+            `the requested language, so this entry can never be found`,
+        );
+      } else {
+        error(
+          'localize.ts',
+          `${file} is imported but has no TRANSLATIONS entry — the language is unreachable`,
+        );
+      }
+    }
+  }
+
+  for (const [key, identifier] of entries) {
+    if (key !== key.toLowerCase()) {
+      error(
+        'localize.ts',
+        `TRANSLATIONS key '${key}' must be lowercase — lookups lowercase the requested language`,
+      );
+    }
+    const file = imports.get(identifier);
+    if (!file) {
+      error(
+        'localize.ts',
+        `TRANSLATIONS entry '${key}' refers to '${identifier}', which is not imported`,
+      );
+      continue;
+    }
+    const expected = basename(file, '.json').toLowerCase();
+    if (key.toLowerCase() !== expected) {
+      error(
+        'localize.ts',
+        `TRANSLATIONS key '${key}' is wired to ${file} — expected key '${expected}'`,
+      );
+    }
+  }
+}
+
+/**
+ * Every registered language must resolve to a dayjs locale that is both imported and listed
+ * in supportedLocales. Missing either one is silent: relative times fall back to English while
+ * everything else keeps working.
+ */
+function checkDayjsWiring(entries, { imports, supported, specialCased }) {
+  for (const code of entries.keys()) {
+    const mapped = mapLocale(code, specialCased);
+
+    if (!imports.has(mapped)) {
+      error(
+        'dayjs.ts',
+        `'${code}' maps to dayjs locale '${mapped}', which is not imported — ` +
+          `dayjs will fall back to English relative times`,
+      );
+    }
+    if (!supported.has(mapped)) {
+      error(
+        'dayjs.ts',
+        `'${code}' maps to dayjs locale '${mapped}', which is missing from supportedLocales — ` +
+          `mapLocale() returns 'en' and relative times silently fall back to English`,
+      );
+    }
+  }
+
+  // The two lists must agree with each other, independently of the translations.
+  for (const locale of imports) {
+    if (!supported.has(locale)) {
+      error(
+        'dayjs.ts',
+        `'${locale}' is imported but missing from supportedLocales — the import is dead weight`,
+      );
+    }
+  }
+  for (const locale of supported) {
+    if (!imports.has(locale)) {
+      error(
+        'dayjs.ts',
+        `'${locale}' is in supportedLocales but never imported — dayjs cannot load it`,
+      );
+    }
+  }
+
+  // Bundle hygiene: every dayjs locale is bytes in a single-file bundle.
+  const needed = new Set([...entries.keys()].map((c) => mapLocale(c, specialCased)));
+  for (const locale of imports) {
+    if (!needed.has(locale)) {
+      warn('dayjs.ts', `dayjs locale '${locale}' is imported but no translation maps to it`);
+    }
+  }
+}
+
+/** Editor keys referenced in code must exist in en.json, or they render as their own name. */
+function checkEditorKeyUsage(languages) {
+  const reference = languages.get('en');
+  if (!reference?.data?.editor) return;
+
+  const defined = new Set(Object.keys(reference.data.editor));
+  const { literal, viaFieldName } = readEditorKeyUsage();
+
+  for (const key of literal) {
+    if (!defined.has(key)) {
+      error(
+        'editor.ts',
+        `_getTranslation('${key}') has no matching key in ${REFERENCE_LANG} — it will render ` +
+          `as the literal string "${key}"`,
+      );
+    }
+  }
+
+  const reachable = new Set([...literal, ...viaFieldName]);
+  const unused = [...defined].filter((k) => !reachable.has(k));
+  if (unused.length > 0) {
+    warn(
+      REFERENCE_LANG,
+      `${unused.length} editor key(s) are never referenced: ` +
+        `${unused.slice(0, 8).join(', ')}${unused.length > 8 ? ', …' : ''} ` +
+        `(each one is dead weight in every language file that translates \`editor\`)`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+function report(languageCount, editorCount) {
+  const line = (kind, { where, msg }) => {
+    if (IN_CI) console.log(`::${kind === 'error' ? 'error' : 'warning'}::${where}: ${msg}`);
+    else console.log(`  ${kind === 'error' ? '✖' : '⚠'} ${where}: ${msg}`);
+  };
+
+  if (errors.length > 0) {
+    console.log(`\n${errors.length} error(s):`);
+    errors.forEach((e) => line('error', e));
+  }
+  if (warnings.length > 0) {
+    console.log(`\n${warnings.length} warning(s):`);
+    warnings.forEach((w) => line('warn', w));
+  }
+
+  const summary =
+    `\n${languageCount} languages, ${editorCount} with editor translations — ` +
+    `${errors.length} error(s), ${warnings.length} warning(s).`;
+  console.log(summary);
+
+  if (errors.length > 0) return 1;
+  if (STRICT && warnings.length > 0) {
+    console.log('Failing because --strict was passed.');
+    return 1;
+  }
+  console.log('i18n wiring is consistent.');
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+
+function main() {
+  const languages = readLanguageFiles();
+  const localize = readLocalizeWiring();
+  const dayjsWiring = readDayjsWiring();
+
+  checkLanguageParity(languages);
+  checkLocalizeWiring(languages, localize);
+  checkDayjsWiring(localize.entries, dayjsWiring);
+  checkEditorKeyUsage(languages);
+
+  const editorCount = [...languages.values()].filter((l) => l.data.editor !== undefined).length;
+  process.exit(report(languages.size, editorCount));
+}
+
+main();

--- a/tests/__snapshots__/list-dom.test.ts.snap
+++ b/tests/__snapshots__/list-dom.test.ts.snap
@@ -1,5 +1,187 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`list view DOM > renders a custom today indicator position 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="today-indicator-container">
+<ha-icon icon="mdi:star" class="today-indicator mdi" style="position:absolute;transform:translate(-50%, -50%);left:85%;top:15%;">
+</ha-icon>
+</div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
 exports[`list view DOM > renders a single event 1`] = `
 "<table class=" day-table today ">
 <tr>
@@ -144,6 +326,191 @@ exports[`list view DOM > renders compact mode 1`] = `
 <ha-icon icon="mdi:clock-outline"></ha-icon>
 <span>2:00 PM - 3:00 PM</span>
 </div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders countdown and progress bar 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+<div class="progress-bar">
+<div class="progress-bar-filled" style="width: 33%"></div>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+<div class="time-countdown">in 4 hours</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+<div class="time-countdown">in 6 hours</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+<div class="time-countdown">in a day</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+<div class="time-countdown">in 2 days</div>
 </div>
 </div>
 </div>
@@ -995,6 +1362,188 @@ exports[`list view DOM > renders the default configuration 1`] = `
 <div class="month" style="font-size:12px;color:var(--primary-text-color);">
             Jun
           </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders the today indicator 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="today-indicator-container">
+<ha-icon icon="mdi:circle" class="today-indicator dot" style="position:absolute;transform:translate(-50%, -50%);left:15%;top:50%;">
+</ha-icon>
+</div>
 </td>
 <td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
 <div class="event-content">

--- a/tests/__snapshots__/list-dom.test.ts.snap
+++ b/tests/__snapshots__/list-dom.test.ts.snap
@@ -1,0 +1,1351 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`list view DOM > renders a single event 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders an empty calendar 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders compact mode 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="3">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders empty days when show_empty_days is on 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders in a non-English language 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Mi
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>Ganztägig</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Do
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>Ganztägig, bis 19. Jun</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fr
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders location and end time when enabled 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders past events when show_past_events is on 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="5">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle past-event " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Past standup
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>8:00 AM - 9:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders split multi-day events 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders the default configuration 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders week numbers and separators when enabled 1`] = `
+"<table class="week-row-table" style="margin-top:0px;margin-bottom:5px;">
+<tr>
+<td class="week-number-cell">
+<div class="week-number">25</div>
+</td>
+<td class="separator-cell" style="--separator-display:none;">
+<div class="separator-line"></div>
+</td>
+</tr>
+</table>
+<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<div class="separator" style="border-top-width:1px;border-top-color:var(--secondary-text-color);border-top-style:solid;margin-top:0px;margin-bottom:10px;"></div>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<div class="separator" style="border-top-width:1px;border-top-color:var(--secondary-text-color);border-top-style:solid;margin-top:0px;margin-bottom:10px;"></div>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;

--- a/tests/__snapshots__/list-dom.test.ts.snap
+++ b/tests/__snapshots__/list-dom.test.ts.snap
@@ -1160,6 +1160,627 @@ exports[`list view DOM > renders the default configuration 1`] = `
 </table>"
 `;
 
+exports[`list view DOM > renders weather in both positions with the opt-in fields on 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather" style="font-size: 12px; color: var(--primary-text-color);">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span class="weather-temp-high">24°</span>
+<span class="weather-temp-low">/13°</span>
+</div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            24°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            17°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            24°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            23°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather" style="font-size: 12px; color: var(--primary-text-color);">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span class="weather-temp-high">21°</span>
+<span class="weather-temp-low">/12°</span>
+</div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            21°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather" style="font-size: 12px; color: var(--primary-text-color);">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span class="weather-temp-high">17°</span>
+<span class="weather-temp-low">/11°</span>
+</div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            16°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders weather on events 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            24°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            17°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            24°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            23°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            21°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            16°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > renders weather on the date column 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather" style="font-size: 12px; color: var(--primary-text-color);">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span class="weather-temp-high">24°</span>
+</div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather" style="font-size: 12px; color: var(--primary-text-color);">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span class="weather-temp-high">21°</span>
+</div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather" style="font-size: 12px; color: var(--primary-text-color);">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span class="weather-temp-high">17°</span>
+</div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
 exports[`list view DOM > renders week numbers and separators when enabled 1`] = `
 "<table class="week-row-table" style="margin-top:0px;margin-bottom:5px;">
 <tr>
@@ -1335,6 +1956,235 @@ exports[`list view DOM > renders week numbers and separators when enabled 1`] = 
         </span>
 </div>
 <!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>"
+`;
+
+exports[`list view DOM > suppresses the low temp when a UV index is shown 1`] = `
+"<table class=" day-table today ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="4">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather" style="font-size: 12px; color: var(--primary-text-color);">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span class="weather-temp-high">24°</span>
+<span class="weather-uv-index">UV7</span>
+</div>
+</td>
+<td class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            24°
+          </span>
+<span class="weather-uv-index" style="font-size: 12px; color: var(--secondary-text-color);">
+            UV7
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            17°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            24°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+<tr>
+<td class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            23°
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table tomorrow future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather" style="font-size: 12px; color: var(--primary-text-color);">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span class="weather-temp-high">21°</span>
+<span class="weather-uv-index">UV4</span>
+</div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            21°
+          </span>
+<span class="weather-uv-index" style="font-size: 12px; color: var(--secondary-text-color);">
+            UV4
+          </span>
+</div>
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</td>
+</tr>
+</table>
+<table class=" day-table future-day ">
+<tr>
+<td style="position: relative;" class="date-column " rowspan="1">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather" style="font-size: 12px; color: var(--primary-text-color);">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span class="weather-temp-high">17°</span>
+<span class="weather-uv-index">UV2</span>
+</div>
+</td>
+<td class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<div class="event-weather">
+<ha-icon style="--mdc-icon-size: 14px;"></ha-icon>
+<span style="font-size: 12px; color: var(--secondary-text-color);">
+            16°
+          </span>
+</div>
 </div>
 <div class="time-location">
 <div class="time">

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_CONFIG,
+  hasConfigChanged,
+  normalizeEntities,
+  normalizeNumericOptions,
+  toValidNumber,
+} from '../src/config/config';
+import type * as Types from '../src/config/types';
+
+/**
+ * Config normalization and change detection.
+ *
+ * These are the guards behind issue #327: the visual editor persists an empty
+ * string when a numeric field is cleared, and hand-written YAML can supply `null`
+ * or free text. Such values pass the `!== undefined` checks used throughout the
+ * card, then coerce to `0` in numeric comparisons and silently suppress events or
+ * whole days. The failure is invisible — the card renders successfully, just
+ * empty — so it is exactly the class of bug that needs a test rather than a soak.
+ */
+
+describe('toValidNumber', () => {
+  it('accepts plain numbers at or above the minimum', () => {
+    expect(toValidNumber(5)).toBe(5);
+    expect(toValidNumber(0)).toBe(0);
+    expect(toValidNumber(1, 1)).toBe(1);
+  });
+
+  it('parses numeric strings, which is what the editor persists', () => {
+    expect(toValidNumber('7')).toBe(7);
+    expect(toValidNumber(' 7 ')).toBe(7);
+    expect(toValidNumber('0.5')).toBe(0.5);
+  });
+
+  // The #327 inputs. Each of these coerces to 0 under `Number()` or passes a
+  // `!== undefined` guard, which is how they reached the comparison in the first place.
+  it.each([
+    ['empty string (editor clears a field)', ''],
+    ['whitespace only', '   '],
+    ['null (hand-written YAML)', null],
+    ['undefined', undefined],
+    ['non-numeric text', 'seven'],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['boolean', true],
+    ['object', {}],
+    ['array', []],
+  ])('rejects %s', (_label, value) => {
+    expect(toValidNumber(value)).toBeUndefined();
+  });
+
+  it('rejects values below the minimum rather than clamping them', () => {
+    // Clamping would silently change the user's intent; `undefined` lets the caller
+    // decide between "fall back to default" and "no limit", which differ per key.
+    expect(toValidNumber(0, 1)).toBeUndefined();
+    expect(toValidNumber(-1, 0)).toBeUndefined();
+    expect(toValidNumber('-3', 0)).toBeUndefined();
+  });
+});
+
+describe('normalizeNumericOptions', () => {
+  it('restores defaults for required values so the range can never collapse to zero', () => {
+    const config = {
+      days_to_show: '',
+      refresh_interval: null,
+      event_background_opacity: 'abc',
+    } as unknown as Types.Config;
+
+    normalizeNumericOptions(config);
+
+    expect(config.days_to_show).toBe(DEFAULT_CONFIG.days_to_show);
+    expect(config.refresh_interval).toBe(DEFAULT_CONFIG.refresh_interval);
+    expect(config.event_background_opacity).toBe(DEFAULT_CONFIG.event_background_opacity);
+  });
+
+  it('clears optional limits instead of collapsing them to zero', () => {
+    // `undefined` means "no limit" for these two. Falling back to `0` would hide
+    // all content, which is the opposite of the user's intent when they clear a field.
+    const config = {
+      compact_days_to_show: '',
+      compact_events_to_show: 'nonsense',
+    } as unknown as Types.Config;
+
+    normalizeNumericOptions(config);
+
+    expect(config.compact_days_to_show).toBeUndefined();
+    expect(config.compact_events_to_show).toBeUndefined();
+  });
+
+  it('preserves compact_events_to_show: 0, which is a valid configuration', () => {
+    // 0 means "show nothing until tapped". It must survive normalization, and is
+    // why the minimum for this key is 0 while compact_days_to_show uses 1.
+    const config = { compact_events_to_show: 0 } as unknown as Types.Config;
+    normalizeNumericOptions(config);
+    expect(config.compact_events_to_show).toBe(0);
+  });
+
+  it('rejects compact_days_to_show: 0, which would render nothing at all', () => {
+    const config = { compact_days_to_show: 0 } as unknown as Types.Config;
+    normalizeNumericOptions(config);
+    expect(config.compact_days_to_show).toBeUndefined();
+  });
+
+  it('leaves valid values untouched', () => {
+    const config = {
+      days_to_show: 5,
+      refresh_interval: 60,
+      event_background_opacity: 20,
+      compact_days_to_show: 2,
+      compact_events_to_show: 3,
+    } as unknown as Types.Config;
+
+    normalizeNumericOptions(config);
+
+    expect(config).toMatchObject({
+      days_to_show: 5,
+      refresh_interval: 60,
+      event_background_opacity: 20,
+      compact_days_to_show: 2,
+      compact_events_to_show: 3,
+    });
+  });
+});
+
+describe('normalizeEntities', () => {
+  it('expands bare entity id strings into objects', () => {
+    expect(normalizeEntities(['calendar.personal'])).toEqual([
+      {
+        entity: 'calendar.personal',
+        color: undefined,
+        accent_color: undefined,
+        label_icon_color: undefined,
+      },
+    ]);
+  });
+
+  it('drops malformed entries rather than emitting entity: undefined', () => {
+    const result = normalizeEntities([
+      'calendar.good',
+      { color: 'red' },
+      null,
+      42,
+    ] as unknown as Parameters<typeof normalizeEntities>[0]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].entity).toBe('calendar.good');
+  });
+
+  it('survives a null entry, which a bare "-" in YAML produces', () => {
+    // `typeof null === 'object'`, so this used to throw inside setConfig and take
+    // the whole card down with a red error box rather than dropping the entry.
+    expect(() =>
+      normalizeEntities([null, undefined] as unknown as Parameters<typeof normalizeEntities>[0]),
+    ).not.toThrow();
+
+    expect(
+      normalizeEntities([null, undefined] as unknown as Parameters<typeof normalizeEntities>[0]),
+    ).toEqual([]);
+  });
+
+  it('returns an empty array for a non-array input', () => {
+    expect(normalizeEntities(undefined as unknown as [])).toEqual([]);
+    expect(normalizeEntities({} as unknown as [])).toEqual([]);
+  });
+
+  it('applies the same numeric guard to per-entity compact caps', () => {
+    // Per-entity limits go through toValidNumber too — the #327 class is not
+    // limited to top-level keys.
+    const result = normalizeEntities([
+      { entity: 'calendar.a', compact_events_to_show: '' },
+      { entity: 'calendar.b', compact_events_to_show: 2 },
+      { entity: 'calendar.c', compact_events_to_show: 0 },
+    ] as unknown as Parameters<typeof normalizeEntities>[0]);
+
+    expect(result[0].compact_events_to_show).toBeUndefined();
+    expect(result[1].compact_events_to_show).toBe(2);
+    expect(result[2].compact_events_to_show).toBe(0);
+  });
+
+  it('normalizes empty colour strings to undefined so defaults apply', () => {
+    const result = normalizeEntities([
+      { entity: 'calendar.a', color: '', accent_color: '', label_icon_color: '' },
+    ]);
+
+    expect(result[0].color).toBeUndefined();
+    expect(result[0].accent_color).toBeUndefined();
+    expect(result[0].label_icon_color).toBeUndefined();
+  });
+
+  it('preserves per-entity boolean overrides, including explicit false', () => {
+    // `false` must survive: it is a deliberate override, not an absent value.
+    const result = normalizeEntities([
+      {
+        entity: 'calendar.a',
+        show_time: false,
+        show_location: false,
+        split_multiday_events: false,
+      },
+    ]);
+
+    expect(result[0].show_time).toBe(false);
+    expect(result[0].show_location).toBe(false);
+    expect(result[0].split_multiday_events).toBe(false);
+  });
+});
+
+describe('hasConfigChanged', () => {
+  const base = {
+    entities: ['calendar.personal'],
+    days_to_show: 3,
+    refresh_interval: 30,
+  } as unknown as Types.Config;
+
+  it('treats a missing or empty previous config as changed', () => {
+    expect(hasConfigChanged(undefined, base)).toBe(true);
+    expect(hasConfigChanged({}, base)).toBe(true);
+  });
+
+  it('reports no change for an identical config', () => {
+    expect(hasConfigChanged({ ...base }, base)).toBe(false);
+  });
+
+  it.each([
+    ['days_to_show', { days_to_show: 7 }],
+    ['start_date', { start_date: '2026-01-01' }],
+    ['show_past_events', { show_past_events: true }],
+    ['filter_duplicates', { filter_duplicates: true }],
+    ['refresh_interval', { refresh_interval: 60 }],
+    ['entities', { entities: ['calendar.other'] }],
+  ])('detects a change to %s', (_label, patch) => {
+    expect(hasConfigChanged(base, { ...base, ...patch } as Types.Config)).toBe(true);
+  });
+
+  it('ignores entity reordering, which does not change the data fetched', () => {
+    const previous = { ...base, entities: ['calendar.a', 'calendar.b'] } as Types.Config;
+    const current = { ...base, entities: ['calendar.b', 'calendar.a'] } as Types.Config;
+    expect(hasConfigChanged(previous, current)).toBe(false);
+  });
+
+  it('ignores styling-only entity changes, which need a re-render but not a refetch', () => {
+    // This is the point of the function: colour edits must not trigger an API call.
+    const previous = { ...base, entities: ['calendar.a'] } as Types.Config;
+    const current = {
+      ...base,
+      entities: [{ entity: 'calendar.a', color: 'red' }],
+    } as unknown as Types.Config;
+
+    expect(hasConfigChanged(previous, current)).toBe(false);
+  });
+});

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the test environment itself.
+ *
+ * Every assertion this suite will ever make about a rendered date, a day boundary,
+ * an all-day event or a relative time depends on the process running in a known
+ * timezone. `vitest.config.mjs` pins it via `test.env.TZ`, which works because
+ * Vitest sets the variable before a worker's first `Date` use — but that is a
+ * behaviour of the runner, not a guarantee of the language, and it would break
+ * silently: the suite would keep passing on a maintainer's machine and start
+ * disagreeing with CI, or agree with CI while both asserted the wrong day.
+ *
+ * A day boundary is the specific hazard. The card groups events into days, so a
+ * one-hour host offset can move an event across midnight and change which column
+ * it belongs to — a failure that looks like a grouping bug rather than a
+ * configuration one, and that costs far more to diagnose than this file costs to
+ * keep.
+ */
+describe('test environment', () => {
+  it('runs in UTC, so date assertions do not depend on the host timezone', () => {
+    expect(new Date('2026-06-15T12:00:00Z').getTimezoneOffset()).toBe(0);
+  });
+
+  it('reports UTC through Intl, which is what dayjs and toLocaleString resolve against', () => {
+    expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe('UTC');
+  });
+
+  it('provides a DOM, which Lit requires to render', () => {
+    // happy-dom, configured in vitest.config.mjs. Pure-logic tests do not need this,
+    // but the Stage 2 render tests will, and a missing DOM surfaces there as a
+    // confusing "document is not defined" rather than as a setup problem.
+    expect(typeof document).toBe('object');
+    expect(typeof customElements).toBe('object');
+  });
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,116 @@
+import * as Config from '../src/config/config';
+import type * as Types from '../src/config/types';
+
+/**
+ * Fixtures and helpers for the list-view DOM equality gate (`tests/list-dom.test.ts`).
+ *
+ * Kept separate from the test so that Phase 1's shared leaf renderers, and later the
+ * column view, can reuse exactly the same event data. The whole point of the gate is
+ * that both views are fed identical input; that only holds if the input has one home.
+ */
+
+/**
+ * The instant every list-DOM test runs at.
+ *
+ * The list render is time-dependent — it decides today, weekend and past-event state
+ * from the clock — so the same fixture serialized on two different days produces two
+ * different DOMs. `vi.setSystemTime(FROZEN_NOW)` holds it still.
+ *
+ * Chosen deliberately:
+ * - **Wednesday**, so "today" is mid-week and neither weekend nor week boundary
+ *   styling is silently exercised as the default case.
+ * - **Mid-month (17th)**, so it is not a month boundary either. Both boundaries have
+ *   their own separators; a frozen instant sitting on one would make that separator
+ *   permanently on and its absence permanently untested.
+ * - **10:00 UTC**, leaving room either side within the same day for events that are
+ *   already past and events still upcoming, without either crossing midnight.
+ *
+ * Paired with `TZ=UTC` from `vitest.config.mjs`: an instant alone does not determine
+ * which local day it falls in, so both are required for a stable result.
+ */
+export const FROZEN_NOW = new Date('2026-06-17T10:00:00.000Z');
+
+/**
+ * Builds a config the same way `setConfig` does, so fixtures exercise the real
+ * normalization path rather than a hand-assembled object that happens to look right.
+ *
+ * Mirrors `calendar-card-pro.ts` `setConfig`: merge over defaults, then normalize
+ * entities and numeric options in that order.
+ */
+export function buildConfig(overrides: Partial<Types.Config> = {}): Types.Config {
+  const config: Types.Config = {
+    ...Config.DEFAULT_CONFIG,
+    entities: ['calendar.personal'],
+    ...overrides,
+  };
+  config.entities = Config.normalizeEntities(config.entities);
+  Config.normalizeNumericOptions(config);
+  return config;
+}
+
+/** A timed event on a given date, expressed in UTC to match the pinned zone. */
+function timed(
+  date: string,
+  startHour: string,
+  endHour: string,
+  summary: string,
+  extra: Partial<Types.CalendarEventData> = {},
+): Types.CalendarEventData {
+  return {
+    start: { dateTime: `${date}T${startHour}:00.000Z` },
+    end: { dateTime: `${date}T${endHour}:00.000Z` },
+    summary,
+    _entityId: 'calendar.personal',
+    ...extra,
+  };
+}
+
+/** An all-day event. All-day events use `date`, not `dateTime` — that is the branch. */
+function allDay(
+  startDate: string,
+  endDate: string,
+  summary: string,
+  extra: Partial<Types.CalendarEventData> = {},
+): Types.CalendarEventData {
+  return {
+    start: { date: startDate },
+    end: { date: endDate },
+    summary,
+    _entityId: 'calendar.personal',
+    ...extra,
+  };
+}
+
+/**
+ * The gate's event set.
+ *
+ * Enumerated rather than described, because "the soak fixtures" named no file and a
+ * gate that does not say what it covers will pass while missing the branches most
+ * likely to regress. Each entry below exists to hold one render branch open:
+ *
+ * | Fixture              | Branch it pins                                    |
+ * | -------------------- | ------------------------------------------------- |
+ * | `pastEarlier`        | past-event styling (before FROZEN_NOW, same day)  |
+ * | `currentlyRunning`   | an event straddling "now"                          |
+ * | `upcomingLater`      | ordinary future event on today                     |
+ * | `withLocation`       | the location row, which is separately toggleable   |
+ * | `allDaySingle`       | all-day rendering (no time shown)                  |
+ * | `multiDay`           | an event spanning day boundaries — the rowspan path |
+ * | `tomorrowOnly`       | a day whose events are all future                  |
+ */
+export const EVENTS: Types.CalendarEventData[] = [
+  timed('2026-06-17', '08:00', '09:00', 'Past standup'),
+  timed('2026-06-17', '09:30', '11:00', 'Currently running review'),
+  timed('2026-06-17', '14:00', '15:00', 'Upcoming one-to-one'),
+  timed('2026-06-17', '16:00', '17:00', 'Dentist', { location: '12 High Street' }),
+  allDay('2026-06-17', '2026-06-18', 'Public holiday'),
+  allDay('2026-06-18', '2026-06-20', 'Conference'),
+  timed('2026-06-19', '10:00', '10:30', 'Delivery window'),
+];
+
+/**
+ * A single timed event, for tests that need a minimal render rather than the full set.
+ */
+export const SINGLE_EVENT: Types.CalendarEventData[] = [
+  timed('2026-06-17', '14:00', '15:00', 'Upcoming one-to-one'),
+];

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -114,3 +114,68 @@ export const EVENTS: Types.CalendarEventData[] = [
 export const SINGLE_EVENT: Types.CalendarEventData[] = [
   timed('2026-06-17', '14:00', '15:00', 'Upcoming one-to-one'),
 ];
+
+/**
+ * Weather forecasts covering the fixture dates.
+ *
+ * Included because Phase 1's **first** extraction is weather (`render.ts:526-575`), and
+ * a gate that passes no forecasts leaves that step unprotected — `weatherForecasts` is
+ * optional, so every weather branch short-circuits to `nothing` and the snapshots would
+ * agree perfectly with a broken extraction.
+ *
+ * Two independent render sites, both pinned:
+ * - **daily** → the date column, via `findDailyForecast`, keyed `YYYY-MM-DD`.
+ * - **hourly** → individual events, via `findForecastForEvent`, keyed `YYYY-MM-DD_H`
+ *   with a **non-padded** hour, and looked up by the event's *local* start hour.
+ *
+ * `templow` and `uv_index` are populated because `show_low_temp` and `show_uv_index`
+ * are opt-in and mutually exclusive at the render site (`show_low_temp` is suppressed
+ * when a UV index shows). Absent data would make those branches untestable rather than
+ * merely off.
+ */
+export const WEATHER: Types.WeatherForecasts = {
+  daily: {
+    '2026-06-17': {
+      icon: 'mdi:weather-sunny',
+      condition: 'sunny',
+      temperature: 24,
+      templow: 13,
+      uv_index: 7,
+      datetime: '2026-06-17T12:00:00.000Z',
+    },
+    '2026-06-18': {
+      icon: 'mdi:weather-partly-cloudy',
+      condition: 'partlycloudy',
+      temperature: 21,
+      templow: 12,
+      uv_index: 4,
+      datetime: '2026-06-18T12:00:00.000Z',
+    },
+    '2026-06-19': {
+      icon: 'mdi:weather-rainy',
+      condition: 'rainy',
+      temperature: 17,
+      templow: 11,
+      uv_index: 2,
+      datetime: '2026-06-19T12:00:00.000Z',
+    },
+  },
+  hourly: {
+    '2026-06-17_8': hour('2026-06-17T08:00:00.000Z', 'mdi:weather-fog', 'fog', 14, 8),
+    '2026-06-17_9': hour('2026-06-17T09:00:00.000Z', 'mdi:weather-cloudy', 'cloudy', 17, 9),
+    '2026-06-17_14': hour('2026-06-17T14:00:00.000Z', 'mdi:weather-sunny', 'sunny', 24, 14),
+    '2026-06-17_16': hour('2026-06-17T16:00:00.000Z', 'mdi:weather-sunny', 'sunny', 23, 16),
+    '2026-06-19_10': hour('2026-06-19T10:00:00.000Z', 'mdi:weather-rainy', 'rainy', 16, 10),
+  },
+};
+
+/** An hourly forecast entry. Kept terse — only the fields the render site reads. */
+function hour(
+  datetime: string,
+  icon: string,
+  condition: string,
+  temperature: number,
+  h: number,
+): Types.WeatherData {
+  return { icon, condition, temperature, datetime, hour: h, precipitation_probability: 20 };
+}

--- a/tests/list-dom.test.ts
+++ b/tests/list-dom.test.ts
@@ -1,0 +1,163 @@
+import { render as litRender } from 'lit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EVENTS, FROZEN_NOW, SINGLE_EVENT, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as Render from '../src/rendering/render';
+import * as EventUtils from '../src/utils/events';
+
+/**
+ * Phase 0 Stage 2 — the list-view DOM equality gate.
+ *
+ * Phase 1 extracts the list's leaf renderers into shared functions so the column view
+ * can reuse them. The list's own DOM is supposed to come out **byte-identical**; that
+ * is the entire safety argument for calling Phase 1 low-risk. This file is what makes
+ * that claim checkable instead of asserted.
+ *
+ * ## What is rendered, and into what
+ *
+ * The pipeline under test is `groupEventsByDay` → `renderGroupedEvents` → Lit, which is
+ * exactly what `calendar-card-pro.ts` `render()` does for the populated case. The card
+ * element itself is deliberately **not** constructed. Doing so would require a fake
+ * `hass`, a mocked `callApi` (`events.ts:1167`), and awaiting an async fetch — none of
+ * which this gate is about, and all of which could fail for reasons unrelated to the
+ * DOM. Rendering the pure functions directly isolates the surface Phase 1 changes.
+ *
+ * The two functions kept together on purpose: grouping decides day boundaries,
+ * ordering and which events survive, and rendering turns that into the table. A change
+ * to either shows up here, which is what "the list DOM must not change" means.
+ *
+ * ## Clock
+ *
+ * `render.ts` reads the current date to decide today, weekend and past-event state
+ * (`events.ts` calls `new Date()` in eight places), so the same fixture serialized on
+ * two different days produces two different DOMs. Fake timers freeze `Date.now()` and
+ * the `new Date()` constructor globally, which covers dayjs too since dayjs has no
+ * independent clock. This needs **zero production changes** — no `now` parameter
+ * threaded through the very functions Phase 1 is extracting.
+ *
+ * ## Baselines and the update path
+ *
+ * Snapshots are committed under `tests/__snapshots__/`. A change to list DOM therefore
+ * appears in the PR diff as a snapshot change a reviewer has to look at, which is the
+ * point — an intended change is approved by reviewing that diff and re-running with
+ * `npx vitest run -u`. A gate with no sanctioned update path gets deleted the first
+ * time the DOM legitimately changes; this one has one, and it is loud.
+ */
+
+/**
+ * Lit leaves three kinds of comment marker in the DOM. Verified by inspecting real
+ * output rather than assumed, because stripping a marker that never appears is dead
+ * code that reads like a guarantee:
+ *
+ * - `<!--?lit$095926250$-->` — carries a **per-render random id**. Left in, every
+ *   snapshot would differ from every other run. This strip is what makes the gate
+ *   possible at all.
+ * - `<!---->` — an empty marker; no information, removed for readability.
+ * - `<!--?-->` — deterministic, and marks where a conditional branch sits.
+ *   Deliberately **kept**: it is stable across runs, and its presence or absence is
+ *   real signal about which branch rendered.
+ *
+ * Whitespace between tags is collapsed onto separate lines so a diff points at the
+ * element that changed rather than at one enormous line.
+ */
+function serialize(container: HTMLElement): string {
+  return container.innerHTML
+    .replace(/<!--\?lit\$[0-9]+\$-->/g, '')
+    .replace(/<!---->/g, '')
+    .replace(/>\s+</g, '>\n<')
+    .trim();
+}
+
+/** Runs the real pipeline and returns normalized markup. */
+function renderList(
+  events: Types.CalendarEventData[],
+  config: Types.Config,
+  { isExpanded = false, language = 'en' } = {},
+): string {
+  const days = EventUtils.groupEventsByDay(events, config, isExpanded, language);
+  const container = document.createElement('div');
+  litRender(Render.renderGroupedEvents(days, config, language), container);
+  return serialize(container);
+}
+
+describe('list view DOM', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('freezes the clock, so these snapshots are reproducible on any day', () => {
+    // Guards the mechanism the rest of the file depends on. Without this, a broken
+    // freeze surfaces as every snapshot failing at once with no stated cause.
+    expect(new Date().toISOString()).toBe('2026-06-17T10:00:00.000Z');
+  });
+
+  it('renders the default configuration', () => {
+    expect(renderList(EVENTS, buildConfig())).toMatchSnapshot();
+  });
+
+  it('renders a single event', () => {
+    expect(renderList(SINGLE_EVENT, buildConfig())).toMatchSnapshot();
+  });
+
+  it('renders an empty calendar', () => {
+    expect(renderList([], buildConfig())).toMatchSnapshot();
+  });
+
+  it('renders empty days when show_empty_days is on', () => {
+    // A distinct render branch: placeholder events carry `_isEmptyDay` and are
+    // rendered differently from real ones.
+    expect(renderList(SINGLE_EVENT, buildConfig({ show_empty_days: true }))).toMatchSnapshot();
+  });
+
+  it('renders past events when show_past_events is on', () => {
+    // Off by default, so without this the past-event branch is never serialized and
+    // the `Past standup` fixture would be silently filtered before reaching the DOM.
+    expect(renderList(EVENTS, buildConfig({ show_past_events: true }))).toMatchSnapshot();
+  });
+
+  it('renders week numbers and separators when enabled', () => {
+    expect(
+      renderList(
+        EVENTS,
+        buildConfig({
+          days_to_show: 10,
+          show_week_numbers: 'iso',
+          week_separator_width: '1px',
+          day_separator_width: '1px',
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('renders split multi-day events', () => {
+    // `split_multiday_events` changes how the Conference fixture is decomposed across
+    // days, which is one of the paths Phase 1's shared renderers must preserve.
+    expect(renderList(EVENTS, buildConfig({ split_multiday_events: true }))).toMatchSnapshot();
+  });
+
+  it('renders compact mode', () => {
+    expect(
+      renderList(EVENTS, buildConfig({ compact_days_to_show: 2, compact_events_to_show: 3 })),
+    ).toMatchSnapshot();
+  });
+
+  it('renders location and end time when enabled', () => {
+    expect(
+      renderList(EVENTS, buildConfig({ show_location: true, show_end_time: true })),
+    ).toMatchSnapshot();
+  });
+
+  it('renders in a non-English language', () => {
+    // Weekday and month names come from the translation layer, so this pins the join
+    // between rendering and i18n that `check-i18n.mjs` cannot see.
+    expect(
+      renderList(EVENTS, buildConfig({ language: 'de' }), { language: 'de' }),
+    ).toMatchSnapshot();
+  });
+});

--- a/tests/list-dom.test.ts
+++ b/tests/list-dom.test.ts
@@ -1,7 +1,7 @@
 import { render as litRender } from 'lit';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { EVENTS, FROZEN_NOW, SINGLE_EVENT, buildConfig } from './fixtures';
+import { EVENTS, FROZEN_NOW, SINGLE_EVENT, WEATHER, buildConfig } from './fixtures';
 import type * as Types from '../src/config/types';
 import * as Render from '../src/rendering/render';
 import * as EventUtils from '../src/utils/events';
@@ -70,14 +70,20 @@ function serialize(container: HTMLElement): string {
 }
 
 /** Runs the real pipeline and returns normalized markup. */
+interface RenderOpts {
+  isExpanded?: boolean;
+  language?: string;
+  weather?: Types.WeatherForecasts;
+}
+
 function renderList(
   events: Types.CalendarEventData[],
   config: Types.Config,
-  { isExpanded = false, language = 'en' } = {},
+  { isExpanded = false, language = 'en', weather }: RenderOpts = {},
 ): string {
   const days = EventUtils.groupEventsByDay(events, config, isExpanded, language);
   const container = document.createElement('div');
-  litRender(Render.renderGroupedEvents(days, config, language), container);
+  litRender(Render.renderGroupedEvents(days, config, language, weather), container);
   return serialize(container);
 }
 
@@ -159,5 +165,75 @@ describe('list view DOM', () => {
     expect(
       renderList(EVENTS, buildConfig({ language: 'de' }), { language: 'de' }),
     ).toMatchSnapshot();
+  });
+
+  // Weather is pinned in its own block because Phase 1 extracts it FIRST, and because it
+  // is the one part of the render that stays inert unless forecasts are supplied — the
+  // rest of this file would pass unchanged against a completely broken weather renderer.
+
+  it('renders weather on the date column', () => {
+    // `position: 'date'` drives `findDailyForecast` inside `renderDateColumn`
+    // (`render.ts:526-575`) — the exact block Phase 1 lifts out first.
+    expect(
+      renderList(EVENTS, buildConfig({ weather: { entity: 'weather.home', position: 'date' } }), {
+        weather: WEATHER,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('renders weather on events', () => {
+    // A separate render site (`renderEventWeather`, `render.ts:1050+`) reading the
+    // hourly forecast. Pinned separately so an extraction that fixes one and breaks the
+    // other cannot pass.
+    expect(
+      renderList(EVENTS, buildConfig({ weather: { entity: 'weather.home', position: 'event' } }), {
+        weather: WEATHER,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('renders weather in both positions with the opt-in fields on', () => {
+    // `show_low_temp` is opt-in and off by default, so without this snapshot the low
+    // temp branch would be extracted with no baseline at all. `position: 'both'` also
+    // pins that the two render sites coexist.
+    expect(
+      renderList(
+        EVENTS,
+        buildConfig({
+          weather: {
+            entity: 'weather.home',
+            position: 'both',
+            date: { show_low_temp: true, show_high_temp: true, show_conditions: true },
+            event: { show_conditions: true, show_high_temp: true },
+          },
+        }),
+        { weather: WEATHER },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('suppresses the low temp when a UV index is shown', () => {
+    // `showLowTemp` is `show_low_temp === true && !showUvIndex && templow !== undefined`
+    // (`render.ts:545-546`) — an interaction between two independent flags, which is
+    // exactly the kind of condition an extraction silently drops. Both flags are on
+    // here, so the snapshot must contain `weather-uv-index` and must NOT contain
+    // `weather-temp-low`; the assertions below state that outright rather than trusting
+    // a reader to notice an absence in 1300 lines of snapshot.
+    const out = renderList(
+      EVENTS,
+      buildConfig({
+        weather: {
+          entity: 'weather.home',
+          position: 'both',
+          date: { show_low_temp: true, show_uv_index: true },
+          event: { show_uv_index: true },
+        },
+      }),
+      { weather: WEATHER },
+    );
+
+    expect(out).toContain('weather-uv-index');
+    expect(out).not.toContain('weather-temp-low');
+    expect(out).toMatchSnapshot();
   });
 });

--- a/tests/list-dom.test.ts
+++ b/tests/list-dom.test.ts
@@ -236,4 +236,55 @@ describe('list view DOM', () => {
     expect(out).not.toContain('weather-temp-low');
     expect(out).toMatchSnapshot();
   });
+
+  // The remaining branches below are all **off by default**, which is exactly why they need
+  // naming: a snapshot suite built from default config renders none of them, and would go on
+  // passing while the code behind them was extracted incorrectly or lost entirely. The weather
+  // gap was the first instance of this; these are the rest of it.
+
+  it('renders the today indicator', () => {
+    // `today_indicator` defaults to `false`, so `renderTodayIndicator` returns `nothing` in
+    // every other test — and `parseIndicatorPosition` (`render.ts:358-382`) is only reachable
+    // through it. That function is one of Phase 1's four **named** extraction targets, so
+    // without this case the gate would have been silent on a quarter of the work it exists to
+    // protect. Asserted directly as well as snapshotted, so "renders nothing" cannot pass.
+    const out = renderList(EVENTS, buildConfig({ today_indicator: 'dot' }));
+
+    expect(out).toContain('today-indicator-container');
+    expect(out).toMatchSnapshot();
+  });
+
+  it('renders a custom today indicator position', () => {
+    // `parseIndicatorPosition` turns a CSS-like `"x y"` string into inline styles (documented
+    // in README.md:841-843; default `'15% 50%'`). Pinning a non-default position is what
+    // distinguishes "the function ran" from "the function ran and its output reached the DOM".
+    const out = renderList(
+      EVENTS,
+      buildConfig({ today_indicator: 'mdi:star', today_indicator_position: '85% 15%' }),
+    );
+
+    expect(out).toContain('today-indicator-container');
+    expect(out).toContain('left:85%');
+    expect(out).toContain('top:15%');
+    expect(out).toMatchSnapshot();
+  });
+
+  it('renders countdown and progress bar', () => {
+    // Both default to `false`. The progress bar additionally requires a *running* event, which
+    // is why the fixture set contains one straddling `FROZEN_NOW` — without it this config
+    // would render no bar and the snapshot would look like coverage while providing none.
+    // Both branches live in the `.event-content` subtree, Phase 1's third extraction target.
+    //
+    // Note for whoever extracts this: `show_progress_bar` is checked **twice** — once at
+    // `render.ts:902` when computing `progressPercentage`, and again at `:954`/`:973` when
+    // rendering. Either guard alone is dead code, because the first already forces
+    // `progressPercentage` to `null`. Mutation-testing confirmed this: removing either one
+    // in isolation changes no output at all, while removing both fails 13 of these 18 tests.
+    // The redundancy is harmless, but it means a Phase 1 extraction that keeps only one of
+    // the two guards is still correct — don't treat dropping one as a regression.
+    const out = renderList(EVENTS, buildConfig({ show_countdown: true, show_progress_bar: true }));
+
+    expect(out).toContain('progress-bar');
+    expect(out).toMatchSnapshot();
+  });
 });

--- a/tests/translations.test.ts
+++ b/tests/translations.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRelativeTimeString } from '../src/translations/dayjs';
+import en from '../src/translations/languages/en.json';
+import {
+  TRANSLATIONS,
+  getEffectiveLanguage,
+  getTranslations,
+  hasEditorTranslations,
+} from '../src/translations/localize';
+
+/**
+ * Translation resolution, exercised through the public functions.
+ *
+ * This deliberately does not duplicate `scripts/check-i18n.mjs`. That script is a
+ * static check on the four-place wiring — it reads the files on disk and compares
+ * keys, so it owns "a language file exists but was never imported or registered".
+ * This suite asserts the *runtime behaviour* those files produce, which is the part
+ * a static check cannot see:
+ *
+ *   - that a registered language actually resolves to its own translations rather
+ *     than falling through to English,
+ *   - that the editor's whole-language English fallback works as AGENTS.md describes,
+ *   - and that relative times are localized, which is the silent failure mode that
+ *     shipped broken in Catalan and Romanian for months because the language works
+ *     everywhere *except* here.
+ *
+ * The last one is why this file exists. A missing `supportedLocales` entry produces
+ * English relative times with no error raised anywhere.
+ *
+ * The corpus is derived from the exported TRANSLATIONS map rather than from a
+ * directory glob, both because that is the surface the card actually resolves
+ * against and because it keeps this file free of Vite-only syntax, so plain `tsc`
+ * can typecheck it alongside src.
+ */
+
+const LANGUAGES = Object.keys(TRANSLATIONS);
+
+describe('language registry', () => {
+  it('registers every shipped language', () => {
+    // Guards the corpus itself. If TRANSLATIONS were gutted, every loop below
+    // would pass while asserting almost nothing.
+    expect(LANGUAGES.length).toBeGreaterThanOrEqual(30);
+    expect(LANGUAGES).toContain('en');
+  });
+
+  it('uses only lowercase keys, because lookups lowercase before matching', () => {
+    // A non-lowercase key can never match, so the language silently renders English.
+    const nonLowercase = LANGUAGES.filter((language) => language !== language.toLowerCase());
+    expect(nonLowercase, 'these keys can never be matched').toEqual([]);
+  });
+});
+
+describe('getEffectiveLanguage', () => {
+  it('resolves an explicitly configured language', () => {
+    expect(getEffectiveLanguage('de')).toBe('de');
+    expect(getEffectiveLanguage('fr')).toBe('fr');
+  });
+
+  it('is case-insensitive, because the map keys are lowercase', () => {
+    // `TRANSLATIONS` keys must be lowercase or lookups can never match. A user
+    // writing `language: DE` in YAML should still get German.
+    expect(getEffectiveLanguage('DE')).toBe('de');
+    expect(getEffectiveLanguage('En-GB')).toBe('en-gb');
+  });
+
+  it('falls back to English for an unknown language', () => {
+    expect(getEffectiveLanguage('klingon')).toBe('en');
+  });
+
+  it('falls back to English when nothing is configured', () => {
+    expect(getEffectiveLanguage(undefined)).toBe('en');
+  });
+
+  it('resolves every shipped language to itself, not to English', () => {
+    // The failure this catches: a language file exists but was never added to the
+    // TRANSLATIONS map, or was added with a non-lowercase key. Either way the card
+    // silently renders English and no error is raised.
+    for (const language of LANGUAGES) {
+      const resolved = getEffectiveLanguage(language);
+      expect(resolved, `${language} did not resolve to itself`).toBe(language.toLowerCase());
+    }
+  });
+});
+
+describe('getTranslations', () => {
+  it('returns the requested language, not English', () => {
+    const de = getTranslations('de');
+    expect(de.loading).not.toBe(en.loading);
+  });
+
+  it('returns complete runtime strings for every shipped language', () => {
+    // Every top-level runtime key must be present and non-empty. A missing key
+    // renders as `undefined` in the UI; an empty one renders as blank. Both look
+    // like a rendering bug rather than a translation bug.
+    const runtimeKeys = Object.keys(en).filter((key) => key !== 'editor');
+
+    for (const language of LANGUAGES) {
+      const translations = getTranslations(language) as unknown as Record<string, unknown>;
+
+      for (const key of runtimeKeys) {
+        const value = translations[key];
+        expect(value, `${language}.${key} is missing`).toBeDefined();
+
+        if (Array.isArray(value)) {
+          expect(value, `${language}.${key} has the wrong length`).toHaveLength(
+            (en as unknown as Record<string, unknown[]>)[key].length,
+          );
+          for (const entry of value) {
+            expect(String(entry).trim(), `${language}.${key} has an empty entry`).not.toBe('');
+          }
+        } else {
+          expect(String(value).trim(), `${language}.${key} is empty`).not.toBe('');
+        }
+      }
+    }
+  });
+});
+
+describe('hasEditorTranslations', () => {
+  it('reports true for English', () => {
+    expect(hasEditorTranslations('en')).toBe(true);
+  });
+
+  it('is all-or-nothing for every language that claims editor support', () => {
+    // This is the AGENTS.md trap. `hasEditorTranslations` returns true when the
+    // section has *one or more* keys, so a partially translated editor defeats the
+    // whole-language English fallback: translated keys render, missing ones render
+    // as the raw key name. Either translate all of it or omit the section.
+    const editorKeys = Object.keys(en.editor);
+
+    for (const language of LANGUAGES) {
+      if (!hasEditorTranslations(language)) continue;
+
+      const editor = (getTranslations(language) as unknown as { editor: Record<string, string> })
+        .editor;
+
+      const missing = editorKeys.filter((key) => !editor[key] || editor[key].trim() === '');
+      expect(missing, `${language} has a partial editor section`).toEqual([]);
+    }
+  });
+});
+
+describe('locale mapping', () => {
+  // `mapLocale` is private, so this asserts its observable effect instead of
+  // importing it: a regional variant must produce the same relative time as its
+  // base locale, because mapLocale reduces it before dayjs sees it.
+  const reference = new Date('2026-06-15T12:00:00Z');
+  const future = new Date('2026-06-17T12:00:00Z');
+
+  it('reduces a regional variant to its base locale', () => {
+    // en-gb needs neither a dayjs import nor a supportedLocales entry precisely
+    // because mapLocale reduces it to `en`.
+    expect(getRelativeTimeString(future, 'en-gb', reference)).toBe(
+      getRelativeTimeString(future, 'en', reference),
+    );
+  });
+
+  it('keeps the Chinese variants distinct from each other', () => {
+    // zh-cn and zh-tw are the two special cases that survive reduction.
+    const simplified = getRelativeTimeString(future, 'zh-cn', reference);
+    const traditional = getRelativeTimeString(future, 'zh-tw', reference);
+    expect(simplified).not.toBe(getRelativeTimeString(future, 'en', reference));
+    expect(traditional).not.toBe(getRelativeTimeString(future, 'en', reference));
+  });
+
+  it('falls back to English for an unsupported locale', () => {
+    expect(getRelativeTimeString(future, 'klingon', reference)).toBe(
+      getRelativeTimeString(future, 'en', reference),
+    );
+  });
+});
+
+describe('relative time localization', () => {
+  // The silent failure. A language missing its `supportedLocales` entry works
+  // everywhere except here, where it quietly falls back to English. Catalan and
+  // Romanian shipped broken this way for months precisely because nothing errors.
+  const reference = new Date('2026-06-15T12:00:00Z');
+  const future = new Date('2026-06-17T12:00:00Z');
+
+  it('produces English for English', () => {
+    const result = getRelativeTimeString(future, 'en', reference);
+    expect(result.toLowerCase()).toContain('day');
+  });
+
+  it('produces a localized string, not English, for every non-English language', () => {
+    const english = getRelativeTimeString(future, 'en', reference);
+
+    const untranslated: string[] = [];
+
+    for (const language of LANGUAGES) {
+      if (language === 'en') continue;
+
+      const result = getRelativeTimeString(future, language, reference);
+      if (result === english) {
+        untranslated.push(language);
+      }
+    }
+
+    // Regional English variants legitimately share English relative times.
+    const genuinelyBroken = untranslated.filter((language) => !language.startsWith('en-'));
+
+    expect(genuinelyBroken, 'these languages fall back to English relative times').toEqual([]);
+  });
+
+  it('is deterministic given a fixed reference instant', () => {
+    // getRelativeTimeString already accepts an explicit reference, which is what
+    // makes this testable without faking the clock.
+    const first = getRelativeTimeString(future, 'de', reference);
+    const second = getRelativeTimeString(future, 'de', reference);
+    expect(first).toBe(second);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     },
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Test configuration for Calendar Card Pro.
+ *
+ * `vitest` and `happy-dom` are devDependencies. AGENTS.md states the project has
+ * "no test suite ... keep it that way", with bundle size as the stated rationale —
+ * that rationale does not apply here, because a test runner never enters
+ * `dist/calendar-card-pro.js`. Rollup's only input is `src/calendar-card-pro.ts`,
+ * so nothing under `tests/` can reach the bundle even accidentally.
+ *
+ * `happy-dom` rather than `jsdom`: it renders Lit correctly at roughly a fifth of
+ * the install footprint, and swapping back is a one-word change to `environment`
+ * below if a real gap ever appears.
+ */
+export default defineConfig({
+  test: {
+    // Lit needs a DOM to render into. Pure-logic tests do not care either way, so
+    // setting this once avoids per-file environment annotations later.
+    environment: 'happy-dom',
+    include: ['tests/**/*.test.ts'],
+
+    // Time and zone are pinned globally rather than per-file. Anything that renders
+    // a date depends on both, and a suite that passes in Europe and fails in
+    // America is worse than no suite at all.
+    env: {
+      TZ: 'UTC',
+    },
+  },
+});


### PR DESCRIPTION
Phase 0 of the column-view work: a safety net built **before** the refactor, so a
behaviour change during Phase 1's extraction fails loudly instead of silently.

This is infrastructure only — **it ships nothing**. See _Zero runtime impact_ below.

## What's here

**`scripts/check-i18n.mjs` + `npm run check:i18n`** — wires into CI between typecheck and
build. Adding a language means editing four places, and missing one fails *silently*: omit
the `supportedLocales` entry in `dayjs.ts` and everything works except relative times,
which quietly fall back to English. Catalan and Romanian shipped that way for months. The
script checks all four mechanically, plus the partial-`editor`-section trap that renders
raw key names like `show_end_time` in the UI.

Zero dependencies, plain Node ESM. Currently reports **35 languages, 11 with editor
translations, 0 errors, 1 warning** — the warning is pre-existing (`image_label_note` and
`start_date` are declared in `en.json` but never referenced).

**A Vitest + happy-dom suite, 73 tests in 4 files.** Not aiming at coverage — it pins what
has actually broken before (translation wiring, config normalization) and, in
`tests/list-dom.test.ts`, the **serialized list-view DOM**. That last one is the Phase 1
gate: the extraction refactor must produce byte-identical markup, and this is what proves
it did.

**An AGENTS.md correction.** The file said "no test suite — keep it that way; bundle size
is a design constraint". Bundle size governs `dependencies`, not `devDependencies` —
nothing here reaches `dist/`. Reworded to keep the constraint where it applies and to
document the suite's two real traps.

## Zero runtime impact — measured, not asserted

No file under `src/` is touched. But `rollup.config.mjs:48` passes `tsconfig.json` to the
esbuild plugin, and this branch edits `tsconfig.json`, so that needed proving rather than
assuming:

```
build at this HEAD                                 sha256 30f7b8ec…  347,943 bytes
build with tsconfig/package/eslint reverted to dev sha256 30f7b8ec…  347,943 bytes
```

**Byte-identical.** No HA testing required — there is nothing to test.

## The finding worth keeping

The DOM gate had to be fixed **twice** after it was first written, and both holes had the
same shape: **an option that defaults to `false` renders nothing, so a suite built from
default config never reaches it.** Four branches were invisible that way — including
`parseIndicatorPosition`, reachable only through `renderTodayIndicator`, which returns
`nothing` when `today_indicator` is off. Two of Phase 1's four extraction targets had
**zero** coverage while the gate looked complete.

Mutation testing does not catch this: it proves the assertions you *have* are load-bearing,
and says nothing about a branch no fixture reaches. Coverage had to be argued mechanically
against the 32 config keys `render.ts` actually reads. That lesson is now written into
AGENTS.md next to the suite.

## Checks

`check:i18n` 0 errors · `tsc --noEmit` clean · `lint` clean · `vitest` 73/73 · `build`
347,943 bytes (identical to dev).
