### PR TITLE
docs: give orphan options a home and pin the README example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,13 @@ quick-start example. Links from the README into the docs site must be **absolute
 (`https://calendar-card-pro.alexpfau.com/...`) — the README also renders on GitHub and in
 HACS, where relative docs paths do not resolve.
 
+The README's quick-start YAML block is the one **deliberate** duplicate in the project: it
+is the HACS landing page, so it has to show a working config without sending the reader
+elsewhere first. `check:docs` pins it byte-for-byte to the first example in
+`docs/guide/usage.md`. Do not resolve that failure by deleting either copy — edit both.
+Anything that *teaches* (multiple calendars, per-calendar colours, compact mode) belongs
+only in `docs/`, never in the README.
+
 **Do not touch the `## 4️⃣ What's New` section** in a feature PR. It is organised by
 release, so a feature branch cannot know which version it will land in, and concurrent
 branches conflict in it.

--- a/README.md
+++ b/README.md
@@ -130,27 +130,9 @@ show_month: false
 
 <img src="https://raw.githubusercontent.com/alexpfau/calendar-card-pro/main/.github/img/example_1_basic_native.png" alt="Basic Configuration" width="600">
 
-And a multi-calendar setup with per-calendar colours and compact mode, tapping to expand:
+Swap `calendar.family` for one of your own `calendar.*` entities and you have a working card.
 
