### PR TITLE
fix(config): report removed config keys instead of ignoring them silently

### DIFF
--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -46,5 +46,7 @@ When you open the editor with a configuration that uses deprecated parameters, t
 Click **"Update config..."** to automatically migrate to the current parameter names.
 
 ::: warning YAML Is Not Migrated Automatically
-The upgrader runs **only in the visual editor**. There is no runtime migration, so a deprecated option written directly in YAML is silently ignored and the card falls back to the default — it does not keep working under the old name. If you manage your card in YAML, use the current names from the [Configuration Options reference](/reference/configuration).
+The upgrader runs **only in the visual editor**. There is no runtime migration, so a deprecated option written directly in YAML is ignored and the card falls back to the default — it does not keep working under the old name.
+
+The card does tell you when this happens: each deprecated option found in your configuration is reported in the browser console, naming the current option to use in its place. Open your browser's developer tools and look for messages prefixed with `📅 Calendar Card Pro`. If you manage your card in YAML, use the current names from the [Configuration Options reference](/reference/configuration).
 :::

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -715,12 +715,13 @@ class CalendarCardPro extends LitElement {
   setConfig(config: Partial<Types.Config>): void {
     const previousConfig = this.config;
 
-    // First do the standard merging
-    let mergedConfig = { ...Config.DEFAULT_CONFIG, ...config };
+    // Inspect the raw config before the merge — afterwards every key is present and a
+    // removed one can no longer be told apart from one the user never wrote.
+    for (const message of Config.findDeprecatedKeys(config)) {
+      Logger.deprecation(message);
+    }
 
-    //============================================================================
-    // END OF DEPRECATED PARAMETERS HANDLING
-    //============================================================================
+    const mergedConfig = { ...Config.DEFAULT_CONFIG, ...config };
 
     this.config = mergedConfig;
     this.config.entities = Config.normalizeEntities(this.config.entities);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -173,6 +173,73 @@ export function toValidNumber(value: unknown, minimum = 0): number | undefined {
 }
 
 /**
+ * Config keys removed in the v3.0.0 API cleanup, mapped to their replacements.
+ *
+ * The removal was deliberate — the runtime no longer understands these names. The
+ * visual editor offers a one-click upgrade for them, but a user who configures the
+ * card in YAML and never opens the editor gets no signal at all: the value is simply
+ * ignored and the replacement key silently takes its default. `warnDeprecatedKeys`
+ * closes that gap by naming the replacement on the console.
+ *
+ * This is the single source of truth — the editor's upgrade path reads it too, so a
+ * key can never be offered for migration in one place and unknown in the other.
+ */
+export const DEPRECATED_CONFIG_MAP: Readonly<Record<string, string>> = {
+  max_events_to_show: 'compact_events_to_show',
+  vertical_line_color: 'accent_color',
+  horizontal_line_width: 'day_separator_width',
+  horizontal_line_color: 'day_separator_color',
+  row_spacing: 'day_spacing',
+};
+
+/**
+ * Per-entity config keys removed in the same cleanup, mapped to their replacements.
+ */
+export const DEPRECATED_ENTITY_CONFIG_MAP: Readonly<Record<string, string>> = {
+  max_events_to_show: 'compact_events_to_show',
+};
+
+/**
+ * Reports removed config keys found in the raw user configuration.
+ *
+ * Reads the config *as the user wrote it*, before the merge with `DEFAULT_CONFIG`
+ * fills every key in — afterwards a removed key is indistinguishable from an absent
+ * one. Entity entries are inspected in place because `normalizeEntities` has not run
+ * yet and a string entry carries no options.
+ *
+ * @param config - Raw configuration passed to `setConfig`
+ * @returns Human-readable messages, one per removed key found; empty when the config is clean
+ */
+export function findDeprecatedKeys(config: Partial<Types.Config>): string[] {
+  const raw = config as Record<string, unknown>;
+  const messages: string[] = [];
+
+  for (const [oldKey, newKey] of Object.entries(DEPRECATED_CONFIG_MAP)) {
+    if (oldKey in raw) {
+      messages.push(`"${oldKey}" was removed in v3.0.0 and is being ignored — use "${newKey}"`);
+    }
+  }
+
+  const entities = raw.entities;
+  if (Array.isArray(entities)) {
+    entities.forEach((entity, index) => {
+      if (typeof entity !== 'object' || entity === null) return;
+      const entry = entity as Record<string, unknown>;
+
+      for (const [oldKey, newKey] of Object.entries(DEPRECATED_ENTITY_CONFIG_MAP)) {
+        if (oldKey in entry) {
+          messages.push(
+            `"${oldKey}" on entities[${index}] was removed in v3.0.0 and is being ignored — use "${newKey}"`,
+          );
+        }
+      }
+    });
+  }
+
+  return messages;
+}
+
+/**
  * Sanitizes every numeric option so invalid values fall back to their defaults.
  *
  * Applied on each `setConfig` call, which means configurations already saved with an

--- a/src/rendering/editor.ts
+++ b/src/rendering/editor.ts
@@ -63,17 +63,11 @@ function getInputTag(): ReturnType<typeof literal> {
   return haInputTag;
 }
 
-// Deprecated parameter mappings for config upgrade
-const DEPRECATED_CONFIG_MAP: Record<string, string> = {
-  max_events_to_show: 'compact_events_to_show',
-  vertical_line_color: 'accent_color',
-  horizontal_line_width: 'day_separator_width',
-  horizontal_line_color: 'day_separator_color',
-  row_spacing: 'day_spacing',
-};
-const DEPRECATED_ENTITY_CONFIG_MAP: Record<string, string> = {
-  max_events_to_show: 'compact_events_to_show',
-};
+// Deprecated parameter mappings for config upgrade.
+// Re-exported from config.ts so the editor's upgrade path and the runtime's
+// deprecation notice can never disagree about which keys are dead.
+const DEPRECATED_CONFIG_MAP = Config.DEPRECATED_CONFIG_MAP;
+const DEPRECATED_ENTITY_CONFIG_MAP = Config.DEPRECATED_ENTITY_CONFIG_MAP;
 
 /**
  * Matches an absolute start_date the date picker can represent: a plain

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -209,6 +209,29 @@ export function warn(message: string, ...data: unknown[]): void {
 }
 
 /**
+ * Log a configuration deprecation notice.
+ *
+ * Deliberately ungated, unlike `warn`. Production builds ship with the log level
+ * pinned to ERROR (`rollup.config.mjs` rewrites `CURRENT_LOG_LEVEL` to 0), so a
+ * `warn` call reaches nobody outside a dev build. That is the right trade for the
+ * running commentary — a stale cache entry or a failed unsubscribe is not the user's
+ * problem — but it is the wrong trade here: this message reports a setting the user
+ * wrote by hand that the card is throwing away, and they cannot act on advice they
+ * never see.
+ *
+ * Routed through `console.warn` rather than `error` because it is not an error: the
+ * card renders correctly, just not as configured.
+ */
+export function deprecation(message: string, ...data: unknown[]): void {
+  const [formattedMsg, styleArg] = formatLogMessage(message, LOG_STYLES.warn);
+  if (data.length > 0) {
+    console.warn(formattedMsg, styleArg, ...data);
+  } else {
+    console.warn(formattedMsg, styleArg);
+  }
+}
+
+/**
  * Log an info message
  */
 export function info(message: string, ...data: unknown[]): void {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_CONFIG,
+  DEPRECATED_CONFIG_MAP,
+  findDeprecatedKeys,
   hasConfigChanged,
   normalizeEntities,
   normalizeNumericOptions,
@@ -247,5 +249,62 @@ describe('hasConfigChanged', () => {
     } as unknown as Types.Config;
 
     expect(hasConfigChanged(previous, current)).toBe(false);
+  });
+});
+
+/**
+ * Removed-key reporting.
+ *
+ * The five keys below were deleted from the runtime in the v3.0.0 API cleanup
+ * (`ac801e0`), but the visual editor kept offering a one-click upgrade for them.
+ * A user who writes YAML and never opens the editor therefore got no signal:
+ * the value was ignored and its replacement silently took the default. These
+ * pin the reporting that closes that gap.
+ *
+ * Note the shape being tested — `findDeprecatedKeys` reads the *raw* config, not
+ * a merged one, because after the `DEFAULT_CONFIG` spread every key is present
+ * and a removed key can no longer be distinguished from an absent one.
+ */
+describe('findDeprecatedKeys', () => {
+  it('says nothing about a clean config', () => {
+    expect(findDeprecatedKeys({ entities: ['calendar.a'] } as Types.Config)).toEqual([]);
+  });
+
+  it('names the replacement for every removed top-level key', () => {
+    for (const [oldKey, newKey] of Object.entries(DEPRECATED_CONFIG_MAP)) {
+      const [message, ...rest] = findDeprecatedKeys({ [oldKey]: 'x' } as unknown as Types.Config);
+
+      expect(rest).toEqual([]);
+      expect(message).toContain(oldKey);
+      // The replacement is the actionable half — a notice without it is just noise.
+      expect(message).toContain(newKey);
+    }
+  });
+
+  it('reports a removed key on a per-entity object, with its index', () => {
+    const messages = findDeprecatedKeys({
+      entities: [{ entity: 'calendar.a' }, { entity: 'calendar.b', max_events_to_show: 3 }],
+    } as unknown as Types.Config);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('entities[1]');
+    expect(messages[0]).toContain('compact_events_to_show');
+  });
+
+  it('tolerates string entities, which carry no options', () => {
+    // normalizeEntities has not run at this point, so plain strings are still present.
+    expect(findDeprecatedKeys({ entities: ['calendar.a'] } as Types.Config)).toEqual([]);
+  });
+
+  it('survives a null entity entry rather than throwing during setConfig', () => {
+    // typeof null === 'object', so the guard has to test for null explicitly.
+    expect(
+      findDeprecatedKeys({ entities: [null, 'calendar.a'] } as unknown as Types.Config),
+    ).toEqual([]);
+  });
+
+  it('reports a top-level key set to a falsy value', () => {
+    // `in` rather than truthiness: `row_spacing: 0` is still a setting being discarded.
+    expect(findDeprecatedKeys({ row_spacing: 0 } as unknown as Types.Config)).toHaveLength(1);
   });
 });

