### PR TITLE
docs: give new users a working card and de-duplicate the editor page

### DIFF
--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -4,6 +4,8 @@ Calendar Card Pro includes a comprehensive visual editor that makes configuratio
 
 <img src="https://raw.githubusercontent.com/alexpfau/calendar-card-pro/main/.github/img/example_editor.png" alt="Visual Configuration Editor" width="600"><br>
 
+To open it, click the three dots (⋮) in the top-right corner of the card and select **Configure**. If you have not added a card yet, start with [Usage](/guide/usage).
+
 ## Editor Organization
 
 The editor is organized into logical panels that guide you through all configuration options:
@@ -23,16 +25,26 @@ The editor is organized into logical panels that guide you through all configura
 - **Smart Validation** - Input validation prevents configuration errors
 - **Automatic Config Upgrader** - Detects deprecated settings from older versions
 
-> **Note:** The visual configuration editor is currently available in 11 languages. Calendar settings applied through the editor will still display properly in all 35 supported languages.
+::: info Editor language support
+The visual configuration editor is currently available in **11 languages**, while the calendar itself supports **35 languages**. If your language is not among the 11, the editor falls back to English — calendar settings applied through it still display correctly in all 35 supported languages. Community contributions for additional editor translations are welcome!
+:::
 
-<details>
-<summary>Configuration Upgrader Details</summary>
+## Configuration Upgrader
 
-When you open the editor with a configuration that uses deprecated parameters, the editor will detect this and offer a one-click upgrade. Example:
+When you open the editor with a configuration that uses deprecated parameters, the editor detects this and offers a one-click upgrade. The full set of renames it handles:
 
-- `vertical_line_color` → `accent_color`
-- `max_events_to_show` → `compact_events_to_show`
+| Deprecated | Current |
+| ---------- | ------- |
+| `max_events_to_show` | `compact_events_to_show` |
+| `vertical_line_color` | `accent_color` |
+| `horizontal_line_width` | `day_separator_width` |
+| `horizontal_line_color` | `day_separator_color` |
+| `row_spacing` | `day_spacing` |
 
-Simply click "Update config..." to automatically migrate to the current parameter names.
+`max_events_to_show` is also upgraded when it appears on an individual entry under `entities:`.
 
-</details>
+Click **"Update config..."** to automatically migrate to the current parameter names.
+
+::: warning YAML configurations are not migrated automatically
+The upgrader runs **only in the visual editor**. There is no runtime migration, so a deprecated option written directly in YAML is silently ignored and the card falls back to the default — it does not keep working under the old name. If you manage your card in YAML, use the current names from the [Configuration Variables reference](/reference/configuration).
+:::

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-Once **Calendar Card Pro** is installed, follow these steps to add and configure it in your Home Assistant dashboard.
+Once **Calendar Card Pro** is [installed](/guide/installation), this page takes you from an empty dashboard to a working, customised card.
 
 ## 📌 Adding the Card to Your Dashboard
 
@@ -15,31 +15,72 @@ Once **Calendar Card Pro** is installed, follow these steps to add and configure
    - Select the card to add it to your dashboard
 4. **Configure with the Visual Editor**
    - Click the three dots (⋮) in the top-right corner of the card
-   - Select **"Configure"** to open the visual editor
-   - Follow the intuitive interface to customize your calendar
+   - Select **"Configure"** to open the [visual editor](/features/editor)
 
-> **Shortcut (Home Assistant 2026.6+):** In the card picker, switch to the **By entity** tab and pick any `calendar.*` entity. Calendar Card Pro is offered under **Community**, already pointed at that calendar and previewed with its real events — so you can skip straight to step 4. Nothing needs to be enabled for this.
+::: tip Shortcut (Home Assistant 2026.6+)
+In the card picker, switch to the **By entity** tab and pick any `calendar.*` entity. Calendar Card Pro is offered under **Community**, already pointed at that calendar and previewed with its real events — so you can skip straight to step 4. Nothing needs to be enabled for this.
+:::
 
-> **Note:** The visual configuration editor is currently available in 11 languages, while the calendar itself supports 35 languages. Community contributions for additional editor translations are welcome!
+## 🚀 Your First Card
+
+If you prefer YAML — or want to see what the editor is producing — this is a **complete, working configuration**. Paste it into the card's YAML editor as-is:
+
+```yaml
+type: custom:calendar-card-pro
+entities:
+  - calendar.family
+days_to_show: 3
+show_location: false
+show_month: false
+```
+
+<img src="https://raw.githubusercontent.com/alexpfau/calendar-card-pro/main/.github/img/example_1_basic_native.png" alt="Basic Configuration" width="600">
+
+Replace `calendar.family` with one of your own `calendar.*` entities and you have a working card.
+
+::: info Reading examples elsewhere in these docs
+Configuration snippets on the feature pages usually show **only the options being discussed**, so the relevant setting is easy to spot. To use one, add it to a card that already has `type:` and `entities:` — like the one above.
+:::
+
+## 📅 A Multi-Calendar Example
+
+Once the basics work, this shows several calendars at once with per-calendar colours and compact mode, tapping to expand:
+
+```yaml
+type: custom:calendar-card-pro
+title: Upcoming events
+entities:
+  - entity: calendar.family
+    color: '#ff6c92' # Red for family events
+  - entity: calendar.work
+    color: '#86ebda' # Blue for work events
+  - entity: calendar.personal
+    color: '#c2ffb3' # Green for personal events
+days_to_show: 7
+compact_events_to_show: 3 # Always only show 3 events
+tap_action:
+  action: expand # Tap to expand/collapse
+```
+
+<img src="https://raw.githubusercontent.com/alexpfau/calendar-card-pro/main/.github/img/example_2_advanced_compact.png" alt="Advanced Configuration" width="600">
 
 ## ⚙️ Customizing the Card
 
 Calendar Card Pro offers two ways to customize your card:
 
