### PR TITLE
docs: use "option" for config keys, and enforce it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,23 @@ the real headings.
 **US spelling** (`color`, `customize`, `behavior`) — the config options themselves are
 US-spelled, so British spelling in the prose around them reads as inconsistent.
 
+**One word for a config key: _option_.** Not parameter, setting, variable, property or
+field. The same key was a "parameter" on one page and an "option" on the next, which
+makes the docs look like they describe two different things. Check 15 enforces this only
+where a backticked name is followed by the wrong noun (`` `start_date` parameter ``),
+because that is the one construction where the meaning is unambiguous. These stay as they
+are and are not flagged:
+
+- **CSS/theme variables** — `var(--primary-color)` genuinely is a variable.
+- **Action parameters** — those belong to Home Assistant's action API, not to this card.
+- **"Core Settings" / "Display Settings"** — these mirror the editor's own section labels
+  in `src/translations/languages/en.json`. Renaming them in the docs would make the text
+  disagree with the UI the reader is looking at.
+- **Event properties** — an event's all-day status and timing are properties of the
+  event, not options of the card.
+- **`whats-new.md` and `RELEASE_NOTES.md`** — a record of what was announced at the time;
+  not rewritten.
+
 ## Release process
 
 1. Bump `version` in `package.json` — it is the single source of truth. Rollup

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ always matches the latest release.
 | 🚀 [Installation](https://calendar-card-pro.alexpfau.com/guide/installation) | Set the card up via HACS or manually |
 | 📌 [Usage](https://calendar-card-pro.alexpfau.com/guide/usage) | Add the card and configure it visually |
 | ✨ [Features & Configuration](https://calendar-card-pro.alexpfau.com/features/editor) | Weather, templates, layout, actions, and more |
-| 📚 [Configuration Variables](https://calendar-card-pro.alexpfau.com/reference/configuration) | Complete reference for every option |
+| 📚 [Configuration Options](https://calendar-card-pro.alexpfau.com/reference/configuration) | Complete reference for every option |
 | 💡 [Examples](https://calendar-card-pro.alexpfau.com/reference/examples) | Ready-made configurations to copy |
 | 🆕 [Release Notes](https://calendar-card-pro.alexpfau.com/RELEASE_NOTES) | Full history of every release |
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -141,7 +141,7 @@ export default defineConfig({
         text: 'Reference',
         collapsed: false,
         items: [
-          { text: 'Configuration Variables', link: '/reference/configuration' },
+          { text: 'Configuration Options', link: '/reference/configuration' },
           { text: 'Examples', link: '/reference/examples' },
         ],
       },

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -18,7 +18,7 @@ entities:
     accent_color: '#ff6347'
 ```
 
-### Available Properties for Entity Configuration Objects
+### Available Options for Entity Configuration Objects
 
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
@@ -37,7 +37,7 @@ entities:
 
 This structure gives you granular control over how information from different calendars is displayed.
 
-These properties are per calendar. For the card-wide options they override, see [Core Settings in the configuration reference](/reference/configuration#core-settings).
+These options are per calendar. For the card-wide options they override, see [Core Settings in the configuration reference](/reference/configuration#core-settings).
 
 ## 🔍 Event Filtering
 
@@ -169,7 +169,7 @@ This feature provides several important behaviors:
 
 ### Controlling Days in Compact Mode
 
-The `compact_days_to_show` parameter lets you display fewer days in compact mode:
+The `compact_days_to_show` option lets you display fewer days in compact mode:
 
 ```yaml
 days_to_show: 7 # Show 7 days when expanded
@@ -180,7 +180,7 @@ This is useful for dashboards where you want an initial view showing just the mo
 
 ### Preserving Complete Days
 
-When using event limits, the `compact_events_complete_days` parameter ensures that partial days are never shown:
+When using event limits, the `compact_events_complete_days` option ensures that partial days are never shown:
 
 ```yaml
 compact_events_to_show: 5

--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -46,5 +46,5 @@ When you open the editor with a configuration that uses deprecated parameters, t
 Click **"Update config..."** to automatically migrate to the current parameter names.
 
 ::: warning YAML Is Not Migrated Automatically
-The upgrader runs **only in the visual editor**. There is no runtime migration, so a deprecated option written directly in YAML is silently ignored and the card falls back to the default — it does not keep working under the old name. If you manage your card in YAML, use the current names from the [Configuration Variables reference](/reference/configuration).
+The upgrader runs **only in the visual editor**. There is no runtime migration, so a deprecated option written directly in YAML is silently ignored and the card falls back to the default — it does not keep working under the old name. If you manage your card in YAML, use the current names from the [Configuration Options reference](/reference/configuration).
 :::

--- a/docs/features/event-content.md
+++ b/docs/features/event-content.md
@@ -26,7 +26,7 @@ When `show_empty_days` is set to `true`, days without events will display a "No 
 
 The default message is deliberately neutral, but an empty day often means something specific to you. A meal-plan calendar reads far better with "Leftovers" than with "No upcoming events", and the point of showing the day at all is to keep the week's layout stable rather than letting it collapse.
 
-The **`empty_day_text`** parameter replaces that message on every day the card renders as empty, and falls back to the translated default when unset. It applies wherever an empty day appears: a gap in the middle of a planned week, an entire range with nothing scheduled, or the single row the card shows for today when `show_empty_days` is off and there is nothing at all to display.
+The **`empty_day_text`** option replaces that message on every day the card renders as empty, and falls back to the translated default when unset. It applies wherever an empty day appears: a gap in the middle of a planned week, an entire range with nothing scheduled, or the single row the card shows for today when `show_empty_days` is off and there is nothing at all to display.
 
 ```yaml
 days_to_show: 7
@@ -40,7 +40,7 @@ By default, empty days are prefixed with a ✓ so they read as "nothing on". Tha
 `empty_day_text` changes only the wording, never the layout. Whether an empty day appears at all — and how many — is decided by `show_empty_days`, and its color by `empty_day_color`.
 :::
 
-The `empty_day_color` parameter lets you customize the color of this message to match your theme or stand out as needed.
+The `empty_day_color` option lets you customize the color of this message to match your theme or stand out as needed.
 
 If you would rather the card disappear completely instead of showing "No upcoming events", set `hide_when_empty: true`. The card removes itself from the dashboard whenever it has no events to display, and surrounding cards close the gap. It reappears automatically as soon as an event shows up, and always stays visible while you are editing the dashboard so you can still select and configure it.
 
@@ -75,7 +75,7 @@ location_color: 'var(--secondary-text-color)'
 location_icon_size: '14px'
 ```
 
-The `remove_location_country` parameter offers three modes:
+The `remove_location_country` option offers three modes:
 
 ```yaml
 # Option 1: Don't remove any country information

--- a/docs/features/layout-appearance.md
+++ b/docs/features/layout-appearance.md
@@ -45,7 +45,7 @@ event_background_opacity: 15 # 0-100 scale for background color intensity
 vertical_line_width: '3px' # Width of the colored event indicator line
 ```
 
-The `event_background_opacity` setting (ranging from 0-100) works together with each calendar's `accent_color` to create semi-transparent backgrounds for events. At 0 (default), events have no background color. Higher values create more intense backgrounds.
+The `event_background_opacity` option (ranging from 0-100) works together with each calendar's `accent_color` to create semi-transparent backgrounds for events. At 0 (default), events have no background color. Higher values create more intense backgrounds.
 
 When styling your calendar, you can use:
 
@@ -69,7 +69,7 @@ date_vertical_alignment: 'top' # Options: 'top', 'middle', 'bottom'
 event_icon_vertical_alignment: 'top' # Options: 'top', 'middle', 'bottom'
 ```
 
-The `date_vertical_alignment` option controls how dates align with their events, which is especially noticeable when a day has many events. The default `middle` setting centers the date between its events, while `top` aligns it with the first event and `bottom` with the last event.
+The `date_vertical_alignment` option controls how dates align with their events, which is especially noticeable when a day has many events. The default `middle` option centers the date between its events, while `top` aligns it with the first event and `bottom` with the last event.
 
 `event_icon_vertical_alignment` does the same job one level down, for the small icons on an event's time, location and description rows. It only becomes visible when one of those wraps onto a second line: the default `middle` centers the icon against the whole block, while `top` lines it up with the first line of text.
 
@@ -141,8 +141,8 @@ today_month_color: '#03a9f4' # Today's month name
 
 The date column appears on the left side of each day's events and helps users quickly identify when events occur. By default, all dates use the base styling, but you can apply special styling to:
 
-- **Weekend days** (Saturday and Sunday) using the `weekend_*` parameters
-- **Today's date** using the `today_*` parameters
+- **Weekend days** (Saturday and Sunday) using the `weekend_*` options
+- **Today's date** using the `today_*` options
 
 When special styling parameters are not specified, they will inherit from the base styling. If today falls on a weekend, today styling takes precedence over weekend styling.
 
@@ -186,7 +186,7 @@ Available indicator types:
 - Emoji characters: Any emoji like `🎯` or `⭐`
 - Image path: Any image URL or local path
 
-The `today_indicator_position` parameter accepts CSS-like position values in the format "x% y%", allowing precise placement of the indicator anywhere within the date column.
+The `today_indicator_position` option accepts CSS-like position values in the format "x% y%", allowing precise placement of the indicator anywhere within the date column.
 
 `today_indicator_size` scales every indicator type — it sets the icon size, the emoji font size and the image width. `today_indicator_color` colors the icon-based types (the dot, `pulse`, `glow` and any `mdi:` icon) and is also the color of the glow itself; emojis and images keep their own colors.
 

--- a/docs/features/start-date-offset.md
+++ b/docs/features/start-date-offset.md
@@ -8,7 +8,7 @@ Calendar Card Pro offers flexible options for controlling which dates are displa
 
 ## 📅 Start Date Configuration
 
-The `start_date` parameter can be configured in multiple ways:
+The `start_date` option can be configured in multiple ways:
 
 - **Fixed dates**: Use a specific date in YYYY-MM-DD format
 

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -75,12 +75,12 @@ Calendar Card Pro offers two ways to customize your card:
 
 2. **YAML Configuration (Advanced)**
    - Use YAML for advanced customization or automation
-   - See [Configuration Variables](/reference/configuration) for every available option
+   - See [Configuration Options](/reference/configuration) for every available option
 
 ## 🚀 Next Steps
 
 - **Explore the Features** - [Core Settings](/features/core-settings), [Layout & Appearance](/features/layout-appearance) and [Event Content](/features/event-content) cover the options most people reach for first
 - **Discover Advanced Capabilities** - Add [weather forecasts](/features/weather), filter events with [blocklists and allowlists](/features/core-settings), or set up [tap and hold actions](/features/actions)
 - **See Examples** - Browse [Examples](/reference/examples) for complete, ready-made setups
-- **Reference Configuration** - Use [Configuration Variables](/reference/configuration) as the complete option reference
+- **Reference Configuration** - Use [Configuration Options](/reference/configuration) as the complete option reference
 - **Get Involved!** - See [Contributing & Roadmap](/contributing) to contribute or view upcoming features

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,4 +1,4 @@
-# Configuration Variables
+# Configuration Options
 
 Every option Calendar Card Pro accepts, grouped by the part of the card it affects.
 
@@ -39,7 +39,7 @@ the card-wide settings for that one calendar:
 `show_location` · `show_description` · `compact_events_to_show` · `blocklist` ·
 `allowlist` · `split_multiday_events`
 
-**→ [Entity configuration options](/features/core-settings#available-properties-for-entity-configuration-objects)** — full table, with filtering examples.
+**→ [Entity configuration options](/features/core-settings#available-options-for-entity-configuration-objects)** — full table, with filtering examples.
 
 ## 🏷️ Header
 

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -795,6 +795,55 @@ function checkSpelling(docs) {
 }
 
 /**
+ * Check 15: a backticked option name is followed by the word "option".
+ *
+ * The docs settled on "option" as the single term for a card configuration key
+ * (106 uses), but prose had drifted into "parameter" (17) and "setting" (39) for
+ * the same concept, so the same key was a "parameter" on one page and an
+ * "option" on the next.
+ *
+ * The rule is deliberately narrow: it only fires on a backticked identifier
+ * immediately followed by the wrong noun. That is the one construction where the
+ * noun unambiguously refers to a card option, which keeps the legitimate uses of
+ * these words intact:
+ *
+ *   - "Home Assistant theme variables (`var(--primary-color)`)" — CSS variables
+ *     really are variables, and the backtick follows rather than precedes.
+ *   - "the parameters are Home Assistant's own" — action parameters, no backtick.
+ *   - "Core Settings" / "Display Settings" — these mirror the editor's own
+ *     section labels in `src/translations/languages/en.json`, so renaming them
+ *     would make the docs disagree with the UI the reader is looking at.
+ *   - "preserves their original properties" — properties of a calendar event,
+ *     not of the config.
+ *
+ * `whats-new.md` and the release notes are exempt: they record what was
+ * announced at the time and are not rewritten.
+ */
+const OPTION_NOUN = /(`[a-z0-9_*]+`\*{0,2}\s+)(parameters|parameter|settings|setting|variables|variable|properties|property)\b/;
+
+function checkOptionNoun(docs) {
+  for (const file of docs) {
+    if (isExcluded(file, STYLE_EXCLUDES)) continue;
+    const rel = relative(ROOT, file);
+    let fenced = false;
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .forEach((line, i) => {
+        if (line.startsWith('```')) {
+          fenced = !fenced;
+          return;
+        }
+        if (fenced || line.trimStart().startsWith('|')) return;
+        const m = line.match(OPTION_NOUN);
+        if (m)
+          error(
+            `${rel}:${i + 1} calls a config key a "${m[2]}"; use "option" (or "options") so one term is used throughout.`,
+          );
+      });
+  }
+}
+
+/**
  * Check 13: option tables are `Option | Type | Default | Description`.
  *
  * `check:docs` reconciles documented defaults against the code for the reference
@@ -925,6 +974,7 @@ function main() {
   checkPageIntros(docs);
   checkSpelling(docs);
   checkOptionTables(docs);
+  checkOptionNoun(docs);
   checkCrossLinks(docs);
 
   process.exit(


### PR DESCRIPTION
Completes the deferred item from #399: the docs used five different words for the same thing.

`option` was already dominant (106 uses in user-facing pages), but prose had drifted into `parameter` (17) and `setting` (39) for the same concept, so a given config key was a "parameter" on one page and an "option" on the next.

### What changed

- **11 prose fixes** — `` `start_date` parameter `` → `` `start_date` option ``, etc.
- **Reference page renamed** to **Configuration Options**. Its own table header already said `Option` (enforced by check 13), so the title was the outlier. Sidebar, the four inbound link texts and the README row updated with it.
- **One concrete mismatch fixed**: `reference/configuration.md` linked with the text *"Entity configuration options"* to a heading titled *"Available **Properties** for Entity Configuration Objects"*. Heading and anchor renamed so link text and destination agree.
- **Check 15** added so this cannot rot.

### What deliberately did not change

The naive sweep would have caused real damage, so the check is scoped to a backticked name followed by the wrong noun — the one construction where the meaning is unambiguous. Verified untouched:

| Kept as-is | Why |
| --- | --- |
| `var(--primary-color)` theme **variables** | Genuinely variables |
| Action **parameters** | Home Assistant's own API, not this card's |
| "Core **Settings**" / "Display **Settings**" | These are the editor's actual section labels in `src/translations/languages/en.json` — renaming them would make the docs contradict the UI on screen |
| Event **properties** | Properties of a calendar event, not options of the card |
| `RELEASE_NOTES.md`, `whats-new.md` | Records of what was announced at the time |

### Verification

- Check 15 **negative-tested both ways**: fires on `` `start_date` parameter ``, stays silent when all four legitimate constructions above are injected into a page.
- `check:docs` clean — **85 internal links still resolve**, which is what confirms the anchor rename propagated rather than breaking the inbound link.
- Rendered `dist/` confirms `<title>Configuration Options | Calendar Card Pro</title>`, matching h1 and sidebar, renamed anchor present, zero stale references repo-wide.
- `npm run lint` and `npm run docs:build` clean.