--- a/tests/logger-deprecation.test.ts
+++ b/tests/logger-deprecation.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Deprecation notices must survive a production build.
+ *
+ * `rollup.config.mjs` rewrites `CURRENT_LOG_LEVEL` to 0 (ERROR) for production, so
+ * every `Logger.warn` in the codebase is dead weight in the shipped bundle. That is
+ * the right trade for internal commentary, but a removed config key is a setting the
+ * user wrote by hand and the card is discarding — advice they never see is no advice.
+ *
+ * `Logger.deprecation` is therefore deliberately ungated. This pins that, because the
+ * obvious "tidy-up" is to route it through `simpleLog` like its neighbours, which
+ * would silently restore the bug in production while every dev build still looked
+ * correct. The level is mocked at module load since `currentLogLevel` is captured
+ * once, at import time, and has no setter.
+ */
+describe('Logger.deprecation', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('still logs when the log level is pinned to ERROR, as production ships it', async () => {
+    vi.resetModules();
+    vi.doMock('../src/config/constants', async () => {
+      const actual =
+        await vi.importActual<typeof import('../src/config/constants')>('../src/config/constants');
+      return { ...actual, LOGGING: { ...actual.LOGGING, CURRENT_LOG_LEVEL: 0 } };
+    });
+
+    const Logger = await import('../src/utils/logger');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    // Control: at this level an ordinary warning must be suppressed. If this ever
+    // starts logging, the mock stopped working and the assertion below proves nothing.
+    Logger.warn('ordinary warning');
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    Logger.deprecation('"row_spacing" was removed');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain('row_spacing');
+  });
+});


