### PR TITLE
docs(weather-i18n): name the gap neither diagnostic can see, and pin it

### DIFF
--- a/src/utils/weather-i18n.ts
+++ b/src/utils/weather-i18n.ts
@@ -180,6 +180,25 @@ const reportedFailures = new Set<string>();
  * same shape of silent failure the raw-token case in `formatCondition` already guards,
  * one layer up.
  *
+ * **What that report can and cannot see**, which is worth stating because the two are
+ * easy to swap. Home Assistant fills every key server-side, so a key genuinely absent
+ * from a fetched payload means a *non-standard condition token* — a third-party weather
+ * integration emitting something outside the fifteen — and that is the case this catches.
+ *
+ * It cannot see the case that actually occurs. An untranslated condition comes back as a
+ * **present key holding the English string**, so `text` is truthy and nothing fires.
+ * Measured on 2026.8.1, sampling eight card languages: all returned 15/15 keys, and
+ * seven of them carried `windy-variant` in English (`is` carried `exceptional` too). A
+ * Portuguese card therefore reads `Windy, cloudy` with no report anywhere, and by
+ * construction there is nothing here to detect it with — the value is not wrong, it is
+ * Home Assistant's own fallback, and telling it apart would mean fetching English as a
+ * second payload to compare against. Deliberately not done: it is a gap in Home
+ * Assistant's translations rather than in the card, the card cannot close it, and the
+ * comparison would cost a request on a path built to avoid needless ones.
+ *
+ * `weather-condition-language.test.ts` pins that silence as behaviour, so this stays a
+ * decision someone has to revisit on purpose rather than a comment that quietly rots.
+ *
  * @param haLanguage Home Assistant language code, from `conditionLanguage`
  * @param condition Raw condition token, e.g. `partlycloudy`
  * @returns The translated text, or `undefined` when the language is not cached yet or

--- a/tests/weather-condition-language.test.ts
+++ b/tests/weather-condition-language.test.ts
@@ -247,6 +247,26 @@ describe('weather conditions follow the card language', () => {
       expect(conditionLanguage(hass, 'en')).toBe('en');
       expect(conditionLanguage(undefined, 'en')).toBeUndefined();
     });
+
+    /**
+     * `toHaLanguage` maps any region correctly, including for languages the card does
+     * not ship — but nothing outside the card's own translation map can reach it, because
+     * `getEffectiveLanguage` resolves an unknown code away first. `pt-br` is the useful
+     * illustration: the casing rule handles it, and the card would still fetch German on
+     * a German instance, because `pt-br` is not one of its 35 languages.
+     *
+     * Both halves are worth pinning. The mapping generalises, and adding a language to
+     * the card is what makes the generalisation reachable — not a change here.
+     */
+    it('maps a region the card does not ship, but cannot route to it', () => {
+      expect(toHaLanguage('pt-br')).toBe('pt-BR');
+
+      const hass = germanHass();
+      expect(conditionLanguage(hass, 'pt-br')).toBeUndefined();
+
+      // `pt` is a card language, so this one does route.
+      expect(conditionLanguage(hass, 'pt')).toBe('pt');
+    });
   });
 
   /**
@@ -435,6 +455,49 @@ describe('weather conditions follow the card language', () => {
 
       const incomplete = debug.mock.calls.filter((call) => String(call[0]).includes('without'));
       expect(incomplete).toHaveLength(0);
+    });
+
+    /**
+     * The limit of both diagnostics, pinned as behaviour rather than left in a comment.
+     *
+     * Home Assistant fills gaps per **key**, so an untranslated condition arrives as a
+     * present key holding the English string. The structural check sees 15/15 and says
+     * nothing; the per-condition report sees a truthy value and says nothing. Measured
+     * on 2026.8.1 across eight card languages: all returned 15/15, and seven carried
+     * `windy-variant` in English — so a Portuguese card really does read
+     * `Windy, cloudy`, silently, and this is the shape it arrives in.
+     *
+     * Asserting the silence is the point. It is a gap in Home Assistant's translations,
+     * not in the card, and closing it would mean fetching English as a second payload
+     * purely to compare. If anyone ever decides that trade is worth making, this test
+     * fails and forces the decision to be deliberate.
+     */
+    it('cannot see an untranslated condition that arrives English-filled', async () => {
+      const debug = vi.spyOn(Logger, 'debug').mockImplementation(() => undefined);
+
+      // Dutch, whose real payload is Dutch throughout with `windy-variant` in English.
+      // A card language on purpose: `getEffectiveLanguage` rejects anything outside the
+      // card's own map before `toHaLanguage` ever sees it, so `pt-br` — the clearest
+      // illustration of the casing rule — cannot reach this path until the card ships
+      // that language.
+      const dutch: Record<string, string> = {};
+      for (const condition of knownConditions()) {
+        dutch[condition] = `nl-${condition}`;
+      }
+      dutch['windy-variant'] = 'Windy, cloudy';
+
+      const hass = germanHass({ nl: dutch });
+      ensureConditionTranslations(hass, 'nl', () => undefined);
+      await settle();
+
+      // It is returned, not reported — the value is HA's own fallback, not an error.
+      expect(formatCondition(hass, 'weather.home', 'windy-variant', 'nl')).toBe('Windy, cloudy');
+
+      const reports = debug.mock.calls.filter((call) => {
+        const text = String(call[0]);
+        return text.includes('has no') || text.includes('without');
+      });
+      expect(reports).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
Follow-up to the merged Y7 work, prompted by the `pt-BR` / `windy-variant` finding. **Comments and tests only — the built card is byte-identical to its parent** (confirmed with `cmp`, not by comparing sizes).

## The consequence that went unstated

The per-key gap-filling note established that the *structural* check cannot detect a translation gap. The consequence for the **other** diagnostic was not drawn, and it inverts what the two actually cover.

An untranslated condition arrives as a **present key holding the English string**. So `lookupCondition` sees a truthy value and stays silent — exactly as the 15/15 structural check does. Neither can see it.

Measured across eight card languages (2026.8.1):

| language | keys | English-filled values |
|---|---|---|
| `nl`, `ca`, `lv`, `pl`, `ro`, `vi`, `pt-BR` | 15/15 | `windy-variant` |
| `is` | 15/15 | `windy-variant`, `exceptional` |
| `de` | 15/15 | none |

So the per-condition report guards the **rarer** path — a key genuinely absent, i.e. a non-standard condition token from a third-party weather integration — while the case that actually occurs is invisible to it. A Dutch card really does read `Windy, cloudy`, silently.

## Deliberately not fixed

Telling an English-filled value apart from a real translation means fetching English as a second payload to compare against. This is a gap in **Home Assistant's** translations that the card cannot close, so paying a request per session to log someone else's data is the wrong trade.

The test asserts the **silence**, so that decision has to be revisited on purpose rather than drifting. Verified it is a real falsifier by adding a probe that does detect the English-filled case — the test goes red.

## A boundary found by a test that failed for the right reason

The first version used `pt-br` and failed: `getEffectiveLanguage` resolves any code outside the card's 35 away **before** `toHaLanguage` sees it, so `pt-br` fell back to the instance language and never reached the cache.

`toHaLanguage('pt-br')` is still `pt-BR` — the mapping does generalise — but the route is closed until the card ships that language. Both halves are now asserted, because "the mapping generalises" and "the path is reachable" are easy to mistake for each other.

## Gates

All green; 845 tests.
