### PR TITLE
docs: fix duplicated container titles and table-cell terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,13 @@ blockquote on the docs site — it only works in files GitHub itself renders, i.
 `README.md` and `CONTRIBUTING.md`. Title Case the titles; that part is not checked,
 because `Pair This With show_past_events` would trip any rule strict enough to be useful.
 
+**A container title is not repeated inside the box.** `::: tip Visual Editor` followed by
+a body starting `**Visual Editor:** …` renders the label twice. This is the residue left
+behind when a bare bold blockquote is converted to a titled container and the old inline
+label is not removed — it shipped on three pages that way. The title already labels the
+box, so drop the lead-in and let the sentence start the body. A bold lead-in that says
+something _different_ is fine and is left alone.
+
 **Option tables** are `Option | Type | Default | Description`. Include the Default column
 even when every value is `-`; a missing column reads as an oversight. `core-settings.md`
 documented no defaults at all for its ten per-entity options, and because the harness

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -44,7 +44,7 @@ These options are per calendar. For the card-wide options they override, see [Co
 Calendar Card Pro provides powerful filtering capabilities to control exactly which events appear on your dashboard:
 
 ::: tip Visual Editor
-**Visual Editor:** Set up filters in the entity configuration panels. For each calendar entity, you can specify blocklist/allowlist patterns and configure duplicate filtering from the "Calendar Entities" section.
+Set up filters in the entity configuration panels. For each calendar entity, you can specify blocklist/allowlist patterns and configure duplicate filtering from the "Calendar Entities" section.
 :::
 
 ### Filtering by Event Name

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -27,9 +27,9 @@ entities:
 | `color` | string | `event_color` | Custom color for event titles from this calendar |
 | `accent_color` | string | `accent_color` | Custom color for the vertical line and event background (when `event_background_opacity` is >0) |
 | `label_icon_color` | string | `-` | Custom color for label icons (only applies to `mdi:` and other icon labels) |
-| `show_time` | boolean | `show_time` | Whether to show event times for this calendar (overrides global `show_time` setting) |
-| `show_location` | boolean | `show_location` | Whether to show event locations for this calendar (overrides global `show_location` setting) |
-| `show_description` | boolean | `show_description` | Whether to show event descriptions for this calendar (overrides global `show_description` setting) |
+| `show_time` | boolean | `show_time` | Whether to show event times for this calendar (overrides global `show_time` option) |
+| `show_location` | boolean | `show_location` | Whether to show event locations for this calendar (overrides global `show_location` option) |
+| `show_description` | boolean | `show_description` | Whether to show event descriptions for this calendar (overrides global `show_description` option) |
 | `compact_events_to_show` | number | `compact_events_to_show` | Maximum number of events to show from this calendar (works with global `compact_events_to_show`) |
 | `blocklist`              | string  | RegExp pattern to specify events to exclude (e.g., "Private\|Conference")                                                      |
 | `allowlist`              | string  | RegExp pattern to specify events to include (e.g., "Birthday\|Anniversary")                                                    |

--- a/docs/features/layout-appearance.md
+++ b/docs/features/layout-appearance.md
@@ -151,7 +151,7 @@ When special styling parameters are not specified, they will inherit from the ba
 Calendar Card Pro provides a sophisticated way to highlight the current day with a customizable indicator:
 
 ::: tip Visual Editor
-**Visual Editor:** Configure today indicators in the "Date Display" section, where you can choose from dots, pulses, glows, custom icons, emojis or images, and adjust their position.
+Configure today indicators in the "Date Display" section, where you can choose from dots, pulses, glows, custom icons, emojis or images, and adjust their position.
 :::
 
 ```yaml

--- a/docs/features/weather.md
+++ b/docs/features/weather.md
@@ -3,7 +3,7 @@
 Calendar Card Pro can display weather forecasts alongside your calendar events, providing a complete view of both your schedule and the expected weather conditions.
 
 ::: tip Visual Editor
-**Visual Editor:** Access all weather settings in the "Weather Integration" section of the editor, where you can select your weather entity and configure display options for both date and event positions.
+Access all weather settings in the "Weather Integration" section of the editor, where you can select your weather entity and configure display options for both date and event positions.
 :::
 
 ```yaml

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -833,12 +833,20 @@ function checkOptionNoun(docs) {
           fenced = !fenced;
           return;
         }
-        if (fenced || line.trimStart().startsWith('|')) return;
-        const m = line.match(OPTION_NOUN);
-        if (m)
-          error(
-            `${rel}:${i + 1} calls a config key a "${m[2]}"; use "option" (or "options") so one term is used throughout.`,
-          );
+        if (fenced) return;
+        // Table rows are checked cell by cell: a row like `| \`show_time\` | setting |`
+        // puts the name and the noun in different columns, which is not a sentence
+        // and must not be flagged. Descriptions inside a single cell still are.
+        const cells = line.trimStart().startsWith('|') ? line.split('|') : [line];
+        for (const cell of cells) {
+          const m = cell.match(OPTION_NOUN);
+          if (m) {
+            error(
+              `${rel}:${i + 1} calls a config key a "${m[2]}"; use "option" (or "options") so one term is used throughout.`,
+            );
+            return;
+          }
+        }
       });
   }
 }

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -674,6 +674,9 @@ function checkAdmonitions(docs) {
   for (const file of docs) {
     if (isExcluded(file, STYLE_EXCLUDES)) continue;
     let fenced = false;
+    // Set when a titled container opens, so the first line of its body can be
+    // compared against the title.
+    let openTitle = null;
     readFileSync(file, 'utf8')
       .split('\n')
       .forEach((line, i) => {
@@ -682,6 +685,14 @@ function checkAdmonitions(docs) {
           return;
         }
         if (fenced) return;
+        if (openTitle && line.trim()) {
+          const bold = line.match(/^\*\*(.+?)\*\*:?\s*/);
+          if (bold && bold[1].replace(/:$/, '').trim().toLowerCase() === openTitle.toLowerCase())
+            error(
+              `${relative(ROOT, file)}:${i + 1} repeats the container title "${openTitle}" as a bold lead-in, so it renders twice. The title already labels the box.`,
+            );
+          openTitle = null;
+        }
         if (/^>\s*\[!/.test(line))
           error(
             `${relative(ROOT, file)}:${i + 1} uses a GitHub alert. Use ::: tip Title — containers can be titled.`,
@@ -690,6 +701,8 @@ function checkAdmonitions(docs) {
           error(
             `${relative(ROOT, file)}:${i + 1} opens an untitled container. Give it a descriptive title.`,
           );
+        const opened = line.match(/^:::\s*(?:tip|warning|info|danger|details)\s+(.+?)\s*$/);
+        if (opened) openTitle = opened[1];
         if (/^>\s*\*\*[^*]+:\*\*/.test(line))
           warn(
             `${relative(ROOT, file)}:${i + 1} looks like a callout in a bare blockquote, which gets no callout styling.`,


### PR DESCRIPTION
Two consistency fixes found by verifying the **built site** rather than the source. Both are now enforced.

---

### 1. Duplicated container titles

The weather page rendered **"Visual Editor" twice** in the same purple box — once as the container title, once as a bold lead-in inside it:

```
::: tip Visual Editor
**Visual Editor:** Access all weather settings in the …
:::
```

This is residue from converting bare-blockquote callouts into titled containers: the old inline label was left in place when the title was added. Same thing on `core-settings.md` and `layout-appearance.md` — **3 instances**, all `Visual Editor`.

The title already labels the box, so the lead-in is dropped and the sentence starts the body.

`checkAdmonitions()` now compares the first body line against the container title. A *different* bold lead-in is left alone, since that is a legitimate way to open a callout.

### 2. Option terminology inside table cells

Check 15 (from #400) skipped table rows wholesale, which hid three real violations in the per-entity table in `core-settings.md`:

> Whether to show event times for this calendar (overrides global `show_time` **setting**)

`show_time` is a card config option, so this is exactly the drift #400 was meant to end — it just happened to sit inside a table cell.

Rows are now split on the pipe and **each cell checked on its own**, which preserves the original reason for skipping tables: a row like `| \`show_time\` | boolean | setting |` puts the name and the noun in *different columns*, is not a sentence, and is still not flagged.

---

### Verification

Every branch of both checks was negative-tested:

| Case | Expected | Result |
| --- | --- | --- |
| Bold lead-in repeats the title | fires | ✅ |
| Bold lead-in differs from the title | silent | ✅ |
| Blank line between title and lead-in | fires | ✅ |
| Option name and noun in different cells | silent | ✅ |
| Violation inside a single cell | fires | ✅ |
| Plain prose violation | fires | ✅ |

`check:docs` clean, 85 internal links still resolve, `docs:build` clean. Confirmed in the rendered HTML that the callout now reads "Visual Editor" once.