-1. **Visual Editor (Recommended)**
-   - Open the comprehensive visual editor
+1. **[Visual Editor](/features/editor) (Recommended)**
    - Organized panels guide you through all available options
    - Changes are previewed in real-time
    - Smart validation prevents configuration errors
 
 2. **YAML Configuration (Advanced)**
-   - Use YAML configuration for advanced customization or automation
-   - Reference the [📚 Configuration Variables](/reference/configuration) section for all available options
+   - Use YAML for advanced customization or automation
+   - See [📚 Configuration Variables](/reference/configuration) for every available option
 
 ## 🚀 Next Steps
 
-- **Try the Visual Editor** - Open the card configuration and explore the intuitive editor panels to customize your calendar
-- **Discover Advanced Features** - Check out [✨ Features & Configuration](/features/editor) to learn about specialized capabilities like weather integration and event filtering
-- **See Examples** - Browse the [💡 Examples](/reference/examples) section for inspiration and pre-configured setups
-- **Reference Configuration** - For advanced YAML customization, use the [📚 Configuration Variables](/reference/configuration) as a complete reference
-- **Get Involved!** - Check out [Contributing & Roadmap](/contributing) to learn how to contribute or see upcoming features
+- **Explore the Features** - [Core Settings](/features/core-settings), [Layout & Appearance](/features/layout-appearance) and [Event Content](/features/event-content) cover the options most people reach for first
+- **Discover Advanced Capabilities** - Add [weather forecasts](/features/weather), filter events with [blocklists and allowlists](/features/core-settings), or set up [tap and hold actions](/features/actions)
+- **See Examples** - Browse [💡 Examples](/reference/examples) for complete, ready-made setups
+- **Reference Configuration** - Use [📚 Configuration Variables](/reference/configuration) as the complete option reference
+- **Get Involved!** - See [Contributing & Roadmap](/contributing) to contribute or view upcoming features


### PR DESCRIPTION
## Phase 1 of the docs IA remediation — onboarding

Addresses audit finding **F1 (critical)**: there was no path anywhere on the docs site from *"installed"* to *"working card"*.

### The problem

`docs/guide/usage.md` explained how to click **Add Card** and then how to *customize* — but contained **zero card YAML**. A reader who preferred YAML, or who just wanted to see what the editor produces, had nowhere to go. The only complete configs on the whole site lived in `reference/examples.md`, which is not on the onboarding path.

Separately, `usage.md` and `features/editor.md` had drifted into near-duplicates: both described the editor's benefits, and both carried the same "11 of 35 languages" note.

### What changed

**`docs/guide/usage.md`** — now owns onboarding:

- Adds **Your First Card**: a complete, copy-pasteable minimal config with screenshot, migrated from the README Quick Start
- Adds **A Multi-Calendar Example**: per-calendar colours, compact mode, tap-to-expand, with screenshot
- Promotes the HA 2026.6+ card-picker shortcut to a proper VitePress `tip` container
- Rewrites *Next Steps* to point at the actual feature pages rather than at the editor page labelled "Features & Configuration"

**`docs/features/editor.md`** — now owns editor detail:

- Drops the duplicated onboarding prose; links back to Usage instead
- Becomes the single home for the 11-of-35 language note
- Promotes the config upgrader out of a collapsed `<details>` into a real section

### A defect found while writing this

Documenting the upgrader, I checked whether deprecated option names still work in YAML. They do **not**: `DEPRECATED_CONFIG_MAP` is referenced only from `editor.ts`, so there is no runtime migration — a deprecated option written directly in YAML is **silently ignored** and the card falls back to the default.

My first draft of that section claimed the opposite. It now carries a warning, and lists **all five** renames plus the entity-level one rather than three examples.

### Convention established for Phase 2

Usage now states the rule the rest of the docs follow, so the Phase 2 drift checker has something concrete to enforce:

> Configuration snippets on the feature pages usually show **only the options being discussed**. To use one, add it to a card that already has `type:` and `entities:`.

This is why Phase 1 had to land before Phase 2 — the checker cannot validate a convention that does not yet exist.

### Not changed

No page was renamed or moved and no heading was removed, so every existing anchor still resolves. The two inbound deep links to `usage.md#adding-the-card-to-your-dashboard` (from `whats-new.md` and the README) were verified intact.

### Validation

| Check | Result |
| ----- | ------ |
| `npm run docs:build` | complete — `ignoreDeadLinks: false`, so every link verified |
| `npx tsc --noEmit` | clean |
| `npm test` | 73/73 across 4 files |
| `npm run lint` | clean |
