### PR TITLE
docs(agents): point at the local skills that a worktree cannot see

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,33 @@ Instructions for AI coding agents working in this repository.
 Human contributors should read [CONTRIBUTING.md](./CONTRIBUTING.md) — this file is the
 agent-facing summary plus the things that are easy to get wrong.
 
+## Local agent skills — read this before building any tooling
+
+Three skills live at an **absolute path outside this checkout**:
+
+```
+/Users/alexpfau/Documents/Tech/GitHub/calendar-card-pro/.agents/skills/
+    calendar-card-pro-deploy     build → deploy to HA → live-test in a real browser
+    calendar-card-pro-release    release preflight
+    calendar-card-pro-triage     issue triage
+```
+
+**They are untracked, so they exist only in the main checkout — a worktree under
+`.worktrees/` has none of them, which is exactly where you are when working a branch.**
+That is why the path above is absolute and must not be shortened; the scripts resolve
+their own neighbours from `import.meta.url`, so only the invocation needs it.
+
+Read `calendar-card-pro-deploy/SKILL.md` before doing anything involving the live Home
+Assistant instance — deploying a dev build, driving a browser, taking screenshots, or
+touching the `ccp-release-*` dashboard tabs. It already covers the dev-build deploy loop,
+the cache-buster bump, the screenshot fixtures, macOS Local Network permission, and a
+list of traps with the measurements behind them.
+
+This pointer exists because those skills are invisible from a worktree and nothing else
+names them: a session rebuilt Playwright capture tooling, re-diagnosed the macOS LAN
+block, and rediscovered the `max_columns: 1` column-view trap, all of which were already
+written down there.
+
 ## Project
 
 Calendar Card Pro is a custom Lovelace card for Home Assistant, written in TypeScript

--- a/docs/development/screenshots.md
+++ b/docs/development/screenshots.md
@@ -17,6 +17,15 @@ HA_TOKEN=… node scripts/capture-screenshots.mjs --probe column-week         # 
 HA_TOKEN=… node scripts/capture-screenshots.mjs --list                      # ids
 ```
 
+::: tip There Is A Companion Skill
+`calendar-card-pro-deploy` at
+`/Users/alexpfau/Documents/Tech/GitHub/calendar-card-pro/.agents/skills/` covers the rest
+of the live-Home-Assistant loop — deploying a dev build, the cache-buster bump, the
+browser harness, and the machine-specific setup. It is **untracked, so it does not exist
+in a worktree**; the absolute path is deliberate. This page is the tracked half and covers
+the card knowledge; that one covers the machine.
+:::
+
 Playwright is deliberately **not** a dependency: its postinstall downloads a browser that
 no gate would ever use, and CI runs `npm ci` on every pull request. The script resolves it
 from a global install, because Node's ESM resolver does not consult the global root on its


### PR DESCRIPTION
Answers "where should the screenshot learnings live" — and fixes the reason I didn't put them in the right place to begin with.

**Targets `feature/column-view-v4`.**

## The problem

Three skills live at `.agents/skills/` in the main checkout: `calendar-card-pro-deploy`, `-release`, `-triage`. They are **untracked**, so a worktree under `.worktrees/` has none of them — which is exactly where an agent is when working a branch. And nothing in `AGENTS.md` named them, so from inside a worktree they are invisible.

The cost was concrete this session. I rebuilt Playwright capture tooling, re-diagnosed the macOS Local Network block, and rediscovered the `max_columns: 1` column-view trap. **All three were already written down** in `calendar-card-pro-deploy/SKILL.md` — which even carries a warning about this precise worktree-invisibility problem. That warning cannot help, because it is inside the file you cannot see.

## The fix

`AGENTS.md` is tracked and loads into every session, so the pointer belongs there — with the absolute path the skill itself insists on, and a one-line statement of why it is absolute.

`screenshots.md` gains the reciprocal link and states the split explicitly: **the tracked page carries the card knowledge, the skill carries the machine.**

## Also updated (in the skill, outside this PR)

`.agents/` isn't version-controlled, so these changes can't be included here — noting them for the record:

- `ha-test.mjs` — `ccp-release-column` added to `ALLOWED_VIEWS` and `READONLY_VIEWS`. The tab created in August wasn't allow-listed, so the harness refused to open it. Syntax-checked; backup at `/tmp/ha-test.mjs.bak`.
- `SKILL.md` — the *Screenshots for releases* section pointed at `ha-test.mjs shot`, which is no longer how the published set is made. It now points at `scripts/capture-screenshots.mjs`, explains the framing/scales/assertions, and links `docs/development/screenshots.md`. Backup at `/tmp/SKILL.md.bak`.
- `SKILL.md` — the "frozen fixture" rule now records that those configs *were* deliberately edited in August at your direction (start_date pins, v3 key migration, two composition restorations), while keeping the default rule intact.

## Validation

`npm run check:docs`, `npm run docs:build` — pass. `node --check ha-test.mjs` — clean.