### PR TITLE
fix(weather): "Nowhere" subscribed to every forecast stream

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -97,6 +97,7 @@ Translation resolves **per string**, requested language first and English second
 
 ### Weather
 
+- **"Nowhere" Was the Most Expensive Weather Setting** - The editor's weather position offers "Nowhere" alongside the date column, the event row and both. Picking it drew no weather anywhere, as intended — but it also fell through the branch that decides which forecasts to subscribe to, landing on the arm reserved for the positions that draw the most. So the option that renders nothing quietly subscribed to _both_ the daily and hourly forecast streams, more than "Date Column" asks for. It now subscribes to neither, and `'none'` is a documented value of `weather.position` rather than one the editor could produce but the type never admitted
 - **The Editor Wrote a Weather Color Into Your Configuration** - `weather.event.color` shipped a default, and the editor writes the whole weather block back the moment you pick an entity — so that default was copied into the user's YAML, where it became indistinguishable from a deliberate choice forever after. A card nobody had styled ended up with a weather badge pinned to the primary text color, beside siblings that were not. The default is now absent so it is never created, and each placement supplies the color it actually wants. A configuration already saved in this state keeps its explicit value; delete the `color` line to pick up the per-placement fallback. The icon takes the resolved color too, where it previously inherited and put a dark glyph in front of grey text
 
 ### Translations

--- a/docs/features/weather.md
+++ b/docs/features/weather.md
@@ -13,7 +13,7 @@ entities:
 days_to_show: 5
 weather:
   entity: weather.forecast_home
-  position: both # Options: 'date', 'event', or 'both'
+  position: both # Options: 'none', 'date', 'event', or 'both'
   date:
     # Date column shows condition icon and high temperature only
     show_conditions: true
@@ -40,7 +40,7 @@ This flexible configuration allows you to create a personalized experience that 
 | Option                            | Type    | Default                       | Description                                                                                                                        |
 | --------------------------------- | ------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `entity`                          | string  | -                             | Weather entity to use for forecasts                                                                                                |
-| `position`                        | string  | `date`                        | Where to show weather data: `'date'` (date column), `'event'` (next to events), or `'both'`                                        |
+| `position`                        | string  | `date`                        | Where to show weather data: `'none'` (nowhere), `'date'` (date column), `'event'` (next to events), or `'both'`                    |
 | `date → show_conditions`          | boolean | `true`                        | Whether to show weather condition icons in date column                                                                             |
 | `date → show_high_temp`           | boolean | `true`                        | Whether to show high temperature in date column                                                                                    |
 | `date → show_low_temp`            | boolean | `false`                       | Whether to show low temperature in date column. The UV index takes this place on days it is shown                                  |
@@ -65,6 +65,7 @@ These sit under the card's `weather` option — see [Weather in the configuratio
 
 You can choose where weather information appears in your calendar:
 
