### PR TITLE
Fix three stale/redundant code comments found in third review pass

### DIFF
--- a/src/config/view.ts
+++ b/src/config/view.ts
@@ -673,15 +673,23 @@ export function resolveMinDaysFallback(config: Types.Config): Types.ColumnMinDay
 }
 
 /**
- * Resolves which view the card actually renders.
+ * Resolves the view for a width, without resolving a column count.
+ *
+ * **Not the production path.** The card renders through {@link resolveColumnFit}, which
+ * answers view *and* column count in one pass. This function survives as the reference
+ * implementation of the view half: `tests/view-config.test.ts` pins `resolveColumnFit`
+ * against it, so a future change to the fit logic that silently altered the view
+ * decision fails there. It is tree-shaken out of the bundle, so keeping it costs
+ * nothing shipped — but do not add callers, and do not delete it without replacing
+ * that equivalence check.
  *
  * - **`requestedView`** is what the user configured.
  * - **`effectiveView`** is what is rendered after the width fallback.
  *
  * Everything downstream — option resolution, grouping, compaction, rendering — takes
- * `effectiveView`. Nothing reads `config.view` directly, because below the threshold
- * that value still says `column` while the card renders a list, and every per-view
- * resolution would then resolve for the wrong view.
+ * the resolved effective view. Nothing reads `config.view` directly, because below the
+ * threshold that value still says `column` while the card renders a list, and every
+ * per-view resolution would then resolve for the wrong view.
  *
  * The fallback is **wholesale**: below the threshold the card renders list view with
  * every configured day. It never renders column view with fewer columns than asked
@@ -720,6 +728,10 @@ export function resolveEffectiveView(
 
 /**
  * Resolves the view for a freshly measured width, given the previous measurement.
+ *
+ * **Not the production path**, for the same reason as {@link resolveEffectiveView}: the
+ * card measures through {@link resolveColumnFitOnMeasurement}. This is the reference
+ * implementation that check is pinned against.
  *
  * `resolveEffectiveView` renders the *requested* view before any measurement exists,
  * so that optimistic answer must not seed hysteresis. A `null`

--- a/src/rendering/column.ts
+++ b/src/rendering/column.ts
@@ -165,6 +165,9 @@ function renderColumnEvent(
     'past-event': presentation.isPastEvent,
   };
 
+  // Column view places two of these differently from list view: the countdown rides the
+  // time row, and the progress bar takes a row of its own. Documented for users at
+  // docs/features/column-view.md § Progress Bar & Countdown.
   return html`
     <div
       class=${classMap(eventClasses)}

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -31,10 +31,8 @@ export function getRequiredForecastTypes(
     return ['daily'];
   }
 
-  if (position === 'event') {
-    return ['daily', 'hourly'];
-  }
-
+  // 'event' and 'both' both render a per-event forecast, which needs hourly data;
+  // 'both' additionally keeps the daily forecast on the day header.
   return ['daily', 'hourly'];
 }
 


### PR DESCRIPTION
Third independent review pass over `feature/column-view-v4`. All three findings were verified before implementing; none is a runtime defect.

### 1. `src/config/view.ts` — two docstrings claimed a role the functions no longer have

`resolveEffectiveView` and `resolveViewOnMeasurement` describe themselves in the present tense as the live render path — *"Everything downstream — option resolution, grouping, compaction, rendering — takes `effectiveView`"*. Production resolves through `resolveColumnFit` / `resolveColumnFitOnMeasurement` (`calendar-card-pro.ts:830` and `:484`); neither function has a production call site.

**Kept, not deleted.** They are the equivalence oracle `tests/view-config.test.ts:1144` pins the fit logic against — deleting them removes the check that would catch a fit change silently altering the view decision. The "costs nothing" half was measured, not assumed: excising both (53 lines) and rebuilding gave a **0-byte delta** in both bundles. Both docstrings now state all of this, including "do not add callers".

### 2. `src/rendering/column.ts` — three hardcoded placements with no rationale

`weatherPlacement: 'row'`, `progressPlacement: 'row'`, `countdownPlacement: 'text'` overrode list-view behaviour with no inline note. Added a comment pointing at `docs/features/column-view.md § Progress Bar & Countdown`, where the behaviour is already documented for users. Written as a JS comment above the template, **not** an HTML comment inside it — Lit emits those into the DOM.

### 3. `src/utils/weather.ts` — redundant branch

`if (position === 'event') return ['daily', 'hourly'];` sat immediately above an identical fallthrough. Since the type is `'date' | 'event' | 'both'`, `'event'` and `'both' genuinely share a return; collapsed to one with a comment saying why.

The function has **no direct test coverage**, so the green suite was not treated as evidence — equivalence is provable by inspection (removed body byte-identical to the fallthrough, no statements between them, no side effects). The shipped bundle shrinks **23 B**, confirming it was live code rather than already elided.

### Gate

`tsc --noEmit`, `lint`, `check:format`, `test` (1066 passing / 39 files), `check:i18n`, `check:docs`, `build`, `check:bundle`, `docs:build` — **all exit 0**.