### PR TITLE
docs(agents): record when the version bump lands in the release cycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,23 @@ jobs:
       - name: Check docs integrity
         run: npm run check:docs
 
+      # The converse of the step above, and the reason both exist. check:docs reads the
+      # markdown; this compiles the site the way Cloudflare does. Neither subsumes the
+      # other: a link to a heading that does not exist is caught here by check:docs and
+      # sails through vitepress build, while a broken docs/.vitepress/config.mts is
+      # invisible to check:docs, to lint, and to tsc --noEmit — docs/ is outside the
+      # tsconfig include — and fails only the real build.
+      #
+      # That gap mattered because the site deploys on push to main and nowhere else, so
+      # no pull request ever ran this command. A config error would pass every check
+      # here, merge, fail the Cloudflare build, and leave the site quietly serving the
+      # previous version — the same silent-stale-docs failure recorded in AGENTS.md for
+      # the npm-major drift, which the .nvmrc pinning check above now guards. Running
+      # the deploy's own build command is the strongest form of that guarantee, and it
+      # costs about two seconds.
+      - name: Build docs site
+        run: npm run docs:build
+
       - name: Build
         run: npm run build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -663,7 +663,9 @@ download would have to live outside the release assets entirely.
   the two release-infra
   drifts nothing else can see: `package.json` disagreeing with either version field in
   `package-lock.json`, and `.nvmrc` disagreeing with `.node-version`. Both run before the
-  install, so they fail in seconds.
+  install, so they fail in seconds. It also runs `docs:build`, so the site's own build
+  command is exercised on a pull request rather than first on `main` — see _Docs site
+  deployment_.
 - `hacs-validate.yml` — HACS validation on the same PR branches, plus `main` and nightly.
   Everything it validates is decided before a merge, so running it only on `main` meant a
   packaging mistake could only be found once `main` already carried it.
@@ -678,6 +680,13 @@ and serves `docs/.vitepress/dist` as static assets.
 - **It builds only on push to `main`.** Pushing to `dev` produces no Workers check run at
   all, so nothing on `dev` is ever live. **Merging the `dev` → `main` PR _is_ the deploy** —
   there is no separate publish step and no tag involved.
+- **`ci.yml` runs `docs:build` so a pull request exercises the deploy's own command.** It
+  did not always, and the gap was invisible: a broken `docs/.vitepress/config.mts` passes
+  `check:docs`, `lint` and `tsc --noEmit` — `docs/` sits outside the tsconfig include — so
+  every check went green, the PR merged, and the Cloudflare build was the first thing to
+  run it. The two docs checks are complementary rather than redundant, and each catches
+  what the other misses: a link to a heading that does not exist fails `check:docs` and
+  builds cleanly under VitePress, while a config error fails only the build. Keep both.
 - `wrangler.jsonc` defines the Worker: no `main` script, `assets.directory` pointing at the
   VitePress output, and the custom domain declared as a route so the hostname binding stays
   in version control.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,6 +560,16 @@ vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements.
    of 37 tags overall. `ci.yml` now checks all three, so skipping this fails the release PR
    rather than shipping quietly.
 
+   **When the bump lands.** Historically 0–48 h before the tag, because a minor release is
+   prepared and cut from `dev` in one sitting. A major developed on a long-lived
+   integration branch is the exception and the bump lands early by necessity — the release
+   notes, the two "What's New" surfaces and the docs all name the version, so they cannot
+   be written against a placeholder. `feature/column-view-v4` carried `4.0.0` for two days
+   and 146 commits, which is the same lead time v3.2.0 had. Do not file this as premature:
+   the version's only consumers are the event cache key (a change self-heals), the
+   card↔editor mismatch warning (both halves are built from the same value) and the logger
+   banner. A review pass raised it as a finding purely because this paragraph did not exist.
+
 2. Update `docs/RELEASE_NOTES.md`, the README's `## 4️⃣ What's New` section, **and**
    `docs/guide/whats-new.md` — see _The two "What's New" surfaces_ for the differing rules.
 3. Open a PR from `dev` into `main` and merge it. `main`'s ruleset requires an approving


### PR DESCRIPTION
## Why

A review pass filed `feature/column-view-v4` carrying `4.0.0` as a premature version bump. It is not — but nothing in `AGENTS.md` said so, and the reviewer had no way to tell.

The release process lists "bump `version` in `package.json`" as step 1 and never says *when in the cycle* that step happens. For a minor cut from `dev` in one sitting the answer is obvious; for a major developed on a long-lived integration branch it looks like a deviation.

## What the measurement says

Lead time from the bump commit to the tag, across the last five releases:

| Release | Lead time |
| --- | --- |
| v3.2.0 | 48 h |
| v3.3.0 | 0 h |
| v3.4.0 | 0 h |
| v3.5.0 | 1 h |
| v3.6.0 | 0 h |

`feature/column-view-v4` has carried `4.0.0` for **two days and 146 commits** — the same lead time v3.2.0 had, so it is within precedent rather than outside it.

The bump has to land early on a major: the release notes, both "What's New" surfaces and the docs all name the version, and none of them can be written against a placeholder.

## Why it is harmless mid-cycle

The substituted value has exactly three consumers, and none of them can misbehave from an early bump:

- **event cache key** (`src/utils/events.ts`) — a change invalidates cached events once, then self-heals
- **card↔editor mismatch warning** (`src/calendar-card-pro.ts`) — both halves are built from the same value, so they always agree
- **logger banner** — cosmetic

## Scope

`AGENTS.md` only, +10 lines. No source, test or docs-site change.

- `npm run check:format` — 0
- `npm run check:docs` — 0, "Documentation is consistent with the code."