-```yaml
-type: custom:calendar-card-pro
-title: Upcoming events
-entities:
-  - entity: calendar.family
-    color: '#ff6c92' # Red for family events
-  - entity: calendar.work
-    color: '#86ebda' # Blue for work events
-  - entity: calendar.personal
-    color: '#c2ffb3' # Green for personal events
-days_to_show: 7
-compact_events_to_show: 3 # Always only show 3 events
-tap_action:
-  action: expand # Tap to expand/collapse
-```
-
-<img src="https://raw.githubusercontent.com/alexpfau/calendar-card-pro/main/.github/img/example_2_advanced_compact.png" alt="Advanced Configuration" width="600">
-
-**➡️ Every available option is documented in the [Configuration Variables reference](https://calendar-card-pro.alexpfau.com/reference/configuration), and more ready-made setups are in [Examples](https://calendar-card-pro.alexpfau.com/reference/examples).**
+**➡️ From here, [Usage](https://calendar-card-pro.alexpfau.com/guide/usage) walks you through multiple calendars, per-calendar colours and compact mode. Every available option is listed in the [Configuration reference](https://calendar-card-pro.alexpfau.com/reference/configuration), and more ready-made setups are in [Examples](https://calendar-card-pro.alexpfau.com/reference/examples).**
 
 <p align="right"><a href="#top">⬆️ back to top</a></p>
 

--- a/docs/features/layout-appearance.md
+++ b/docs/features/layout-appearance.md
@@ -62,9 +62,14 @@ event_spacing: '6px' # Internal padding within each event
 
 # Date column alignment
 date_vertical_alignment: 'top' # Options: 'top', 'middle', 'bottom'
+
+# Event icon alignment
+event_icon_vertical_alignment: 'top' # Options: 'top', 'middle', 'bottom'
 ```
 
 The `date_vertical_alignment` option controls how dates align with their events, which is especially noticeable when a day has many events. The default `middle` setting centers the date between its events, while `top` aligns it with the first event and `bottom` with the last event.
+
+`event_icon_vertical_alignment` does the same job one level down, for the small icons on an event's time, location and description rows. It only becomes visible when one of those wraps onto a second line: the default `middle` centres the icon against the whole block, while `top` lines it up with the first line of text.
 
 ## 📅 Week Numbers & Visual Separators
 
@@ -158,6 +163,10 @@ today_indicator: /local/custom-indicator.png # Image path
 today_indicator_position: "15% 50%" # Centered left in the date column (default)
 today_indicator_position: "15% 15%" # Top left
 today_indicator_position: "85% 15%" # Top right
+
+# Restyle the indicator
+today_indicator_color: "#03a9f4" # Colour — applies to the dot and to MDI icons (default)
+today_indicator_size: 6px # Size — applies to icons, emojis and images alike (default)
 ```
 
 <img src="https://raw.githubusercontent.com/alexpfau/calendar-card-pro/main/.github/img/example_today_indicator.png" alt="Today Indicator" width="600"><br>
@@ -174,3 +183,5 @@ Available indicator types:
 - Image path: Any image URL or local path
 
 The `today_indicator_position` parameter accepts CSS-like position values in the format "x% y%", allowing precise placement of the indicator anywhere within the date column.
+
+`today_indicator_size` scales every indicator type — it sets the icon size, the emoji font size and the image width. `today_indicator_color` colours the icon-based types (the dot, `pulse`, `glow` and any `mdi:` icon) and is also the colour of the glow itself; emojis and images keep their own colours.

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -372,6 +372,48 @@ function checkCopyableExamples(docs) {
 }
 
 // ---------------------------------------------------------------------------
+// Check 5 — the README's quick-start example still matches the docs
+// ---------------------------------------------------------------------------
+
+/**
+ * The README is the HACS landing page, so it has to show what a config looks like
+ * without sending the reader elsewhere first. That one block is therefore the single
+ * place in the project where duplication is deliberate rather than accidental.
+ *
+ * Duplication that nothing checks is just drift with a delay on it, so rather than
+ * removing the block or tolerating the copy, this pins it: the README's first card
+ * example must stay byte-identical to the first one in the usage guide. Edit either
+ * and this fails, naming both files.
+ */
+function checkReadmeExample() {
+  const readme = join(ROOT, 'README.md');
+  const usage = join(DOCS_DIR, 'guide/usage.md');
+
+  const firstCard = (file) => {
+    const blocks = readFileSync(file, 'utf8').match(/^```ya?ml\n[\s\S]*?^```/gm) || [];
+    return blocks.find((b) => /^\s*type:\s*custom:calendar-card-pro\s*$/m.test(b));
+  };
+
+  const a = firstCard(readme);
+  const b = firstCard(usage);
+
+  // Neither side may quietly lose its example: that would make the check vacuous.
+  if (!a) {
+    error('README.md: no complete card example found — the landing page must show one working config');
+    return;
+  }
+  if (!b) {
+    error('docs/guide/usage.md: no complete card example found — the README example is pinned to it');
+    return;
+  }
+  if (a.trim() !== b.trim()) {
+    error(
+      "README.md and docs/guide/usage.md show different first examples. They are meant to be the same config — update both, or they will teach two different things.",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 
 function report(counts) {
   console.log(
@@ -413,6 +455,7 @@ function main() {
   checkCoverage(fields, docs);
   checkFences(docs);
   const complete = checkCopyableExamples(docs);
+  checkReadmeExample();
 
   process.exit(
     report({ defaults: defaults.size, rows: rows.size, fields: fields.size, docs: docs.length, complete }),


### PR DESCRIPTION
Final phase of the documentation audit. Closes the two remaining gaps: options with no prose home, and a README that duplicated the usage guide unchecked.

### Three orphan options now have a home

`today_indicator_color`, `today_indicator_size` and `event_icon_vertical_alignment` existed only as rows in the reference table. `AGENTS.md` already states that a table row is not documentation — these were undiscoverable unless you read the table end to end.

The today-indicator scope was **verified against `styles.ts`, not assumed** — my first draft claimed the two options only affected the plain dot, which the CSS contradicts:

- `--calendar-card-today-indicator-size` drives `--mdc-icon-size` for icons, `width`/`max-height` for images and `font-size` for emoji, so it scales **every** variant.
- `--calendar-card-today-indicator-color` sets `color` on the container and feeds the `glow` drop-shadow, so it applies to the icon-based types but not to images.

`event_icon_vertical_alignment` is documented beside its sibling `date_vertical_alignment`, since a reader hunting for alignment options is already in that section.

### README: one example, not two

The advanced multi-calendar block was a near-verbatim copy of `docs/guide/usage.md`. It *teaches* — per-calendar colours, compact mode, tap-to-expand — so it belongs only in the guide, which the README now links to.

The basic example stays. The README is the HACS landing page and needs to answer "what does a config look like" without a redirect.

### The remaining duplicate is now guarded, not tolerated

That one block is deliberate duplication, and **duplication nothing checks is drift with a delay on it**. Rather than removing it or living with the copy, `check:docs` now pins it byte-for-byte to the usage guide's first example.

This applies the same principle as Phase 3 — *generate the check, not the content* — and notably it is **the first check to look at the README at all**; the script previously walked `docs/` only, leaving the landing page entirely unverified.

All three failure paths were mutation-tested, each mutation confirmed to actually land before trusting the result:

| Mutation | Outcome |
|---|---|
| Change `days_to_show` in the README | ✗ fails, naming both files |
| Delete the README's card example | ✗ fails |
| Delete the usage guide's card example | ✗ fails |
| Unmodified tree | ✓ passes |

That third case matters: without it the check could pass vacuously if the guide's example disappeared.

`AGENTS.md` records why the duplicate exists, so the next reader fixes a failure by editing both copies instead of deleting one.

### Validation

`check:docs` 0 errors / 8 known-good warnings / 21 pages · `docs:build` clean · `tsc --noEmit` · `lint` · 73/73 tests.

Also confirmed the removed image is still referenced by `usage.md` and `examples.md`, so nothing is orphaned.

---

This completes all six phases of the audit on `dev`. Happy to open the single `dev` → `main` PR whenever you want it.
