### PR TITLE
ci: run checks on PRs into long-lived feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,23 @@
 name: Build & Lint Checks
 
+# `main` and `dev` are the two branches the model in AGENTS.md says receive PRs, and for
+# a long time they were the only two listed here. That left long-lived integration
+# branches — the ones a release's worth of work is assembled on before it reaches `dev` —
+# taking PRs with no checks at all. `feature/column-view-v4` took 390 commits that way;
+# merged PR #409 into it has `check-runs=0`. Nothing in the PR UI says a branch is
+# unchecked, so the gap is invisible from exactly the place you would look for it.
+#
+# `feature/**` matches on the PR's *base* branch, so this covers PRs into any such branch
+# without depending on what the head branch is called. Note the residual case: an
+# integration branch named outside that prefix is still unchecked, and if one is ever
+# created the fix is to add it here, or to drop the filter entirely — under the branch
+# model this list can only ever exclude PRs that should have been checked.
 on:
   pull_request:
     branches:
       - main
       - dev
+      - 'feature/**'
 
 jobs:
   lint-build:


### PR DESCRIPTION
The trigger listed `main` and `dev` — the two branches [AGENTS.md](../blob/feature/column-view-v4/AGENTS.md) says receive PRs. Integration branches receive them too, and were getting nothing.

`feature/column-view-v4` has taken **390 commits with no CI**. Merged PR #409 into it reports `check-runs=0`:

```
$ gh api repos/alexpfau/calendar-card-pro/commits/bfd55de/check-runs -q .total_count
0
```

## Why this went unnoticed

Nothing surfaces it. A PR into an unchecked branch looks exactly like one whose checks have not started, so the place you would look is the place that stays silent. It only came out because `gh pr create` defaulted #415 to `dev`, which ran the checks, and retargeting to the v4 branch made them vanish.

## The change

One line. `branches:` filters on the PR **base**, so `feature/**` covers PRs into any such branch regardless of the head branch name — the one that found this was `alexpfau-column-view-v4-review`, which carries no prefix at all.

## This PR is its own test

It targets `feature/column-view-v4`. **CI running here is the evidence the trigger works**; if the checks stay silent, the change is wrong and says so immediately, in the one place that matters.

## Left deliberately

The filter still cannot cover an integration branch named outside `feature/`. Under this branch model the list can only ever *exclude* PRs that should have been checked, so dropping it entirely is defensible — but that is a wider behavioural change than the gap being closed here. The comment in the file records the choice for whoever hits the next variant.

`hacs-validate.yml` and `release.yml` were checked for the same shape and do not have it: one runs on push to `main` plus nightly, the other on tags. Both as intended.