### PR TITLE
ci: guard lockfile version and Node pin drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,33 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
+      # Two release-infra drifts that every other check is blind to, guarded before the
+      # install so they fail in seconds. `npm ci` validates dependencies but never the root
+      # version, and exits 0 when package.json and package-lock.json disagree — so a release
+      # that bumps package.json alone passes lint, tsc, the tests and the build (8 of the 10
+      # releases from v3.0.1 through v3.4.0 shipped with a stale lock version that way, and
+      # 31 of 37 tags overall). And CI pins Node from .nvmrc while the Cloudflare build image
+      # reads .node-version: two files that must
+      # agree for the pin above to mean anything. When they drift, CI and the deploy run
+      # different npm majors and the #404 failure returns invisibly — CI green, docs site
+      # stale, the only log in the Cloudflare dashboard.
+      - name: Check version and Node pinning consistency
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          LOCK=$(node -p "require('./package-lock.json').version")
+          LOCK_ROOT=$(node -p "require('./package-lock.json').packages[''].version")
+          if [ "$PKG" != "$LOCK" ] || [ "$PKG" != "$LOCK_ROOT" ]; then
+            echo "::error::Version drift — package.json=$PKG, package-lock.json=$LOCK, packages['']=$LOCK_ROOT. Fix with: npx npm@10.9.2 install --package-lock-only"
+            exit 1
+          fi
+          NVMRC=$(tr -d ' \r\n' < .nvmrc)
+          NODEVER=$(tr -d ' \r\n' < .node-version)
+          if [ "$NVMRC" != "$NODEVER" ]; then
+            echo "::error::.nvmrc ($NVMRC) and .node-version ($NODEVER) disagree. CI pins from .nvmrc, the Cloudflare build image reads .node-version; drift between them reintroduces the #404 npm-version mismatch."
+            exit 1
+          fi
+          echo "Consistent: v$PKG on Node $NVMRC"
+
       - name: Install dependencies
         run: npm ci
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,6 +275,19 @@ are and are not flagged:
 1. Bump `version` in `package.json` — it is the single source of truth. Rollup
    substitutes it into the bundle header and into `constants.ts` via `@version
 vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements.
+
+   Then regenerate the lockfile so its **two** version fields follow — `.version` and
+   `.packages[""].version`:
+
+   ```bash
+   npx npm@10.9.2 install --package-lock-only
+   ```
+
+   `npm ci` validates dependencies but never the root version, and exits 0 on a mismatch,
+   so bumping `package.json` alone passes lint, tsc, the tests and the build. That is how
+   8 of the 10 releases from v3.0.1 through v3.4.0 shipped with a stale lock version — 31
+   of 37 tags overall. `ci.yml` now checks all three, so skipping this fails the release PR
+   rather than shipping quietly.
 2. Update `docs/RELEASE_NOTES.md`, the README's `## 4️⃣ What's New` section, **and**
    `docs/guide/whats-new.md` — see _The two "What's New" surfaces_ for the differing rules.
 3. Open a PR from `dev` into `main` and merge it. `main`'s ruleset requires an approving
@@ -290,7 +303,10 @@ vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements.
 
 ## CI
 
-- `ci.yml` — lint + build on every PR to `main` or `dev`.
+- `ci.yml` — lint + build on every PR to `main` or `dev`. Also guards the two release-infra
+  drifts nothing else can see: `package.json` disagreeing with either version field in
+  `package-lock.json`, and `.nvmrc` disagreeing with `.node-version`. Both run before the
+  install, so they fail in seconds.
 - `hacs-validate.yml` — HACS validation on `main` and nightly.
 - `release.yml` — tag-triggered draft release.
 
@@ -308,10 +324,11 @@ and serves `docs/.vitepress/dist` as static assets.
   in version control.
 - The Node version is pinned by **both `.nvmrc` and `.node-version`** (kept in sync), and
   `ci.yml` reads `.nvmrc` via `node-version-file` so CI and the deploy run the same runtime.
-  Keep it that way. When they drifted — CI on Node 24, the build image on Node 22 — npm 11
-  in CI accepted a `package-lock.json` that npm 10 on the build image rejected with
-  `EUSAGE … Missing: esbuild@… from lock file`. CI was green on every PR while the deploy
-  failed and the site quietly served stale content.
+  Keep it that way — `ci.yml` now fails when the two files disagree, because their agreement
+  is the whole reason a green CI run predicts a successful deploy. When they drifted — CI on
+  Node 24, the build image on Node 22 — npm 11 in CI accepted a `package-lock.json` that npm
+  10 on the build image rejected with `EUSAGE … Missing: esbuild@… from lock file`. CI was
+  green on every PR while the deploy failed and the site quietly served stale content.
 - **A lockfile that installs locally is not a lockfile that installs on the build image.**
   Merging branches that each touched `package-lock.json` can produce a file that is
   internally inconsistent but still satisfies a newer npm. To check against the deploy's


### PR DESCRIPTION
Closes #413.

Adds one step to `ci.yml` covering the two release-infra drifts nothing else can see. It reads four files and compares strings, and runs **before** `npm ci` so it fails in seconds.

## Gap 1 — `package.json` vs `package-lock.json`

`npm ci` validates dependencies but never the root version, and exits 0 on a mismatch. I audited every tag rather than taking the estimate on trust, and it confirms the issue's figure exactly:

| Range | Drifted |
| --- | --- |
| v3.0.1 → v3.4.0 | **8 of 10** |
| All tags | **31 of 37** |

Only `v1.0.0`, `v3.0.0`, `v3.2.0`, `v3.3.0`, `v3.5.0` and `v3.6.0` ever had all three version fields agree. The check compares all three — `package.json`, the lock's `.version`, and `.packages[""].version` — since a release editing `package.json` alone leaves both lock fields stale.

## Gap 2 — `.nvmrc` vs `.node-version`

CI pins Node from `.nvmrc`; the Cloudflare build image reads `.node-version`. Their agreement is the entire reason a green CI run predicts a successful deploy, so drift reintroduces the #404 npm-major mismatch invisibly — CI green, docs site stale, the only log in the Cloudflare dashboard.

This is worth guarding *because* it otherwise silently voids the lockfile-pruning protection that `npm ci` already provides.

## Verification

Extracted the step body from the parsed YAML and ran it under `bash -e`, exactly as Actions does:

- **Current tree** → `Consistent: v3.6.0 on Node 22`, exit 0
- **`package.json` bumped, lock stale** → exit 1
- **Lock `.version` updated but `.packages[""]` stale** → exit 1 (proves the third comparison is load-bearing)
- **`.nvmrc` 24 vs `.node-version` 22, versions all correct** → exit 1
- **Trailing space / CRLF in a pin file** → still passes (`tr -d` strips them)

`npm run check:docs` and `npm run check:i18n` both still exit 0 (pre-existing warnings only).

## Blast radius

Nothing outside CI — no source file, no dependency, no bundle byte, no runtime behaviour. It cannot fail a PR that is currently correct. The one intended behavioural change: a release PR that forgets the lockfile now fails CI instead of merging quietly.

## AGENTS.md

Release step 1 said to bump `package.json` and stopped there, which would now fail CI — so it documents regenerating the lock alongside. Also notes the new guard in the CI section and on the `.nvmrc`/`.node-version` bullet, which described the two files as "kept in sync" by convention when that is now enforced.

## Not included

Per the issue, deliberately skipped an `@esbuild/linux-x64` presence check (redundant — `npm ci` already fails harder and with a better message) and pinning npm separately (the Node pin determines the bundled npm; a second pin is another pair of files that can drift).