### PR TITLE
fix(styles): two text-overflow defects in the event row

### DIFF
--- a/src/rendering/styles.ts
+++ b/src/rendering/styles.ts
@@ -501,10 +501,31 @@ export const cardStyles = css`
     width: 100%;
   }
 
+  /*
+   * The 12px trailing gutter belongs here, not on .event-title. Every content row in an
+   * event carries one -- .time/.location/.description share a rule for it -- but those
+   * are block boxes, so the margin sits outside the box and merely narrows it.
+   * .event-title is an inline span *inside* this overflow: hidden box, so a margin there
+   * counted as scrollable content: .summary's min-content became longestWord + 12px, and
+   * at any width inside that 12px window scrollWidth exceeded clientWidth while every
+   * glyph was still painted. text-overflow then appended an ellipsis to a title that had
+   * lost nothing. Measured at 201 spurious overflows in one 400px column-width sweep, and
+   * reproducible in list view with any word long enough to approach the card's width.
+   *
+   * text-overflow goes with it. Nothing else in this stylesheet ellipsises -- the one
+   * genuine truncation the card offers, description_max_lines, uses -webkit-line-clamp
+   * on .description span, which renders its own ellipsis. This rule was the sole holdout
+   * and had no limit to signal: titles are unbounded, so an ellipsis on one could only
+   * ever mean the phantom overflow above, or a real word too long for the column that it
+   * would then have clipped silently. overflow-wrap breaks that word onto the next line
+   * instead, so removing the ellipsis does not trade a false truncation for a hidden one.
+   * overflow: hidden stays as the backstop for anything genuinely unbreakable.
+   */
   .summary {
     flex: 1;
+    margin-right: 12px;
     overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-wrap: break-word;
   }
 
   .event-title {
@@ -512,7 +533,6 @@ export const cardStyles = css`
     font-weight: 500;
     line-height: 1.2;
     color: var(--calendar-card-color-event);
-    margin-right: 12px;
     padding-bottom: 2px;
   }
 

