### PR TITLE
chore: ignore .agents so worktree skill links cannot be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ docs/.vitepress/cache/
 
 # Ignore local-only MCP server config (may contain access tokens)
 .mcp.json
+
+# Local agent skills (machine-specific, not for contributors).
+# No trailing slash: worktrees reach these through a symlink, and a
+# `.agents/` pattern matches real directories only, so the link would
+# be left untracked and could be committed.
+.agents


### PR DESCRIPTION
The local agent skills live in `.agents/` (machine-specific, not for contributors). That path is gitignored on `main`’s side, but **had no rule on this branch at all** — so a `.agents` entry created here would have been staged into the public repo.

Worktrees do not inherit the directory, so they reach it through a symlink. The pattern is written **without a trailing slash**, because `.agents/` matches real directories only and would leave the symlink untracked.

Verified against a live symlink:

| pattern | result |
| --- | --- |
| *(no rule — this branch today)* | not ignored |
| `.agents/` | not ignored |
| `.agents` | ignored ✓ |

`npx tsc --noEmit` and `npm run lint` pass; both are scoped to `src/`/`tests/`/`scripts/`, so the link is invisible to them.