+- `none`: Hides weather everywhere, without clearing the entity — the card subscribes to no forecast at all
 - `date`: Shows daily forecasts in the date column (left side)
 - `event`: Shows hourly forecasts next to event titles
 - `both`: Displays weather in both positions simultaneously

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -272,7 +272,7 @@ export interface WeatherPositionConfig {
 /** Weather configuration. */
 export interface WeatherConfig {
   entity?: string;
-  position?: 'date' | 'event' | 'both';
+  position?: 'none' | 'date' | 'event' | 'both';
   date?: WeatherPositionConfig;
   event?: WeatherPositionConfig;
 }

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -27,6 +27,13 @@ export function getRequiredForecastTypes(
 
   const position = weatherConfig.position || 'date';
 
+  // 'none' renders nothing anywhere, so subscribing to a forecast would pay the
+  // cost of a stream nobody reads. Without this arm it falls through to the
+  // `['daily', 'hourly']` return below and becomes the most expensive option.
+  if (position === 'none') {
+    return [];
+  }
+
   if (position === 'date') {
     return ['daily'];
   }

--- a/tests/weather-position.test.ts
+++ b/tests/weather-position.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Weather `position` — forecast subscriptions must match what is actually rendered.
+ *
+ * The visual editor offers four positions including `'none'` ("Nowhere"). Before this
+ * suite, `'none'` was absent from the `WeatherConfig['position']` union, so it fell
+ * through `getRequiredForecastTypes`'s `!== 'date'` arm and subscribed to *both*
+ * forecast streams while rendering nothing — making the cheapest-looking option the
+ * most expensive one in the card.
+ *
+ * The invariant these tests pin: a position never subscribes to a stream it cannot
+ * render. `daily` is required exactly when the date column shows weather; `hourly`
+ * exactly when the event row does.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import * as Types from '../src/config/types';
+import * as WeatherUtils from '../src/utils/weather';
+
+const ENTITY = 'weather.forecast_home';
+
+/** Every position the visual editor can produce, in the order the select offers them. */
+const EDITOR_POSITIONS = ['none', 'date', 'event', 'both'] as const;
+
+function forecastsFor(position?: string): Array<string> {
+  return WeatherUtils.getRequiredForecastTypes({
+    entity: ENTITY,
+    ...(position === undefined ? {} : { position }),
+  } as Types.WeatherConfig);
+}
+
+describe('getRequiredForecastTypes', () => {
+  it('subscribes to nothing without an entity, whatever the position', () => {
+    const mismatches: Array<string> = [];
+    for (const position of EDITOR_POSITIONS) {
+      const got = WeatherUtils.getRequiredForecastTypes({ position } as Types.WeatherConfig);
+      if (got.length !== 0) mismatches.push(`${position} -> ${JSON.stringify(got)}`);
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it('subscribes to nothing for position "none"', () => {
+    expect(forecastsFor('none')).toEqual([]);
+  });
+
+  it('subscribes to daily only for position "date"', () => {
+    expect(forecastsFor('date')).toEqual(['daily']);
+  });
+
+  it('defaults to "date" behaviour when position is omitted', () => {
+    expect(forecastsFor(undefined)).toEqual(['daily']);
+  });
+
+  it('subscribes to daily and hourly for "event" and "both"', () => {
+    expect(forecastsFor('event')).toEqual(['daily', 'hourly']);
+    expect(forecastsFor('both')).toEqual(['daily', 'hourly']);
+  });
+
+  /**
+   * The bug in one assertion: "Nowhere" must never cost more than a position that
+   * actually draws something. This is what regressed, and it is the cheapest guard
+   * against the same fall-through returning.
+   */
+  it('never makes "none" more expensive than a rendering position', () => {
+    const none = forecastsFor('none').length;
+    const mismatches = EDITOR_POSITIONS.filter(
+      (p) => p !== 'none' && forecastsFor(p).length < none,
+    );
+    expect(mismatches).toEqual([]);
+    expect(none).toBe(0);
+  });
+
+  /**
+   * Guards the pairing that the fall-through violated: a stream is subscribed to
+   * exactly when some renderer consumes it. `leaves.ts` gates the date badge on
+   * `'date' | 'both'` and the event badge on `'event' | 'both'`.
+   */
+  it('subscribes to a stream only when a renderer consumes it', () => {
+    const mismatches: Array<string> = [];
+    for (const position of EDITOR_POSITIONS) {
+      const got = forecastsFor(position);
+      const rendersDate = position === 'date' || position === 'both';
+      const rendersEvent = position === 'event' || position === 'both';
+      // 'both' keeps the daily stream for the date column; 'event' still needs daily
+      // because the per-event forecast falls back to it beyond the hourly horizon.
+      const wantsDaily = rendersDate || rendersEvent;
+      if (got.includes('daily') !== wantsDaily) {
+        mismatches.push(`${position}: daily=${got.includes('daily')} want=${wantsDaily}`);
+      }
+      if (got.includes('hourly') !== rendersEvent) {
+        mismatches.push(`${position}: hourly=${got.includes('hourly')} want=${rendersEvent}`);
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it('treats an unknown position as a rendering one rather than silently dropping it', () => {
+    // Defensive: an unrecognised value must not resolve to "no forecast", which would
+    // hide a future typo behind an empty weather column instead of surfacing it.
+    expect(forecastsFor('bogus')).toEqual(['daily', 'hourly']);
+  });
+});


### PR DESCRIPTION
## The bug

The visual editor's weather position select offers four values — `none` ("Nowhere"), `date`, `event`, `both` — with `none` first and translated in all ten editor languages.

`WeatherConfig['position']` typed only `'date' | 'event' | 'both'`. So `none` was a value the editor could write but the type never admitted, and nothing on the way out strips it.

`getRequiredForecastTypes` branches on `=== 'date'` and treats *everything else* as a rendering position:

```ts
const position = weatherConfig.position || 'date';
if (position === 'date') return ['daily'];
return ['daily', 'hourly'];   // <- 'none' landed here
```

Meanwhile both renderers gate on `'date' | 'both'` and `'event' | 'both'`, so `none` draws nothing.

**Net: the option that renders nothing subscribed to both forecast streams — strictly more than "Date Column", which asks for `['daily']` alone.** The cheapest-looking choice was the most expensive one.

Measured before the fix:

| position | forecasts subscribed | renders |
|---|---|---|
| _(omitted)_ | `["daily"]` | date column |
| `date` | `["daily"]` | date column |
| `event` | `["daily","hourly"]` | event row |
| `both` | `["daily","hourly"]` | both |
| **`none`** | **`["daily","hourly"]`** | **nothing** |

## The fix

- `'none'` added to the `position` union in `types.ts`
- `getRequiredForecastTypes` returns `[]` for it, with a comment naming the fall-through so the arm is not "simplified" back out
- documented in `docs/features/weather.md` — the option table row, the positions list, and the YAML example comment

Keeping the option rather than dropping it from the select: it is a genuinely useful affordance (hide weather without clearing the entity), and removing it would orphan `position.option.none.label` in ten editor translation files.

## Tests

`tests/weather-position.test.ts` — 7 tests. Beyond the per-value assertions, two pin the invariant rather than the values:

- `'none'` must never cost more than a position that actually draws something
- a stream is subscribed to exactly when a renderer consumes it

**Mutation-falsified 5/5** — reverting the fix, returning `['daily']` for `none`, widening `date`, removing the no-entity guard, and flipping the default all turn the suite red.

## Gates

All ten green: `format`, `tsc --noEmit`, `lint`, `check:format`, `test`, `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`.

Found by an independent review pass; chain re-verified end to end and confirmed at runtime before fixing.