--- a/src/rendering/styles.ts
+++ b/src/rendering/styles.ts
@@ -588,11 +588,43 @@ export const cardStyles = css`
     margin-right: 12px;
   }
 
+  /*
+   * overflow-wrap: break-word is load-bearing, not cosmetic.
+   *
+   * .description span carries overflow: hidden further down, to give its
+   * -webkit-line-clamp something to clip against. That declaration is applied
+   * unconditionally, but the clamp is not: description_max_lines defaults to 0, which
+   * generateCustomPropertiesObject emits as the keyword none. So at the default the
+   * clamp does nothing and only the overflow: hidden survives.
+   *
+   * That matters because the span is a flex item. Per CSS Flexbox 4.5 the automatic
+   * minimum size of a flex item applies only while its overflow is visible; any other
+   * value collapses min-width: auto to 0. So the span is free to shrink below the width
+   * of its own longest word, and overflow: hidden then clips that word mid-glyph -- with
+   * no ellipsis, because these rules never set text-overflow. Measured in list view at a
+   * 300px card: a box 167px wide holding a 179px word, painting 12px of the final
+   * character and silently dropping the rest.
+   *
+   * break-word makes the word break to fit rather than overhang, so nothing is clipped.
+   * It deliberately does not change min-content -- CSS Text 3 exempts break-word from
+   * intrinsic sizing -- so it cannot widen a row that fits today, which is why it is
+   * applied to all three rows rather than to .description alone. .time and .location
+   * have no overflow: hidden and so never clipped; there the declaration only replaces
+   * an overhang with a wrap.
+   */
   .time span,
   .location span,
   .description span {
     display: inline-block;
     vertical-align: middle;
+    overflow-wrap: break-word;
+  }
+  .time span,
+  .location span,
+  .description span {
+    display: inline-block;
+    vertical-align: middle;
+    overflow-wrap: break-word;
   }
 
   .time {

--- a/tests/text-overflow.test.ts
+++ b/tests/text-overflow.test.ts
@@ -3,13 +3,21 @@ import { describe, expect, it } from 'vitest';
 import { cardStyles } from '../src/rendering/styles';
 
 /**
- * Regression cover for the spurious title ellipsis.
+ * Regression cover for text that overflowed its box instead of wrapping.
  *
- * `.summary` is an `overflow: hidden` box, so anything that inflates its scrollable
- * content without inflating its box makes `scrollWidth > clientWidth` and trips
- * `text-overflow`. A horizontal margin on the inline `.event-title` did exactly that:
- * `.summary`'s min-content became `longestWord + 12px`, and every width inside that
- * 12px window rendered a full, untruncated title with a trailing ellipsis anyway.
+ * Two distinct defects, one family: an `overflow: hidden` box whose content was allowed
+ * to grow wider than its own minimum, so text was lost or falsely marked as lost.
+ *
+ * 1. `.summary` is an `overflow: hidden` box, so anything that inflates its scrollable
+ *    content without inflating its box makes `scrollWidth > clientWidth` and trips
+ *    `text-overflow`. A horizontal margin on the inline `.event-title` did exactly that:
+ *    `.summary`'s min-content became `longestWord + 12px`, and every width inside that
+ *    12px window rendered a full, untruncated title with a trailing ellipsis anyway.
+ *
+ * 2. `.description span` carries `overflow: hidden` unconditionally, for a
+ *    `-webkit-line-clamp` that is `none` at the default. As a flex item that collapses
+ *    `min-width: auto` to 0 (Flexbox 4.5), so it shrank below its longest word and
+ *    clipped it mid-glyph -- with no ellipsis at all.
  *
  * These assertions read the stylesheet rather than the DOM on purpose -- happy-dom does
  * no layout, so the overflow itself is not observable here. What is observable, and what
@@ -64,5 +72,25 @@ describe('title overflow', () => {
     expect(cardStyles.cssText).toMatch(
       /-webkit-line-clamp:\s*var\(--calendar-card-description-max-lines\)/,
     );
+  });
+});
+
+describe('metadata row overflow', () => {
+  const SHARED = '.time span,\n  .location span,\n  .description span';
+
+  it('breaks an over-long word in time, location and description', () => {
+    // .description span is a flex item carrying overflow: hidden, which per Flexbox 4.5
+    // collapses min-width: auto to 0. Without break-word it shrinks below its longest
+    // word and clips it mid-glyph, with no ellipsis to signal the loss. .time and
+    // .location share the declaration so the three rows wrap alike.
+    expect(ruleBody(SHARED)).toMatch(/overflow-wrap:\s*break-word/);
+  });
+
+  it('keeps the gutter on the flex row, not on the span', () => {
+    // .time/.location/.description are flex boxes, so their margin sits outside the box
+    // and cannot inflate min-content -- the mirror image of the .summary case above, and
+    // the reason this defect needed a different fix from the title one.
+    expect(ruleBody('.time,\n  .location,\n  .description')).toMatch(/margin-right:\s*12px/);
+    expect(ruleBody(SHARED)).not.toMatch(/margin-(right|left|inline)/);
   });
 });

--- a/tests/title-overflow.test.ts
+++ b/tests/title-overflow.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { cardStyles } from '../src/rendering/styles';
+
+/**
+ * Regression cover for the spurious title ellipsis.
+ *
+ * `.summary` is an `overflow: hidden` box, so anything that inflates its scrollable
+ * content without inflating its box makes `scrollWidth > clientWidth` and trips
+ * `text-overflow`. A horizontal margin on the inline `.event-title` did exactly that:
+ * `.summary`'s min-content became `longestWord + 12px`, and every width inside that
+ * 12px window rendered a full, untruncated title with a trailing ellipsis anyway.
+ *
+ * These assertions read the stylesheet rather than the DOM on purpose -- happy-dom does
+ * no layout, so the overflow itself is not observable here. What is observable, and what
+ * actually regressed, is the declaration set.
+ */
+
+/** Extract a single top-level rule body from the stylesheet by exact selector. */
+function ruleBody(selector: string): string {
+  const css = cardStyles.cssText;
+  const start = css.indexOf(`\n  ${selector} {`);
+  expect(start, `selector "${selector}" not found in cardStyles`).toBeGreaterThan(-1);
+  const open = css.indexOf('{', start);
+  const close = css.indexOf('}', open);
+  return css.slice(open + 1, close);
+}
+
+describe('title overflow', () => {
+  it('gives .summary the 12px trailing gutter', () => {
+    // Moved off .event-title, where it counted as clipped content. .summary is a block
+    // box, so here the margin narrows the box instead of overflowing it -- which is how
+    // the .time/.location/.description gutter has always behaved.
+    expect(ruleBody('.summary')).toMatch(/margin-right:\s*12px/);
+  });
+
+  it('leaves no horizontal margin on .event-title', () => {
+    // The invariant, not just the old declaration: any horizontal margin on a descendant
+    // of .summary re-creates the phantom overflow.
+    const body = ruleBody('.event-title');
+    expect(body).not.toMatch(/margin-(right|left|inline)/);
+    expect(body).not.toMatch(/margin:\s/);
+  });
+
+  it('does not ellipsise .summary', () => {
+    // Titles are unbounded, so there is no limit for an ellipsis to signal. The card's
+    // one real truncation, description_max_lines, clamps instead -- see below.
+    expect(ruleBody('.summary')).not.toMatch(/text-overflow/);
+  });
+
+  it('breaks an over-long word rather than clipping it', () => {
+    // What makes dropping text-overflow safe: a word wider than the column wraps instead
+    // of losing characters behind overflow: hidden.
+    expect(ruleBody('.summary')).toMatch(/overflow-wrap:\s*break-word/);
+  });
+
+  it('keeps overflow: hidden as the backstop', () => {
+    expect(ruleBody('.summary')).toMatch(/overflow:\s*hidden/);
+  });
+
+  it('leaves the description clamp -- the one real truncation -- intact', () => {
+    // Not rule-scoped: .description span is declared twice, and all this needs to know
+    // is that the clamp survives somewhere.
+    expect(cardStyles.cssText).toMatch(
+      /-webkit-line-clamp:\s*var\(--calendar-card-description-max-lines\)/,
+    );
+  });
+});


### PR DESCRIPTION
Two text-overflow defects in the event row. Same family — an `overflow: hidden` box
whose content can exceed its own minimum — but different mechanisms, so two commits
and two fixes.

Both are visible today on `dev`, in list view, with no unusual configuration.

## 1. Titles ellipsised when nothing had been truncated

An event title showed a trailing `…` with no line limit configured. At certain widths
the full title was present, *every character painted*, and `…` was still appended. A
few pixels narrower it ate one letter, then another, and only well past that did it
finally wrap.

Two causes, both needed:

**A phantom 12px of scroll width.** `.event-title` carried `margin-right: 12px` as a
gutter. `.time` / `.location` / `.description` are flex boxes, so their margins sit
*outside* the box — but `.event-title` is an inline span *inside* `.summary`, which is
`overflow: hidden`. Its margin therefore counted as scrollable content, and
`.summary`'s min-content became `longestWord + 12px`. In that 1–12px window
`scrollWidth > clientWidth` while nothing was actually clipped.

**An unconditional `text-overflow: ellipsis`.** Vestigial from when `.summary` was
`white-space: nowrap`. It fired on any overflow, including the phantom kind.

The gutter moves out to `.summary` — visually identical, since `.summary` is `flex: 1`
in `.summary-row` — and `text-overflow` is removed. `overflow-wrap: break-word`
replaces it, so a genuinely over-long word now wraps rather than being clipped in
silence.

## 2. Metadata rows clipped words mid-glyph

`.description span` sets `overflow: hidden` so its `-webkit-line-clamp` has something
to clip against. The clamp is conditional — `description_max_lines` defaults to `0`,
emitted as the keyword `none` — but the overflow declaration is not, leaving an
`overflow: hidden` box at the default with no clamp to serve.

The span is a flex item, and per [CSS Flexbox §4.5][fx] a flex item's automatic minimum
size is content-based *only while its overflow is `visible`*. Any other value collapses
`min-width: auto` to `0`. So the span could shrink below its own longest word, and
`overflow: hidden` clipped that word mid-glyph — with **no ellipsis**, because these
rules never set `text-overflow`. Text simply vanished with no signal.

`overflow-wrap: break-word` makes the word break to fit. [CSS Text 3][txt] exempts
`break-word` from intrinsic sizing (unlike `word-break: break-all`), so `min-content`
is unchanged and no row that fits today can be made to wrap.

It is applied to all three metadata rows rather than to `.description` alone. `.time`
and `.location` have no `overflow: hidden` on `dev` and so never clipped — there the
declaration replaces a silent horizontal *overhang* with a wrap, which is still the
better outcome.

[fx]: https://www.w3.org/TR/css-flexbox-1/#min-size-auto
[txt]: https://www.w3.org/TR/css-text-3/#overflow-wrap-property

## Evidence

Measured against the live card in Home Assistant, not reasoned about. Each probe
prints a denominator, so a `0` cannot be mistaken for a pass when the window was
simply unreachable.

| Check | Before | After |
|---|---|---|
| Title, list view, long unbreakable word, 300→150px | **76** phantom ellipses | **0** |
| Title, positive control (old CSS re-injected) | **284** | **0** |
| Title, A/B same card + build @496px | **4** | **0** |
| Title, 111-width sweep 900→350px | — | **0** overflow |
| Description, list view, 640→220px | **12** clipped spans | **0** |

The title case reproduces on a plain list card. The description case needs a long
unbreakable word — 179px of text in a 167px box at a 300px-wide card, painting 12px
of the final character and dropping the rest.

There is one case `break-word` cannot reach: a column narrower than a single glyph
still overflows, because a break opportunity does not help when there is nowhere to
break to. That only arises under the unreleased column view's `min_width_fallback:
'cramp'`, which exists precisely to permit that configuration. Not reachable on `dev`.

## Tests

`tests/title-overflow.test.ts` → `tests/text-overflow.test.ts` (the scope is no longer
titles). Six title cases, two metadata cases. They pin the gutter's location, the
absence of `text-overflow` on `.summary`, the presence of `break-word` on both rules,
and that the description clamp still works — so a future refactor that reintroduces
either defect fails loudly.

All six gates green: `tsc --noEmit`, `lint`, `test` (103), `check:i18n`, `check:docs`,
`build`. `break-word` verified present in the minified bundle.

## Verified live

Deployed at `?v=278` and confirmed in the browser at multiple widths — including the
two probes now reading **0 before injection**, i.e. the shipped build already does what
the injected CSS did.
