### PR TITLE
ci: run docs:build so a PR exercises the deploy's own command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,23 @@ jobs:
       - name: Check docs integrity
         run: npm run check:docs
 
+      # The converse of the step above, and the reason both exist. check:docs reads the
+      # markdown; this compiles the site the way Cloudflare does. Neither subsumes the
+      # other: a link to a heading that does not exist is caught here by check:docs and
+      # sails through vitepress build, while a broken docs/.vitepress/config.mts is
+      # invisible to check:docs, to lint, and to tsc --noEmit — docs/ is outside the
+      # tsconfig include — and fails only the real build.
+      #
+      # That gap mattered because the site deploys on push to main and nowhere else, so
+      # no pull request ever ran this command. A config error would pass every check
+      # here, merge, fail the Cloudflare build, and leave the site quietly serving the
+      # previous version — the same silent-stale-docs failure recorded in AGENTS.md for
+      # the npm-major drift, which the .nvmrc pinning check above now guards. Running
+      # the deploy's own build command is the strongest form of that guarantee, and it
+      # costs about two seconds.
+      - name: Build docs site
+        run: npm run docs:build
+
       - name: Build
         run: npm run build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -663,7 +663,9 @@ download would have to live outside the release assets entirely.
   the two release-infra
   drifts nothing else can see: `package.json` disagreeing with either version field in
   `package-lock.json`, and `.nvmrc` disagreeing with `.node-version`. Both run before the
-  install, so they fail in seconds.
+  install, so they fail in seconds. It also runs `docs:build`, so the site's own build
+  command is exercised on a pull request rather than first on `main` — see _Docs site
+  deployment_.
 - `hacs-validate.yml` — HACS validation on the same PR branches, plus `main` and nightly.
   Everything it validates is decided before a merge, so running it only on `main` meant a
   packaging mistake could only be found once `main` already carried it.
@@ -678,6 +680,13 @@ and serves `docs/.vitepress/dist` as static assets.
 - **It builds only on push to `main`.** Pushing to `dev` produces no Workers check run at
   all, so nothing on `dev` is ever live. **Merging the `dev` → `main` PR _is_ the deploy** —
   there is no separate publish step and no tag involved.
+- **`ci.yml` runs `docs:build` so a pull request exercises the deploy's own command.** It
+  did not always, and the gap was invisible: a broken `docs/.vitepress/config.mts` passes
+  `check:docs`, `lint` and `tsc --noEmit` — `docs/` sits outside the tsconfig include — so
+  every check went green, the PR merged, and the Cloudflare build was the first thing to
+  run it. The two docs checks are complementary rather than redundant, and each catches
+  what the other misses: a link to a heading that does not exist fails `check:docs` and
+  builds cleanly under VitePress, while a config error fails only the build. Keep both.
 - `wrangler.jsonc` defines the Worker: no `main` script, `assets.directory` pointing at the
   VitePress output, and the custom domain declared as a route so the hostname binding stays
   in version control.


### PR DESCRIPTION
## What

Adds a `docs:build` step to `ci.yml`, so a pull request runs the same command the Cloudflare deploy runs.

## Why

The docs site builds on push to `main` **and nowhere else**. No pull request ever ran `vitepress build docs`, which left a class of breakage with nothing in front of it — the PR goes green, merges, the Workers build fails, and the site quietly keeps serving the previous version. `AGENTS.md` already records that exact silent-stale-docs failure from the npm-major drift, and the `.nvmrc` / `.node-version` check exists specifically so a green CI run predicts a successful deploy. This closes the other half of that guarantee.

## How it was verified

By planting failures and measuring which gate caught them, not by reasoning about it:

| Planted defect | `tsc` | `lint` | `check:docs` | `docs:build` |
|---|---|---|---|---|
| Link to a heading that does not exist | — | — | **caught** | missed |
| Link to a page that does not exist | — | — | **caught** | **caught** |
| Undefined identifier in `.vitepress/config.mts` | missed | missed | missed | **caught** |

Each plant was control-tested (file confirmed changed), and both gates were confirmed green before and after every plant.

Two things follow. The config error is invisible to `tsc --noEmit` because `docs/` sits outside the tsconfig include — so nothing in CI could see it. And the two docs checks are **complementary rather than redundant**: `check:docs` catches dead anchors that VitePress builds cleanly, `docs:build` catches build errors `check:docs` cannot see. This adds a step rather than replacing one.

Cost: **2.5s** measured locally.

## Also

`AGENTS.md` updated in both places a reader would look — the `## CI` list, and the _Docs site deployment_ section that previously told the reader no pull request exercises the build.

## Gates

`tsc --noEmit`, `lint`, `check:format`, `test`, `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle` — all pass.
