### PR TITLE
docs: warn that branch names ending in `tags` break HACS validation

### DIFF
--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -8,6 +8,14 @@ name: HACS Validation
 # thing a PR can get wrong.
 #
 # The branch list mirrors ci.yml, for the reason documented there.
+#
+# A branch whose name ends in `tags` fails this workflow for a reason that has nothing to do
+# with the repository. HACS reads `hacs.json` and the README over the network from
+# raw.githubusercontent.com/{repo}/{ref}/{file}, and hacs/integration's base.py strips
+# `tags/` out of that URL unconditionally, to normalise release refs like `tags/v1.2.3`. The
+# fetch then 404s and both content checks report generic "invalid hacs.json" / "no images in
+# Readme" errors while the six metadata checks pass. Rename the branch — see AGENTS.md,
+# "Branch model".
 on:
   pull_request:
     branches:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,19 @@ passing status checks; `dev` only blocks deletion.
 External contributors frequently open PRs against `main` by mistake. Retarget them to
 `dev` (`gh pr edit <n> --base dev`) rather than merging into `main`.
 
+**Never name a branch so that it ends in `tags`** — `validate-hacs` fails on it, and the
+failure accuses the repository rather than the name. HACS reads `hacs.json` and the README
+over the network from `raw.githubusercontent.com/{repo}/{ref}/{file}`, and
+`custom_components/hacs/base.py` strips `tags/` out of that URL unconditionally, to
+normalise release refs like `tags/v1.2.3`. A branch called `fix/void-element-end-tags`
+therefore requests `…-tags/hacs.json`, HACS rewrites it to `…-hacs.json`, and both fetches 404. The two content checks then report _"invalid 'hacs.json' file"_ and _"does not have
+images in the Readme file"_ while the six metadata checks pass, because those need no file
+fetch — **that 6-pass/2-fail split is the signature**, and the generic wording is the second
+tell, since a genuinely malformed `hacs.json` produces a humanized schema error instead.
+Both files were byte-identical to `main` throughout. Ten hypotheses were falsified before
+the branch name was suspected; the fix is to rename it and re-open the PR. Only reachable
+since v4 added the `pull_request` trigger below.
+
 **When several branches feed one integration branch, "merged" has to name which branch.**
 Merging the integration branch _into_ your own, or merging your work into a peer's, leaves
 a local state indistinguishable from being integrated: `git status` is clean, local equals


### PR DESCRIPTION
Records the root cause of the `validate-hacs` failure that blocked #439, so the next person does not spend a session on it.

## What happened

`validate-hacs` failed deterministically on `fix/void-element-end-tags` while passing on `main`, `dev`, `feature/column-view-v4` and `fix/editor-typed-lengths` — with `hacs.json` and `README.md` byte-identical across all of them. Ten hypotheses were falsified by control, including a paired same-window dispatch of both refs 8 seconds apart (mine failed, v4 passed) which ruled out flakiness and CDN rate limiting.

## Cause

HACS validates **by ref, over the network**, not from the checkout. It fetches `hacs.json` and the README from `raw.githubusercontent.com/{repo}/{ref}/{file}`, and [`custom_components/hacs/base.py`](https://github.com/hacs/integration/blob/main/custom_components/hacs/base.py) strips `tags/` out of that URL unconditionally, to normalise release refs like `tags/v1.2.3`:

```python
if not keep_url and "tags/" in url:
    url = url.replace("tags/", "")
```

The branch name ended in `-tags`, so the URL contained `tags/` at the branch/filename boundary:

`.../refs/heads/fix/void-element-end-tags/hacs.json` → `.../refs/heads/fix/void-element-end-hacs.json` → **404**

Both fetches returned `None`, which is the code path behind the two generic errors. Reproduced directly against the mangled URL (404) and confirmed by re-pushing the identical commit to `fix/void-element-markup`, where all 8 checks passed (#440).

## Why it looks like a repository defect

The six checks that pass are all repository metadata and need no file fetch; only the two content checks fail. **That 6-pass/2-fail split is the signature.** The wording is the second tell — a genuinely malformed `hacs.json` produces a humanized schema error, not the generic "invalid 'hacs.json' file".

## Scope

Only reachable since v4 added the `pull_request` trigger to `hacs-validate.yml`. No code change; comment in the workflow and a paragraph in AGENTS.md's branch-model section.