### PR TITLE
fix(countdown): count calendar days on every row of a split multi-day event

### DIFF
--- a/docs/features/event-content.md
+++ b/docs/features/event-content.md
@@ -149,6 +149,8 @@ show_countdown: true
 show_countdown_allday: false # Timed events only
 ```
 
+When [`split_multiday_events`](/features/multi-day-events) is on, a multi-day event appears as one row per day and each row counts whole calendar days to its own date, so the countdowns read consecutively down the card.
+
 ## 🕒 Past Events Display
 
 Control visibility of events that have already occurred:

--- a/docs/features/multi-day-events.md
+++ b/docs/features/multi-day-events.md
@@ -28,6 +28,8 @@ This feature is especially useful for:
 - Seeing all active events for a given day at a glance
 - Getting a clearer picture of on-call schedules, multi-day conferences, or travel
 
+Because each row stands for a day rather than for the event as a whole, a [countdown](/features/event-content#countdown-display) on a split row counts whole calendar days to that row's own date. A holiday starting Monday reads as "in 4 days" on its first row, "in 5 days" on the second, and so on, whether or not the original event had a start time.
+
 The setting can be applied globally to all calendars or controlled separately for each calendar entity.
 
 This is the `split_multiday_events` option — see [Event Column in the configuration reference](/reference/configuration#event-column).

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -228,6 +228,17 @@ export interface CalendarEventData {
    * This never affects `visibleEventCount`, which filters on `_isEmptyDay`.
    */
   _isCustomEmptyText?: boolean;
+  /**
+   * Set on every segment produced by splitting a multi-day event, so a row can
+   * tell "one day of a longer event" from a standalone event.
+   *
+   * Splitting rewrites the middle days of a *timed* event as all-day segments
+   * and synthesizes a midnight start for its last day, which means a segment's
+   * `start` shape no longer says whether its time of day is real. The countdown
+   * needs that distinction: every row of a split event is a day, so all of them
+   * count whole calendar days rather than one of them measuring wall-clock time.
+   */
+  _isMultiDaySegment?: boolean;
   _matchedConfig?: EntityConfig;
   time?: string;
 }

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -302,6 +302,7 @@ export function groupEventsByDay(
         _matchedConfig: event._matchedConfig,
         _isEmptyDay: event._isEmptyDay,
         _isCustomEmptyText: event._isCustomEmptyText,
+        _isMultiDaySegment: event._isMultiDaySegment,
       });
     });
   }
@@ -843,6 +844,7 @@ function splitMultiDayEvent(event: Types.CalendarEventData): Types.CalendarEvent
         ...event,
         start: { date: currentDateStr },
         end: { date: nextDateStr },
+        _isMultiDaySegment: true,
       };
 
       segments.push(segment);
@@ -863,6 +865,7 @@ function splitMultiDayEvent(event: Types.CalendarEventData): Types.CalendarEvent
         ...event,
         start: { dateTime: startDateTime.toISOString() },
         end: { dateTime: firstDayEnd.toISOString() },
+        _isMultiDaySegment: true,
       };
       segments.push(firstDaySegment);
 
@@ -890,6 +893,7 @@ function splitMultiDayEvent(event: Types.CalendarEventData): Types.CalendarEvent
           // Create all-day event for middle days
           start: { date: currentDateStr },
           end: { date: nextDateStr },
+          _isMultiDaySegment: true,
         };
 
         segments.push(middleDaySegment);
@@ -900,6 +904,7 @@ function splitMultiDayEvent(event: Types.CalendarEventData): Types.CalendarEvent
         ...event,
         start: { dateTime: lastDayStart.toISOString() },
         end: { dateTime: endDateTime.toISOString() },
+        _isMultiDaySegment: true,
       };
       segments.push(lastDaySegment);
     } else {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -104,8 +104,9 @@ export function formatEventTime(
  * Generates a localized countdown string for an event
  * Uses dayjs for consistent, localized relative time formatting
  *
- * All-day events are measured from the start of today rather than from the
- * current instant, so the countdown reflects whole calendar days.
+ * All-day events, and every row of a split multi-day event, are measured
+ * midnight-to-midnight rather than from the current instant, so the countdown
+ * reflects whole calendar days.
  *
  * @param event Calendar event to generate countdown for
  * @param language Language to use
@@ -133,12 +134,33 @@ export function getCountdownString(
   // the countdown drops a day once the clock passes midday and renders tomorrow's
   // event as "in 4 hours". Anchoring to the start of today makes the difference a
   // whole number of calendar days, which is what an all-day countdown means.
-  const reference = isAllDayEvent
-    ? new Date(now.getFullYear(), now.getMonth(), now.getDate())
-    : undefined;
+  //
+  // The same applies to every row of a split multi-day event. Splitting rewrites
+  // the middle days as all-day segments but leaves a real start time on the first
+  // day and a synthesized midnight on the last, so measuring each row on its own
+  // terms gave one event three different countdowns: 3 / 5 / 6 / 6 where the days
+  // are 4 / 5 / 6 / 7 apart. Each row is a day, so each row counts days.
+  //
+  // Both ends are floored to local midnight rather than only the reference. A
+  // segment can start at 20:00, and start-of-today → 20:00 four days out is 4.8
+  // days, which rounds up to five.
+  const countsCalendarDays = isAllDayEvent || Boolean(event._isMultiDaySegment);
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfEventDay = new Date(
+    startDate.getFullYear(),
+    startDate.getMonth(),
+    startDate.getDate(),
+  );
+
+  // A row falling on today keeps wall-clock precision: "in an hour" is the useful
+  // answer for an event starting at 07:00 today, and flooring both ends would
+  // collapse the difference to zero and render it as "a few seconds ago".
+  if (countsCalendarDays && startOfEventDay > startOfToday) {
+    return getRelativeTimeString(startOfEventDay, language, startOfToday);
+  }
 
   // Use dayjs for relative time formatting
-  return getRelativeTimeString(startDate, language, reference);
+  return getRelativeTimeString(startDate, language);
 }
 
 /**

--- a/tests/countdown.test.ts
+++ b/tests/countdown.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import * as EventUtils from '../src/utils/events';
+import * as FormatUtils from '../src/utils/format';
+
+/**
+ * Countdown behaviour for multi-day events (issue #344 and its follow-up).
+ *
+ * Two regressions have shipped here, both invisible to the rest of the suite:
+ * the original "one day short after midday" for all-day events, and then a
+ * split multi-day event whose rows disagreed with each other because splitting
+ * gives the middle days an all-day shape while the first and last keep a
+ * `dateTime`. Both are time-dependent and neither changes the DOM structure, so
+ * the list-DOM snapshot cannot see them — they need explicit assertions.
+ *
+ * Every case asserts across several times of day. A single instant would have
+ * passed happily on the broken code: the sequence was correct before noon and
+ * wrong after it.
+ */
+
+const TIMED_MULTI_DAY = {
+  summary: 'Sommerferie',
+  start: { dateTime: '2026-08-17T07:00:00.000Z' },
+  end: { dateTime: '2026-08-20T12:00:00.000Z' },
+};
+
+const ALL_DAY_MULTI_DAY = {
+  summary: 'Sommerferie',
+  start: { date: '2026-08-17' },
+  end: { date: '2026-08-21' },
+};
+
+const SINGLE_DAY_TIMED = {
+  summary: 'Standup',
+  start: { dateTime: '2026-08-17T07:00:00.000Z' },
+  end: { dateTime: '2026-08-17T08:00:00.000Z' },
+};
+
+/** Times of day spanning the midday rounding boundary that broke both fixes. */
+const HOURS = ['00:30', '08:30', '11:30', '12:30', '13:30', '19:53', '23:30'];
+
+let instance = 0;
+
+function fakeHass(events: unknown[]) {
+  return {
+    states: {},
+    callApi: async () => events,
+    callService: async () => undefined,
+    locale: { language: 'en' },
+  } as never;
+}
+
+/** Runs the real fetch → process → split → group pipeline and returns one countdown per row. */
+async function countdowns(events: unknown[], nowIso: string, split = true) {
+  vi.setSystemTime(new Date(nowIso));
+  const config = buildConfig({
+    entities: ['calendar.test'],
+    split_multiday_events: split,
+    days_to_show: 12,
+  });
+  const { events: processed } = await EventUtils.fetchEventData(
+    fakeHass(events),
+    config,
+    `countdown-${instance++}`,
+    true,
+  );
+  return EventUtils.groupEventsByDay(processed, config, false, 'en')
+    .flatMap((day) => day.events)
+    .filter((event) => !event._isEmptyDay)
+    .map((event) => FormatUtils.getCountdownString(event, 'en'));
+}
+
+describe('countdown', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  describe('split multi-day events', () => {
+    it('counts consecutive calendar days on every row of a timed event', async () => {
+      for (const hour of HOURS) {
+        expect(await countdowns([TIMED_MULTI_DAY], `2026-08-13T${hour}:00.000Z`), hour).toEqual([
+          'in 4 days',
+          'in 5 days',
+          'in 6 days',
+          'in 7 days',
+        ]);
+      }
+    });
+
+    it('counts consecutive calendar days on every row of an all-day event', async () => {
+      for (const hour of HOURS) {
+        expect(await countdowns([ALL_DAY_MULTI_DAY], `2026-08-13T${hour}:00.000Z`), hour).toEqual([
+          'in 4 days',
+          'in 5 days',
+          'in 6 days',
+          'in 7 days',
+        ]);
+      }
+    });
+
+    it('drops the countdown from rows already under way and keeps counting the rest', async () => {
+      for (const hour of HOURS) {
+        expect(await countdowns([TIMED_MULTI_DAY], `2026-08-18T${hour}:00.000Z`), hour).toEqual([
+          null,
+          'in a day',
+          'in 2 days',
+        ]);
+      }
+    });
+
+    it('keeps wall-clock precision on a row starting later today', async () => {
+      expect(await countdowns([TIMED_MULTI_DAY], '2026-08-17T05:00:00.000Z')).toEqual([
+        'in 2 hours',
+        'in a day',
+        'in 2 days',
+        'in 3 days',
+      ]);
+    });
+  });
+
+  describe('unsplit events', () => {
+    it('measures a single-day timed event from the current instant', async () => {
+      expect(await countdowns([SINGLE_DAY_TIMED], '2026-08-13T19:53:00.000Z')).toEqual([
+        'in 3 days',
+      ]);
+    });
+
+    it('measures an unsplit multi-day event from its real start time', async () => {
+      expect(await countdowns([TIMED_MULTI_DAY], '2026-08-13T19:53:00.000Z', false)).toEqual([
+        'in 3 days',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Symptom

Reported by @BalooDK [on #344](https://github.com/alexpfau/calendar-card-pro/issues/344#issuecomment-5284401597) against v3.5.0: a multi-day event split across days shows a countdown that jumps. The first row was right, the rest were not.

Reproduced exactly, driving the real `fetchEventData` → `groupEventsByDay` pipeline. Event runs 17 Aug 07:00 → 20 Aug 12:00, `now` = 13 Aug 19:53, `split_multiday_events: true`:

| Row | Segment produced by the splitter | v3.5.0 | Expected |
| --- | --- | --- | --- |
| Mon 17 | timed, 07:00–23:59 | **in 3 days** | in 4 days |
| Tue 18 | all-day | in 5 days | in 5 days |
| Wed 19 | all-day | in 6 days | in 6 days |
| Thu 20 | timed, 00:00–12:00 | **in 6 days** | in 7 days |

![Before and after: the split multi-day countdown reads 3 / 5 / 6 / 6 on v3.5.0 and 4 / 5 / 6 / 7 with this PR](https://github.com/user-attachments/assets/22111bbd-ee73-4311-bfcc-eb8e794ce3fe)

Three symptoms, one cause: the 3 → 5 gap that skips 4, the duplicated "in 6 days", and — with `show_countdown_allday: false` — countdowns disappearing from the middle rows while remaining on the first and last.

## Root cause

`splitMultiDayEvent()` rewrites the *middle* days of a timed multi-day event as all-day segments, but leaves a real `dateTime` on the first day and synthesizes a midnight `dateTime` for the last. A segment's `start` shape therefore no longer says whether its time of day is meaningful.

The all-day countdown fix in v3.5.0 (#351) keyed calendar-day counting on exactly that shape, so it applied to the middle rows only. The first row kept measuring wall-clock time from the current instant and lost a day after midday; the last row measured to a midnight that is an artifact of splitting. Before v3.5.0 every row used `fromNow()`, so the sequence was at least self-consistent — this is a v3.5.0 regression, not a leftover of #344.

## Fix

Mark every segment the splitter produces with `_isMultiDaySegment`, and count whole calendar days for those rows. Each row of a split event stands for a day, so each row counts days.

Two details worth calling out:

- **Both ends are floored to local midnight**, not just the reference. A segment can start at 20:00, and start-of-today → 20:00 four days out is 4.8 days, which rounds up to five.
- **Rows falling on today keep wall-clock precision.** Flooring both ends there would collapse the difference to zero and render "a few seconds ago" instead of "in 2 hours".

`groupEventsByDay` rebuilds each event from an explicit field allowlist, so the flag has to be carried there too. It was silently dropped until the new tests caught it after midday.

## Why this approach

Three options were on the table: count calendar days per row (this PR), show the countdown only on the first row, or repeat the event's real start on every row. The latter two arguably match "how soon events begin" more literally, but both also change all-day multi-day events, which render correctly today and which nobody has reported. This one fixes only the broken case and needs no config key.

## Verified

- New `tests/countdown.test.ts` — 6 cases asserting across seven times of day either side of the midday rounding boundary that broke both this fix and #351. A single instant would have passed on the broken code.
- Full suite 116 passing, including the list-DOM snapshot (unchanged).
- `tsc --noEmit`, `npm run lint`, `prettier --check`, `check:docs`, `check:i18n`, `docs:build`, production build.
- DST checked under `TZ=Europe/Copenhagen`: 95h and 97h spans across both transitions still round to 4 days.
- Live on Home Assistant — split timed rows now read 4 / 5 / 6 / 7, matching the all-day control exactly; the unsplit card is unchanged.

Fixes #344