### PR DESCRIPTION
## What

Five config keys were removed from the runtime in the v3.0.0 API cleanup (`ac801e0`):

| Removed | Replacement |
|---|---|
| `max_events_to_show` | `compact_events_to_show` |
| `vertical_line_color` | `accent_color` |
| `horizontal_line_width` | `day_separator_width` |
| `horizontal_line_color` | `day_separator_color` |
| `row_spacing` | `day_spacing` |

That removal was deliberate, and the visual editor still offers a one-click upgrade for them. **This PR does not change that** — the keys stay dead and the value is still discarded.

What it changes is that the card now *says so*.

## Why

The gap is the user who configures the card in YAML and never opens the editor. For them the key is not "removed", it is **ignored**: the value is dropped, the replacement key takes its default, and nothing anywhere reports it. The failure is silent and purely cosmetic, so it presents as *"the update changed my styling"* rather than as a config error.

`docs/features/editor.md` already documented this in as many words — *"a deprecated option written directly in YAML is silently ignored"*. This removes the word `silently`.

## How

`setConfig` reports each removed key it finds and names the replacement:

```
📅 Calendar Card Pro  "row_spacing" was removed in v3.0.0 and is being ignored — use "day_spacing"
📅 Calendar Card Pro  "max_events_to_show" on entities[1] was removed in v3.0.0 and is being ignored — use "compact_events_to_show"
```

