### PR TITLE
docs: restore the What's New archive back to v1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,20 +156,42 @@ elsewhere first. `check:docs` pins it byte-for-byte to the first example in
 Anything that *teaches* (multiple calendars, per-calendar colours, compact mode) belongs
 only in `docs/`, never in the README.
 
-**Do not touch the `## 4️⃣ What's New` section** in a feature PR. It is organised by
-release, so a feature branch cannot know which version it will land in, and concurrent
-branches conflict in it.
+### The two "What's New" surfaces
 
-**In the release PR** (`dev` → `main`), update `## 4️⃣ What's New` alongside
-`docs/RELEASE_NOTES.md`: rename the previous `### Latest Release: vX.Y` to plain `### vX.Y`,
-add a new one with 3–6 one-line bullets condensed from the release notes, and apply the
-retention rule — keep the current major version's minor releases, newest first, capped at
-8, topping up from the previous major only if that leaves fewer than 4.
+There are **two** of them and they follow **different rules**. Updating only one is the
+most likely way for a release to drift:
 
-That list is a **highlights reel, not a changelog** — the full notes are linked directly
-above it, so anything left out is one click away. Select on relevance rather than on
-whether something is a feature or a fix: a Home Assistant compatibility break or a bug that
-made the card look empty belongs there; a narrow styling option, an editor validation
+| | `README.md` `## 4️⃣ What's New` | `docs/guide/whats-new.md` |
+| --- | --- | --- |
+| Purpose | highlights reel for the HACS landing page | the card's full history |
+| Span | current major only, capped at 8 entries | **every** minor line, back to v1.0 |
+| Selection | ruthless — relevance only | fuller, but still curated |
+
+**Do not touch either in a feature PR.** They are organised by release, so a feature
+branch cannot know which version it will land in, and concurrent branches conflict in them.
+
+**In the release PR** (`dev` → `main`), update **both** alongside `docs/RELEASE_NOTES.md`.
+In each, rename the previous `Latest Release: vX.Y` heading to plain `vX.Y` and add a new
+one condensed from the release notes. Then:
+
+- **README** — apply the retention rule: keep the current major version's minor releases,
+  newest first, capped at 8, topping up from the previous major only if that leaves fewer
+  than 4.
+- **docs page** — never drop an entry; it is the archive. `check:docs` fails if a minor
+  line present in `RELEASE_NOTES.md` has no `## vX.Y` heading here, and vice versa.
+
+A **patch** release folds into the existing `vX.Y` entry on both surfaces rather than
+adding a new heading — each entry covers its whole minor line.
+
+When linking **into** the docs page, mind the anchor: the site's `slugify` strips dots, so
+`## v2.1` anchors as `#v21`, not `#v2-1`. These links are written as absolute URLs to the
+live site, so VitePress's dead-link check — which only resolves relative links — cannot
+see them; `check:docs` validates them instead.
+
+The README list is a **highlights reel, not a changelog** — the full notes are linked
+directly above it, so anything left out is one click away. Select on relevance rather than
+on whether something is a feature or a fix: a Home Assistant compatibility break or a bug
+that made the card look empty belongs there; a narrow styling option, an editor validation
 nicety, or a rare edge-case fix does not. Never write a catch-all "🐛 Key Bug Fixes" bullet.
 Three honest bullets beat six padded ones, and older entries may be trimmed further as they
 age. Deep-link each bullet to the relevant docs page where one exists.
