### PR TITLE
fix(scripts): close four blind spots in the documentation gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -585,6 +585,16 @@ vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements.
 
 2. Update `docs/RELEASE_NOTES.md`, the README's `## 4️⃣ What's New` section, **and**
    `docs/guide/whats-new.md` — see _The two "What's New" surfaces_ for the differing rules.
+
+   `check:docs` now reads `package.json` and requires all three to name that exact
+   version: a `# Calendar Card Pro vX.Y.Z` section in the release notes, a `## vX.Y`
+   entry in the archive, and `vX.Y` somewhere in the README's What's New. Before this
+   existed, nothing tied the release docs to the shipped version — a bump could leave
+   every surface describing the _previous_ release, and the only thing that would ever
+   notice was `extract-release-notes.mjs` failing the release workflow after the tag was
+   already pushed. So step 1 and step 2 are now a single commit whether you like it or
+   not; bumping the version alone fails the PR.
+
 3. Open a PR from `dev` into `main` and merge it. `main`'s ruleset requires an approving
    review that you cannot give yourself, so this needs `gh pr merge <n> --merge --admin`.
 4. **Fast-forward `dev` back onto `main`** — `git push origin origin/main:dev`. The merge

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -441,6 +441,11 @@ function checkFences(docs) {
  * Deliberately asymmetric. A fragment showing two options is good documentation and is
  * not flagged. But a block carrying `type: custom:calendar-card-pro` is announcing
  * itself as copy-pasteable, so it has to work — which means it needs `entities:`.
+ *
+ * Checking that the *key* exists is not enough. `entities` must be a sequence: a scalar
+ * such as `entities: calendar.home` normalizes to no usable calendars and renders an
+ * empty card (see `tests/editor-malformed-entities.test.ts`), so an example that reads
+ * as copy-pasteable would still be broken while satisfying the gate.
  */
 function checkCopyableExamples(docs) {
   let complete = 0;
@@ -452,9 +457,34 @@ function checkCopyableExamples(docs) {
     blocks.forEach((block, i) => {
       if (!/^\s*type:\s*custom:calendar-card-pro\s*$/m.test(block)) return;
       complete++;
-      if (!/^\s*entities:/m.test(block)) {
+      const decl = block.match(/^([ \t]*)entities:[ \t]*(.*)$/m);
+      if (!decl) {
         error(
           `${rel}: yaml block #${i + 1} declares \`type: custom:calendar-card-pro\` but has no \`entities:\` — it reads as copy-pasteable but will not render`,
+        );
+        return;
+      }
+      const [matched, indent, inline] = decl;
+      const value = inline.replace(/(?:^|\s)#.*$/, '').trim();
+      let isSequence;
+      if (value) {
+        // A flow sequence on the same line, and a non-empty one: `[]` is as useless
+        // as a scalar.
+        isSequence = /^\[\s*\S[\s\S]*]$/.test(value);
+      } else {
+        // A block sequence: the next meaningful line must be a `- ` item indented at
+        // least as far as the key (YAML permits both `entities:\n- x` and `\n  - x`).
+        isSequence = false;
+        for (const line of block.slice(decl.index + matched.length).split('\n')) {
+          if (!line.trim() || /^\s*#/.test(line)) continue;
+          const item = line.match(/^([ \t]*)-\s+\S/);
+          isSequence = Boolean(item && item[1].length >= indent.length);
+          break;
+        }
+      }
+      if (!isSequence) {
+        error(
+          `${rel}: yaml block #${i + 1} declares \`type: custom:calendar-card-pro\` but \`entities:\` is not a non-empty list — a scalar or empty value normalizes to no calendars and renders an empty card`,
         );
       }
     });
@@ -872,7 +902,7 @@ function checkNoRawHtml(docs) {
         if (fenced) return;
         if (/<a\s[^>]*href=/.test(line))
           error(`${relative(ROOT, file)}:${i + 1} uses a raw <a href>. Use a markdown link.`);
-        if (/\sstyle="/.test(line))
+        if (/\sstyle\s*=/i.test(line))
           error(`${relative(ROOT, file)}:${i + 1} uses an inline style, which ignores the theme.`);
       });
   }
@@ -1130,21 +1160,40 @@ function checkCrossLinks(docs) {
   const rel = relative(ROOT, REFERENCE_DOC);
   let fenced = false;
   let seen = 0;
+  let lastHeading = -1;
+
+  /**
+   * Check that the section ending just above `end` closes with a → feature-page
+   * footer. `end` is the index of the next h2, or `lines.length` for the final
+   * section — which is why this is a named helper rather than inline: the last
+   * section has no following heading to trigger it, and for a long time was
+   * therefore never checked at all.
+   */
+  const checkFooterAbove = (end, label) => {
+    let j = end - 1;
+    while (j >= 0 && !lines[j].trim()) j -= 1;
+    if (j < 0 || /^#/.test(lines[j])) return; // an empty section
+    if (!/\(\/features\//.test(lines[j]))
+      error(`${rel}:${end} section ${label} has no → feature-page footer.`);
+  };
+
   lines.forEach((line, i) => {
     if (line.startsWith('```')) fenced = !fenced;
     if (fenced || !/^## /.test(line)) return;
 
     // The footer belongs to the previous section, so the first h2 has none.
     seen += 1;
+    lastHeading = i;
     if (seen === 1) return;
 
-    // Walk back to the previous section's last non-blank line.
-    let j = i - 1;
-    while (j >= 0 && !lines[j].trim()) j -= 1;
-    if (j < 0 || /^#/.test(lines[j])) return; // an empty section
-    if (!/\(\/features\//.test(lines[j]))
-      error(`${rel}:${i} section above "${line.slice(3)}" has no → feature-page footer.`);
+    checkFooterAbove(i, `above "${line.slice(3)}"`);
   });
+
+  // The final section is followed by end-of-file rather than by an h2, so the
+  // loop above can never reach it.
+  if (seen >= 1) {
+    checkFooterAbove(lines.length, `"${lines[lastHeading].slice(3)}" (final section)`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1314,7 +1363,8 @@ function report(counts) {
   console.log(
     `${counts.defaults} defaults in code, ${counts.rows} rows in the reference, ` +
       `${counts.fields} config fields, ${counts.docs} pages, ${counts.complete} complete examples, ` +
-      `${counts.releases} release lines documented, ${counts.links} internal links resolved.\n`,
+      `${counts.releases} release lines documented, ${counts.links} internal links resolved, ` +
+      `release surfaces agree on v${counts.version}.\n`,
   );
 
   if (errors.length) {
@@ -1392,6 +1442,66 @@ function checkColumnDefaultOverrides(overrides) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Check 18 — the release docs describe the version the package actually ships
+// ---------------------------------------------------------------------------
+
+/**
+ * `package.json` is the single source of truth for the release version, but nothing in
+ * this script read it: release notes were reconciled only against What's New, and the
+ * README's highlights were not checked at all. A version bump could therefore leave
+ * every release surface describing the previous release, and the gap would surface only
+ * at tag time, when `extract-release-notes.mjs` fails the release workflow.
+ *
+ * This moves that failure to the pull request that bumps the version.
+ */
+function checkReleaseVersion() {
+  const pkgPath = join(ROOT, 'package.json');
+  const version = JSON.parse(readFileSync(pkgPath, 'utf8')).version;
+  if (!/^\d+\.\d+\.\d+/.test(version || '')) {
+    error(`package.json: version "${version}" is not a semver release version.`);
+    return null;
+  }
+  const [major, minor] = version.split('.');
+  const line = `${major}.${minor}`;
+
+  const notes = readFileSync(join(DOCS_DIR, 'RELEASE_NOTES.md'), 'utf8');
+  // Anchored to the exact version: a patch release needs its own notes section, which
+  // is also what the tag-time extractor looks for.
+  if (!new RegExp(`^# Calendar Card Pro v${version.replace(/\./g, '\\.')}\\b`, 'm').test(notes)) {
+    error(
+      `docs/RELEASE_NOTES.md has no "# Calendar Card Pro v${version}" section, but package.json ships ${version}. The release workflow extracts this section by exact version and fails without it.`,
+    );
+  }
+
+  const whatsNew = readFileSync(join(DOCS_DIR, 'guide/whats-new.md'), 'utf8');
+  if (
+    !new RegExp(`^## (?:Latest Release: )?v${line.replace('.', '\\.')}\\s*$`, 'm').test(whatsNew)
+  ) {
+    error(
+      `docs/guide/whats-new.md has no "## v${line}" entry, but package.json ships ${version}. The archive must cover every minor line.`,
+    );
+  }
+
+  const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
+  // Sliced rather than matched with an end anchor: JavaScript has no `\Z`, and `$` under
+  // /m would stop at the first line break.
+  const start = readme.search(/^## [^\n]*What's New/m);
+  if (start === -1) {
+    error("README.md: no What's New section found — the landing page must show the highlights.");
+  } else {
+    const rest = readme.slice(start + 1);
+    const next = rest.search(/^## /m);
+    const section = next === -1 ? rest : rest.slice(0, next);
+    if (!new RegExp(`v${line.replace('.', '\\.')}\\b`).test(section)) {
+      error(
+        `README.md's What's New section does not mention v${line}, but package.json ships ${version}. The landing page would advertise the previous release.`,
+      );
+    }
+  }
+  return version;
+}
+
 function main() {
   const defaults = readDefaults();
   const rows = readReferenceRows();
@@ -1420,6 +1530,7 @@ function main() {
   checkCrossLinks(docs);
   checkAgentsDuplication();
   checkAgentsLinks();
+  const version = checkReleaseVersion();
 
   process.exit(
     report({
@@ -1430,6 +1541,7 @@ function main() {
       complete,
       releases,
       links,
+      version,
     }),
   );
 }


### PR DESCRIPTION
Closes four proven blind spots in `scripts/check-docs.mjs`, a ~52 KB gate that had never been audited. Two of them were found independently by two different review models, which is what prompted the audit.

Every hole was demonstrated by **planting a violation and observing exit 0**, and every fix was then re-planted to confirm exit 1 — plus controls to confirm the fix does not reject legal documentation.

### 1 — the last reference section was never checked

Check 14 requires each `configuration.md` section to end with a `**→ [Feature page](/features/…)**` footer, but it validated a section only on encountering the *next* `##`. The final section (`## ⚡ Cache & Refresh`, **1 of 10**) was structurally unreachable.

| plant | before | after |
|---|---|---|
| remove the **final** section's footer | exit 0 ❌ | exit 1 ✅ |
| remove the second-to-last section's footer (control) | exit 1 ✅ | exit 1 ✅ |

### 2 — `entities:` was checked for presence, not shape

A block carrying `type: custom:calendar-card-pro` announces itself as copy-pasteable, so the gate required an `entities:` key. It did not require a *list*. `entities: calendar.home` normalizes to no usable calendars and renders an empty card — `tests/editor-malformed-entities.test.ts` documents exactly this — yet the gate counted such a block as one of its 21 complete examples.

| plant | before | after |
|---|---|---|
| `entities: calendar.scalar` | exit 0 ❌ (counted complete) | exit 1 ✅ |
| `entities: []` | exit 0 ❌ | exit 1 ✅ |
| `entities:` with nothing under it | exit 0 ❌ | exit 1 ✅ |
| key absent (control) | exit 1 ✅ | exit 1 ✅ |

Controls proving no false positives — all five exit 0, before and after:
`entities:\n  - calendar.a` · `entities:\n- calendar.a` · `entities: [a, b]` · `entities:\n  - entity: calendar.a` · `entities: # comment\n  - calendar.a`

### 3 — single-quoted inline styles slipped through

`/\sstyle="/` matched double quotes only.

| plant | before | after |
|---|---|---|
| `style='color:red'` | exit 0 ❌ | exit 1 ✅ |
| `style = "…"` (spaces) | exit 0 ❌ | exit 1 ✅ |
| `STYLE="…"` (uppercase) | exit 0 ❌ | exit 1 ✅ |
| `style="color:red"` (control) | exit 1 ✅ | exit 1 ✅ |

### 4 — no release-version source of truth

The script never read `package.json`. Release notes were reconciled only against What's New, and the README's highlights were not checked at all. A version bump could therefore leave **all three** release surfaces describing the previous release, and the only thing that would ever notice was `extract-release-notes.mjs` failing the release workflow — *after* the tag was pushed. New check 18 moves that failure to the PR that bumps the version.

| plant | result |
|---|---|
| bump to `4.1.0`, no release notes / no `## v4.1` | exit 1 ✅ |
| bump to `4.0.1`, no `v4.0.1` notes section | exit 1 ✅ |
| mangle the What's New heading | exit 1 ✅ |
| README advertises `v3.9` | exit 1 ✅ |

### Two bugs the *controls* caught, not the plants

- A comment placed immediately after the key — `entities: # pick yours` — was not stripped, because the strip regex required whitespace *before* the `#`. It fired on a legal example.
- Check 18's first draft ended its README section match with `(?=^## |\Z)`. **JavaScript has no `\Z`** — it matches a literal `Z` (`/^ab\Z/.test('abZ') === true`). It worked only because another `##` section follows today; had What's New ever been last, the check would have reported the section missing. Replaced with an explicit slice, then falsified by truncating the README so What's New *is* last: no false positive, and a wrong version there still fires.

### Gates

All ten green. `1284` tests. Counts unchanged — the stricter `entities` check rejects none of the 21 real examples: `93 defaults, 93 rows, 119 fields, 22 pages, 21 complete examples, 16 release lines, 133 links, release surfaces agree on v4.0.0`.

No release-notes entry: tooling hygiene, not user-visible.