Three details worth review:

**It inspects the raw config, before the `DEFAULT_CONFIG` merge.** Afterwards every key is present and a removed key is indistinguishable from one the user never wrote.

**It routes through a new `Logger.deprecation`, not `Logger.warn`.** This is the part that would have been easy to get wrong: `rollup.config.mjs` pins `CURRENT_LOG_LEVEL` to `0` in production, so *every* `Logger.warn` in the codebase is dead weight in the shipped bundle. A `warn` here would have looked correct in a dev build and stayed silent for every HACS user — i.e. silent for exactly the people the fix is for. `deprecation` is therefore ungated, and uses `console.warn` rather than `error` because nothing is broken: the card renders fine, just not as configured.

**The key map moves to `config.ts`** and the editor now reads it from there, so a key can no longer be offered for migration in one place and unknown in the other.

Also removes the `END OF DEPRECATED PARAMETERS HANDLING` banner and a non-reassigned `let`, both orphaned by `ac801e0`.

## Verification

Live-tested against Home Assistant on a purpose-built tab (dev build `?v=281`), with a card per case:

- top-level removed key → **1** notice ✅
- removed key on `entities[1]` → **1** notice, **with the correct index** ✅
- three removed keys at once → **3** separate notices, each naming its own replacement ✅
- clean config using the modern names → **0** notices ✅ (the false-positive control)
- editor still renders *"Deprecated config options detected."* and offers the upgrade ✅ — the refactor most likely to break it

Console reported exactly 5 warnings and no errors.

Gates: `tsc --noEmit`, `lint`, `test` (110 passing, 7 files), `check:i18n`, `check:docs`, `build`, `docs:build` — all green.

**The ungating is pinned by a test, and the test is verified by mutation:** rewriting `deprecation` to route through `simpleLog` like its neighbours makes it fail. Without that, the obvious future tidy-up would silently restore the bug in production while every dev build still looked correct.

Bundle: **+542 bytes** raw against `dev`.

## Noticed while testing, not addressed here

- **The `ccp-release-header` capture view uses `max_events_to_show`.** Its release screenshots have been rendering without that limit since v3.0.0. Frozen view, left untouched.
- **All 17 `Logger.warn` call sites are invisible in production**, including genuinely user-actionable ones such as `Invalid start_date … falling back to today` and `Could not load calendar(s)`. Roughly half look like they should reach users and half are internal noise, so raising the production log level is a real judgement call rather than a drive-by — flagging it rather than bundling it.