@@ -179,7 +201,8 @@ age. Deep-link each bullet to the relevant docs page where one exists.
 1. Bump `version` in `package.json` — it is the single source of truth. Rollup
    substitutes it into the bundle header and into `constants.ts` via `@version
 vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements.
-2. Update `docs/RELEASE_NOTES.md` and the README's `## 4️⃣ What's New` section.
+2. Update `docs/RELEASE_NOTES.md`, the README's `## 4️⃣ What's New` section, **and**
+   `docs/guide/whats-new.md` — see _The two "What's New" surfaces_ for the differing rules.
 3. Open a PR from `dev` into `main` and merge it. `main`'s ruleset requires an approving
    review that you cannot give yourself, so this needs `gh pr merge <n> --merge --admin`.
 4. **Fast-forward `dev` back onto `main`** — `git push origin origin/main:dev`. The merge

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -728,7 +728,7 @@ Testing has been conducted across:
 
 **More accessible and more reliable.** This release brings important bug fixes and language enhancements to provide a more robust and internationally accessible calendar experience.
 
-→→→ Please see the [🆕 What's New](https://github.com/alexpfau/calendar-card-pro#2%EF%B8%8F⃣-whats-new) section in the README for an overview of v2.4 features with links to their detailed documentation. ←←←
+→→→ Please see the [🆕 What's New](https://calendar-card-pro.alexpfau.com/guide/whats-new) page in the documentation for an overview of v2.4 features with links to their detailed documentation. ←←←
 
 ## 🎉 New Features
 
@@ -820,7 +820,7 @@ Thank you to everyone who contributed bug reports that made this release possibl
 
 **Visually intelligent and precisely configured.** This release brings visual highlights for the current day, progress tracking for running events, and enhanced compact mode controls - making Calendar Card Pro more visually informative and customizable than ever.
 
-→→→ Please see the [🆕 What's New](https://github.com/alexpfau/calendar-card-pro#2%EF%B8%8F⃣-whats-new) section in the README for an overview of v2.4 features with links to their detailed documentation. ←←←
+→→→ Please see the [🆕 What's New](https://calendar-card-pro.alexpfau.com/guide/whats-new) page in the documentation for an overview of v2.4 features with links to their detailed documentation. ←←←
 
 ## 🎉 New Features
 
@@ -970,7 +970,7 @@ Thank you to everyone who contributed bug reports and translation improvements t
 
 **Time-aware and visually enhanced.** This release brings dynamic countdown displays, weekend styling, and flexible date ranges that adapt to your needs, making Calendar Card Pro more informative and visually distinct than ever before.
 
-→→→ Please see the [🆕 What's New](https://github.com/alexpfau/calendar-card-pro#2%EF%B8%8F⃣-whats-new) section in the README for an overview of v2.3 features with links to their detailed documentation. ←←←
+→→→ Please see the [🆕 What's New](https://calendar-card-pro.alexpfau.com/guide/whats-new) page in the documentation for an overview of v2.3 features with links to their detailed documentation. ←←←
 
 ## 🎉 New Features
 
@@ -1328,7 +1328,7 @@ _This release maintains full compatibility with all existing configurations._
 
 This release introduces powerful new visual organization features and enhanced calendar controls, making Calendar Card Pro even more flexible for all your calendar management needs.
 
-→→→ Please see the [🆕 What's New in v2.1](https://github.com/alexpfau/calendar-card-pro#-whats-new-in-v21) section in the README for detailed examples of all new features. ←←←
+→→→ Please see the [🆕 What's New in v2.1](https://calendar-card-pro.alexpfau.com/guide/whats-new#v21) page in the documentation for detailed examples of all new features. ←←←
 
 ## 🎉 New Features
 
@@ -1399,7 +1399,7 @@ This maintenance release addresses several issues reported by users after the v2
 
 This major release completely reimagines Calendar Card Pro with a new architecture, enhanced performance, and numerous new features for customization. Calendar Card Pro v2 brings significant improvements to theme compatibility, visual styling options, and smart data management.
 
-→→→ Please see the [🆕 What's New in v2](https://github.com/alexpfau/calendar-card-pro#-whats-new-in-v2) section in the README for detailed examples of all new features. ←←←
+→→→ Please see the [🆕 What's New in v2](https://calendar-card-pro.alexpfau.com/guide/whats-new#v20) page in the documentation for detailed examples of all new features. ←←←
 
 ## 🚀 Major Refactoring
 

--- a/docs/guide/whats-new.md
+++ b/docs/guide/whats-new.md
@@ -2,6 +2,10 @@
 
 **➡️ View the [Full Release Notes](/RELEASE_NOTES) for a complete list of features.**
 
+Each entry below covers a whole minor release line — the `X.Y.0` release plus every
+patch that followed it — so this page reads as the card's progression from the first
+public release in January 2025 to today.
+
 ## Latest Release: v3.5
 
 - 🫥 **Empty State Control**: [Remove the card entirely](/features/event-content#calendar-events-display) when there are no upcoming events, or replace "No upcoming events" with [your own wording](/features/event-content#custom-empty-day-text)
@@ -15,7 +19,9 @@
 
 - ⏳ **All-Day Countdown Control**: Hide countdowns on all-day events while keeping them on timed ones with [`show_countdown_allday`](/features/event-content#countdown-display)
 - 🌤️ **Weather Across the Full Range**: Timed events beyond Home Assistant's hourly forecast horizon now [fall back to the daily forecast](/features/weather#weather-configuration-options) instead of showing nothing
+- 🧭 **Compact Mode Guidance**: The visual editor warns about compact configurations that silently do nothing
 - 🐛 **All-Day Countdowns Off By One**: Now measured in whole calendar days instead of from the current instant
+- 🐛 **Cleared Number Fields**: Emptying a numeric field in the editor no longer blanks the card
 - ⚡ **Faster Rendering**: Color resolution is cached, removing hundreds of forced layouts per refresh on large calendars
 
 ## v3.3
@@ -23,33 +29,90 @@
 - 🌍 **Two New Languages**: British English and Latvian (35 total), with editor translations for Italian, British English, and Latvian (11 total)
 - 🐛 **HA 2026.5+ Visual Editor**: Restored the text input fields, which vanished entirely after Home Assistant removed `ha-textfield`
 - 🐛 **`event_color` Fix**: No longer ignored when no per-entity color is configured
+- 🐛 **Catalan & Romanian Relative Times**: Fixed silently falling back to English
 
 ## v3.2
 
 - 📝 **Event Description Display**: Show event descriptions with [configurable line clamping](/features/event-content#event-description-display), HTML stripping, and full styling control
 - 🌤️ **UV Index in Weather**: Display [UV index in weather forecasts](/features/weather#weather-configuration-options) with configurable visibility threshold
+- 🎨 **Event Icon Alignment**: Control the [vertical alignment of event icons](/features/layout-appearance#spacing-alignment) for time, location and description rows
+- 🏷️ **Label Icon Color**: Customise [label icon colours](/features/core-settings#entity-configuration) per entity with `label_icon_color`
 - ↔️ **RTL Support**: Full right-to-left support for event borders and accent lines
-- 🔄 **Improved Loading UX**: Events stay visible during refresh; subtle spinner replaces full-screen loading
+- 🔄 **Improved Loading UX**: Events stay visible during refresh; a subtle spinner replaces the full-screen loading state
 - 🌍 **Three New Languages**: Estonian, Lithuanian, and Turkish (33 at the time), with editor translations for Polish, Estonian, and Lithuanian
 - 🐛 **HA 2026.3+ Compatibility**: Migrated editor dropdowns to the new WebAwesome API
+- 🐛 **Weather WebSocket Leak**: Subscriptions are now cleaned up instead of accumulating
 
 ## v3.1
 
 - 🌍 **Four New Translations**: Bulgarian interface, plus Norwegian Bokmål, German, and Swedish editor translations
-- 🎨 **Tomorrow CSS Class**: New `tomorrow` HTML class for card-mod styling of tomorrow's events
+- 🎨 **Tomorrow CSS Class**: New `tomorrow` HTML class for [card-mod styling](/features/theming#card-mod-examples) of tomorrow's events
+- 🐛 **Zero Temperature Fix**: `0°` no longer disappeared from the weather low temperature
 - 🐛 **Grid Layout Fix**: Resolved card overflow when `grid_options.rows` is set
 
 ## v3.0
 
-- ⚙️ **Visual Configuration Editor**: New visual editor for easy, guided configuration, with smart validation and auto-upgrade of deprecated settings
+- ⚙️ **Visual Configuration Editor**: New [visual editor](/features/editor) for easy, guided configuration, with smart validation and auto-upgrade of deprecated settings
 - 🌦️ **Weather Integration**: Display [weather forecasts](/features/weather) alongside your events
 - 🕒 **Improved Time Format Detection**: Automatically detects and respects all Home Assistant time format settings (12h, 24h, language-based, and system-based)
 - ⚠️ **Breaking Changes**: Parameter renames: `vertical_line_color` → `accent_color`, `max_events_to_show` → `compact_events_to_show`, `horizontal_line_width` → `day_separator_width`, `horizontal_line_color` → `day_separator_color`
 
-_Older releases are covered in the [Full Release Notes](/RELEASE_NOTES)._
+## v2.4
 
-<div style="background-color: rgba(3, 169, 244, 0.1); padding: 12px; margin: 20px 0;">
-  <h4 style="margin: 0; display: inline;">
-    ⬇️ <a href="#5️⃣-features--configuration">View Complete Features Documentation</a>
-  </h4>
-</div>
+- 🌟 **Today Indicator**: Highlight today with a [customisable dot, pulse, glow effect, emoji, or custom icon](/features/layout-appearance#today-indicator)
+- 🎨 **Today's Date Styling**: Customise the [appearance of today's date](/features/layout-appearance#date-column-customization) with dedicated colour options (`today_weekday_color`, `today_day_color`, `today_month_color`)
+- 🚦 **Event Progress Bars**: Visualise how far a running event has progressed with optional [progress bars](/features/event-content#progress-bar-display)
+- ✂️ **Split Multi-Day Events**: Display [multi-day events on every day they cover](/features/multi-day-events#split-multi-day-events)
+- 🧠 **Enhanced Compact Mode Controls**: More precise control over [what appears in compact vs expanded views](/features/core-settings#compact-view-management-event-limits)
+
+## v2.3
+
+- ⏳ **Countdown Display**: [Show how much time remains](/features/event-content#countdown-display) until an event starts with `show_countdown`
+- 🌅 **Weekend Day Styling**: [Style weekend days](/features/event-content#weekend-day-styling) differently with dedicated colour options
+- 📆 **Relative Date Offsets**: Define a [floating start date](/features/start-date-offset#dynamic-start-date-with-relative-offsets) relative to the current day instead of a fixed date
+- 🔤 **Automatic Hyphenation**: Long compound words wrap more elegantly, especially in German
+- 🐛 **Blank Cards After Updates**: Version-aware cache keys stop incompatible cached data from blanking the card after a HACS update
+
+## v2.2
+
+- ⚙️ **Advanced Event Filtering**: Include or exclude specific events with [`blocklist` and `allowlist` patterns](/features/core-settings#filtering-by-event-name) per entity
+- 🔄 **Filter Duplicate Events**: [Remove redundant events](/features/core-settings#filtering-duplicate-events) that appear in multiple calendars
+- 🌍 **Smart Country Filtering**: Precise control over [country name display in locations](/features/event-content#time-location-information)
+- 🏷️ **Enhanced Calendar Labels**: Beyond emojis and text, labels can now use [Material Design icons and custom images](/features/core-settings#entity-configuration)
+- 🎨 **Customisable Empty Day Styling**: Control how [empty days appear](/features/event-content#calendar-events-display) with `empty_day_color`
+
+## v2.1
+
+- 📅 **Week Numbers & Visual Separators**: Better visual organisation with [week number pills and customisable separators](/features/layout-appearance#week-numbers-visual-separators)
+- 📊 **Per-Calendar Event Limits**: Control how many events appear from [each calendar separately](/features/core-settings#entity-level-vs-global-event-limits)
+- 📏 **Fixed Height Control**: Set an [exact card height](/features/layout-appearance#card-dimensions-scrolling) with improved scrolling behaviour
+
+## v2.0
+
+- 🏗️ **Complete Rewrite**: A new rendering engine built on the standard `ha-card` structure, so [card-mod and custom themes](/features/theming#theming-card-mod) work exactly as they do on Home Assistant's built-in cards
+- 🌈 **Custom Styling Per Calendar**: Add [accent colours and opaque backgrounds](/features/layout-appearance#visual-styling-colors) to create visual hierarchy
+- 🏷️ **Calendar Labels**: Add [emoji or text identifiers](/features/core-settings#entity-configuration) for each calendar source
+- 🔧 **Advanced Display Controls**: [Per-calendar time and location settings](/features/event-content#time-location-information)
+- 📆 **Custom Start Date**: View calendars from [any date](/features/start-date-offset#start-date-configuration), not just today
+- 📱 **Maximum Height with Scrolling**: Set a [maximum card size](/features/layout-appearance#card-dimensions-scrolling) with scrollable content
+- ⚠️ **Breaking Changes**: `row_spacing` → `day_spacing`, and `time_location_icon_size` split into `time_icon_size` and `location_icon_size`
+
+## v1.2
+
+- 🌍 **Multi-Language Support**: Grew from 2 languages to 24 over this release line, driven almost entirely by community contributions
+- 📅 **Language-Aware Date Formats**: Dates follow each language's convention — `17. Mar` in German, `Mar 17` in English, `17 Mar` in most others
+- 🐛 **Event Limits Fixed**: `max_events_to_show` now limits individual events across all days rather than dropping whole days
+- 🐛 **12-Hour Format on Multi-Day Events**: `time_24h: false` is now honoured by multi-day events too
+
+## v1.1
+
+- 🌐 **Automatic Language Detection**: The card follows your Home Assistant system language, falling back to English — no `language` option required
+- 🗓️ **Ongoing Multi-Day Events**: Events that started before today now appear on every day they are active, with "Ends Today" and "Ends Tomorrow" labels
+
+## v1.0
+
+- 🎉 **First Public Release**: A performance-focused calendar card for Home Assistant, designed along Material Design principles
+- 📆 **Multi-Calendar Support**: Display several calendars in a single card, each with its own colour
+- 🔄 **Compact & Expandable Views**: Toggle between a space-efficient summary and the full list
+- ⚡ **Built for Performance**: Smart caching, progressive rendering, and minimal API calls from the very first release
+- 🐛 **All-Day Events West of UTC**: All-day events displayed on the wrong day for users in western timezones

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -414,11 +414,110 @@ function checkReadmeExample() {
 }
 
 // ---------------------------------------------------------------------------
+// Check 6 — the What's New archive covers every release line
+// ---------------------------------------------------------------------------
+
+/**
+ * `docs/guide/whats-new.md` is the card's full history, unlike the README's What's New
+ * which is a capped highlights reel. Because it is written by hand at release time and
+ * nothing renders it from the release notes, the failure mode is silent: a release ships,
+ * `RELEASE_NOTES.md` gains an entry, and the archive quietly stops being an archive.
+ *
+ * So pin the two together. Every minor line that has release notes must have a heading
+ * here — patches fold into their `vX.Y` entry rather than adding one, which is why this
+ * compares minor lines rather than exact versions.
+ */
+function checkWhatsNewCoverage() {
+  const notes = join(DOCS_DIR, 'RELEASE_NOTES.md');
+  const page = join(DOCS_DIR, 'guide/whats-new.md');
+
+  const released = new Set(
+    [...readFileSync(notes, 'utf8').matchAll(/^# Calendar Card Pro v(\d+)\.(\d+)\.\d+/gm)].map(
+      (m) => `${m[1]}.${m[2]}`,
+    ),
+  );
+  const documented = new Set(
+    [...readFileSync(page, 'utf8').matchAll(/^## (?:Latest Release: )?v(\d+)\.(\d+)\s*$/gm)].map(
+      (m) => `${m[1]}.${m[2]}`,
+    ),
+  );
+
+  // Either side coming back empty would make every comparison below trivially pass.
+  assertFound(released, 'release headings', notes);
+  assertFound(documented, "What's New entries", page);
+
+  const byVersion = (a, b) => {
+    const [aMaj, aMin] = a.split('.').map(Number);
+    const [bMaj, bMin] = b.split('.').map(Number);
+    return bMaj - aMaj || bMin - aMin;
+  };
+
+  const missing = [...released].filter((v) => !documented.has(v)).sort(byVersion);
+  if (missing.length) {
+    error(
+      `docs/guide/whats-new.md is missing ${missing.length} release line(s): ` +
+        `${missing.map((v) => `v${v}`).join(', ')}. It is the full archive — add an entry rather than trimming it.`,
+    );
+  }
+
+  const unreleased = [...documented].filter((v) => !released.has(v)).sort(byVersion);
+  if (unreleased.length) {
+    error(
+      `docs/guide/whats-new.md documents ${unreleased.map((v) => `v${v}`).join(', ')}, ` +
+        'which has no release notes. Check for a typo in the heading.',
+    );
+  }
+
+  checkWhatsNewAnchors(documented);
+
+  return documented.size;
+}
+
+/**
+ * Links into this page are written as absolute URLs to the live site, so VitePress's
+ * dead-link check — which only resolves relative links — never sees them. That blind
+ * spot is not theoretical: the release notes shipped `#v2-1` when the anchor is `#v21`.
+ *
+ * The site's slugify strips dots, so a `## vX.Y` heading anchors as `vXY`. Deriving the
+ * expected anchors from the headings just parsed keeps this in step with the page rather
+ * than hardcoding a list.
+ */
+function checkWhatsNewAnchors(documented) {
+  const valid = new Set();
+  for (const v of documented) {
+    const slug = `v${v.replace('.', '')}`;
+    valid.add(slug);
+    valid.add(`latest-release-${slug}`); // the newest entry carries a prefix
+  }
+
+  const links = [];
+  for (const file of listDocs()) {
+    const text = readFileSync(file, 'utf8');
+    for (const m of text.matchAll(/guide\/whats-new#([\w-]+)/g)) {
+      links.push({ anchor: m[1], file });
+    }
+  }
+
+  // No links at all would mean the pattern stopped matching, not that all is well.
+  assertFound(links, "links into the What's New page", DOCS_DIR);
+
+  for (const { anchor, file } of links) {
+    if (!valid.has(anchor)) {
+      error(
+        `${relative(ROOT, file)} links to guide/whats-new#${anchor}, which is not a heading on that page. ` +
+          `Note the site's slugify strips dots, so v2.1 anchors as #v21.`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 
 function report(counts) {
   console.log(
     `${counts.defaults} defaults in code, ${counts.rows} rows in the reference, ` +
-      `${counts.fields} config fields, ${counts.docs} pages, ${counts.complete} complete examples.\n`,
+      `${counts.fields} config fields, ${counts.docs} pages, ${counts.complete} complete examples, ` +
+      `${counts.releases} release lines documented.\n`,
   );
 
   if (errors.length) {
@@ -456,9 +555,17 @@ function main() {
   checkFences(docs);
   const complete = checkCopyableExamples(docs);
   checkReadmeExample();
+  const releases = checkWhatsNewCoverage();
 
   process.exit(
-    report({ defaults: defaults.size, rows: rows.size, fields: fields.size, docs: docs.length, complete }),
+    report({
+      defaults: defaults.size,
+      rows: rows.size,
+      fields: fields.size,
+      docs: docs.length,
+      complete,
+      releases,
+    }),
   );
 }
 


### PR DESCRIPTION
## What

Restores the **What's New** page to a full archive: **v3.5 → v1.0**, up from v3.5 → v3.0.

The page was trimmed to v3.0+ this morning, back when it lived in the flat README and space was the binding constraint. On the docs site it isn't, so the trim no longer buys anything — and the page reads better as what it now is: the progression of the card over time.

## How the entries were recovered

The v2.x entries were **recovered from git rather than rewritten**, so the original wording survives. `ec6b466` was the trim commit, but `ec6b466^` had already lost them; walking back 60 README revisions found `afac40e`, which still had the v2.4–v2.0 text intact. v1.2/v1.1/v1.0 had no prior entry and are written fresh from the release notes, deliberately tighter than the later ones.

Each `vX.Y` entry covers its **whole minor line including patches** — the existing convention, now stated on the page itself.

## Notable corrections

**v2.0 was wrong**, not just short. The entry listed per-calendar styling and missed the release's actual headline: v2.0.0 was a rewrite onto a standard `ha-card` structure, which is what made card-mod and themes behave like they do on every other card. The breaking renames (`row_spacing` → `day_spacing`, the `time_location_icon_size` split) were missing too. Both are now there.

**Items cut purely for README length are back**, including the v3.2 rendering and accessibility fixes and the v3.3 relative-times regression for Catalan and Romanian.

**Two dead links fixed.** The release notes pointed at `#v2-1` and `#v2-0`; the site's `slugify` strips dots, so the real anchors are `#v21` and `#v20`.

## Guardrail

The dead anchors above are the interesting part: they were **invisible to CI**. Links into the docs site are written as absolute URLs, and VitePress's dead-link check only resolves relative ones — so `docs:build` passed with both broken.

`check:docs` gains **Check 6**, which closes both gaps:

- every minor line in `RELEASE_NOTES.md` has a `## vX.Y` heading on the page — **and the reverse**, so a typo'd heading is caught too
- every `guide/whats-new#anchor` link across the docs resolves to a real heading, derived from the headings themselves rather than a hardcoded list

Both sides run through the existing `assertFound` helper, so if a parser ever goes blind the check fails loudly instead of passing vacuously.

Verified by mutation, not by assuming a green run means a working check:

| Mutation | Result |
| --- | --- |
| drop the `## v2.1` heading | ✗ `missing 1 release line(s): v2.1` |
| invent a `## v9.9` heading | ✗ `documents v9.9, which has no release notes` |
| restore the `#v2-1` anchor bug | ✗ `not a heading on that page` |

Each mutation asserts it actually landed before the check runs — a mutation that silently fails to apply produces a green run that proves nothing.

## Also

`AGENTS.md` now documents **the two What's New surfaces** and their differing rules — README is a capped highlights reel for HACS, the docs page is the archive — since updating only one is the likeliest way for a release to drift. The release checklist names all three files.

The **README is deliberately unchanged.** It stays v3.x-only under the cap-8 retention rule; growing it to 14 entries would undo this morning's slimming.

## Verification

- `npm run check:docs` → 0 errors, 14 release lines, the 8 known-good warnings
- `npm run docs:build` → clean (`ignoreDeadLinks: false`)
- `npm run lint` → clean
- preview at `/guide/whats-new` → 200, all 14 headings render

One note on that last check: an initial probe reported 11 of 14 and looked like a regression. It was a **stale preview process** serving an older `dist/` — source and `dist/` both had 14 the whole time. Restarting it showed 14. Worth recording because the failure mode looks exactly like real data loss.
