### PR TITLE
fix(quality): complete truncated comments, repair a stale falsifier, align the two view resolvers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,10 +228,14 @@ and breaking lines. The reason the claim survived so long is an asymmetry worth 
 round-trip unchanged**, and it breaks as `</span\n><span` so no new text node appears
 between inline elements. But a template deliberately written to have _none_ gets the
 indentation put back. **Deliberate whitespace needs `// prettier-ignore`**; `leaves.ts`
-uses it at `leaves.ts:122` on the weather badge, added after `npm run format`
-reintroduced the exact spaces a fix had just removed and turned five tests red. If you
-find that directive and wonder whether it is still needed, it is — delete it and run
-`npm test`.
+uses it at **three** sites — the day-header weather badge, the event weather badge, and
+the folded time/countdown spans — each added after `npm run format` reintroduced the
+exact spaces a fix had just removed and turned five tests red. Locate them with
+`grep -n "prettier-ignore" src/rendering/leaves.ts` rather than by line number; two of
+the three moved the last time someone edited a comment above them. If you find one and
+wonder whether it is still needed, it is — delete it, **run `npm run format`**, then
+`npm test`. The format step is the whole experiment: without it the directive's removal
+changes nothing and all 1237 tests pass, which reads as "safe to delete" and is not.
 
 **Never resolve a snapshot failure with `vitest -u`.** It launders the change past review,
 and the gate's entire value is that it is the one artefact the person doing the refactor
@@ -934,8 +938,16 @@ These documents lean hard on the word _verified_, so it is worth saying what it 
 **A claim that no available case could have falsified has not been verified; it has been
 untested** — and "verified, not assumed" is the label most likely to end up attached to
 exactly that. So say **how** you checked, and prefer a claim that ships with its own
-falsifier: _"delete `leaves.ts:122` and run `npm test`"_ cannot go quietly stale the way
-_"prettier does not reformat templates"_ did.
+falsifier: _"delete a `prettier-ignore` in `leaves.ts`, run `npm run format`, then
+`npm test`"_ cannot go quietly stale the way _"prettier does not reformat templates"_ did.
+
+**A falsifier is itself a claim, and it can rot in two ways.** This one did both. It
+cited `leaves.ts:122`, a line that has since become three lines none of which is 122 —
+so write the `grep` that finds the site, not the number. And it omitted the `format`
+step, so anyone who ran it exactly as written saw 1237 tests pass and would reasonably
+have concluded the directive was dead. **Re-run your own falsifiers before quoting them**;
+a falsifier that no longer falsifies is worse than none, because it launders an untested
+claim as a verified one.
 
 **Four ways a check passes while proving nothing.** Each was found here, twice, against
 different artefacts.

--- a/src/config/view.ts
+++ b/src/config/view.ts
@@ -419,7 +419,14 @@ export function resolveViewOption<K extends keyof Types.ColumnOverrides & keyof 
   if (overrides && hasOverride(overrides, key)) {
     // `hasOverride` has established that the option is present and not `undefined`,
     // which is the only way the optional override type can widen the config type.
-    return overrides[key] as Types.Config[K];
+    //
+    // Coerced for the same reason as in `resolveEffectiveConfig`: both resolvers read
+    // the same block, so a bare `day_spacing: 4` has to become `'4px'` whichever one the
+    // caller reached for. A total no-op on non-length keys — `coercePixelLength` acts
+    // only when the value is a bare number and the shipped default is a `px` string, and
+    // every current call site passes a boolean — so this is here to keep the two answers
+    // identical as keys are added, not to fix a live defect.
+    return coercePixelLength(key, overrides[key]) as Types.Config[K];
   }
 
   // `??` rather than a presence test on purpose: a column default of `false` is a

--- a/src/rendering/editor/schemas/content.ts
+++ b/src/rendering/editor/schemas/content.ts
@@ -65,7 +65,9 @@ function compactFields(hasEventLimit: boolean): HaFormSchema[] {
  * @param startMode - Derived start-date mode
  * @param languageMode - Derived language mode
  * @param hasEventLimit - Whether a compact event limit is set, which is what the
+ *   `compact_events_complete_days` toggle depends on
  * @param showEmptyDays - Whether empty days are shown, which is what the two empty-day
+ *   fields depend on
  * @returns The panel's schema
  */
 const contentSchema = Helpers.memoizeLast(

--- a/src/rendering/editor/schemas/weather.ts
+++ b/src/rendering/editor/schemas/weather.ts
@@ -49,6 +49,7 @@ function eventLineLimit(showConditions: boolean): HaFormSchema[] {
  * @param dateUvIndex - Whether the day forecast shows a UV index
  * @param eventUvIndex - Whether the event forecast shows a UV index
  * @param eventConditions - Whether the event row shows its condition, which is the only
+ *   thing `max_lines` depends on
  * @returns The panel's schema
  */
 const weatherSchema = Helpers.memoizeLast(

--- a/src/rendering/leaves.ts
+++ b/src/rendering/leaves.ts
@@ -290,7 +290,9 @@ function hasEventWeather(config: Types.Config): boolean {
  * @param event Event the badge describes
  * @param config Card configuration
  * @param weatherForecasts Fetched forecasts, if any
- * @param placement Where the badge is being placed. `'title'` is the list view's
+ * @param placement Where the badge is being placed. `'title'` is the list view's inline
+ *   badge inside the summary row; `'row'` is column view's dedicated line, which always
+ *   shows the icon and localizes the condition text.
  * @param hass Home Assistant instance, used only to localize the condition text
  * @returns Rendered badge, or an empty template when there is nothing to show
  */
@@ -493,6 +495,7 @@ export function renderEventContent(
               </div>
             `
           : // No text placement here: with `show_time: false` there is no time text to
+            // fold the countdown into, so it always renders on its own.
             countdownStr
             ? html`
                 <div class="time">
@@ -568,7 +571,9 @@ function parseIndicatorPosition(position: string): Record<string, string> {
  *
  * @param config Calendar card configuration
  * @param isToday Whether the current day is today
- * @param layout Placement strategy — `absolute` positions by percentage, `inline`
+ * @param layout Placement strategy — `absolute` positions by percentage from
+ *   `today_indicator_position` (list view), `inline` ignores that option and lets the
+ *   indicator flow inside the column-view day header.
  * @returns TemplateResult or nothing
  */
 export function renderTodayIndicator(

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,9 @@
 /**
  * Helper utilities for Calendar Card Pro
- * General purpose utility functions for debouncing, memoization,
+ *
+ * General purpose utilities: color conversion, indicator and label type
+ * detection, ID generation and hashing, locale-aware formatting, config
+ * default filtering, and single-entry memoization.
  */
 
 //-----------------------------------------------------------------------------

--- a/tests/view-config.test.ts
+++ b/tests/view-config.test.ts
@@ -1361,3 +1361,45 @@ describe('resolveColumnFitOnMeasurement', () => {
     expect(resolveColumnFitOnMeasurement('column', config, 1200, 1065, confirmed).columns).toBe(7);
   });
 });
+
+describe('resolveViewOption and resolveEffectiveConfig agree', () => {
+  // Both resolvers read the same `column:` block, so a caller must get the same answer
+  // whichever it reaches for. They diverged once: only `resolveEffectiveConfig` applied
+  // `coercePixelLength`, so a bare `day_spacing: 4` resolved to `4` through one path and
+  // `'4px'` through the other. Nothing caught it because every `resolveViewOption` call
+  // site happened to pass a boolean, where the coercion is a no-op — the divergence was
+  // waiting for the first length-valued caller.
+  const bareNumberOverrides = Object.fromEntries(
+    COLUMN_OVERRIDE_KEYS.map((key) => [key, 4]),
+  ) as Types.ColumnOverrides;
+
+  it('returns identical values for every override key', () => {
+    const config = buildConfig({ view: 'column', column: bareNumberOverrides });
+    const effective = resolveEffectiveConfig(config, 'column');
+
+    const mismatches = COLUMN_OVERRIDE_KEYS.filter(
+      (key) => resolveViewOption(config, key, 'column') !== effective[key],
+    );
+
+    expect(mismatches).toEqual([]);
+  });
+
+  it('coerces a bare number on a length-valued key, through either path', () => {
+    // Cast because the type says `string` while YAML and the editor both hand over a
+    // bare number — which is the whole reason `coercePixelLength` exists.
+    const config = buildConfig({
+      view: 'column',
+      column: { day_spacing: 4 as unknown as string },
+    });
+
+    expect(resolveViewOption(config, 'day_spacing', 'column')).toBe('4px');
+    expect(resolveEffectiveConfig(config, 'column').day_spacing).toBe('4px');
+  });
+
+  it('leaves a non-length key untouched, through either path', () => {
+    const config = buildConfig({ view: 'column', column: { description_max_lines: 4 } });
+
+    expect(resolveViewOption(config, 'description_max_lines', 'column')).toBe(4);
+    expect(resolveEffectiveConfig(config, 'column').description_max_lines).toBe(4);
+  });
+});


### PR DESCRIPTION
Comment-and-authority hygiene from review pass 7, plus one latent inconsistency closed with a test.

## Seven truncated comments

v4's comment-compaction pass cut six JSDoc blocks and one inline comment mid-clause. Every completion here was **derived from the code**, not reverted from `dev` — a revert is not automatically the right fix:

- **`helpers.ts`'s module header.** The `dev` text described *"debouncing, memoization, performance monitoring"*. Measured: `grep -ci "debounce" src/utils/helpers.ts` returns **0 on both branches**, and the module has no performance monitoring either. The truncation had accidentally deleted an *inaccurate* sentence, so restoring it would have restored a lie. Rewritten from the module's real contents (4 section banners, 13 exports).
- **`leaves.ts`'s `@param placement` / `@param layout` and both `editor/schemas` `@param`s.** These parameters **do not exist on `dev` at all** — they are new in v4 and were cut in the same pass that wrote them. There was nothing to restore. Each was completed by reading its single call site:
  - `placement: 'row'` is set only by `column.ts:178`; it forces the icon on and localizes the condition text.
  - `layout: 'inline'` is set only by `column.ts:232`; it **skips `parseIndicatorPosition` entirely**.
  - The three schema params all document `memoizeLast` keys — each boolean changes the schema *shape*, so it must be in the key.

A detector keyed on determiners rather than prepositions (`the`/`which`/`a`/`that` cannot end an English sentence; `from`/`for`/`to` routinely do) confirms **these seven were the complete set** — no eighth truncation exists in `src/`.

## AGENTS.md's `prettier-ignore` falsifier was broken in two ways

It cited `leaves.ts:122`. There are **three** such directives and none is at 122 — and two of them moved under this very commit, which is the argument against citing line numbers at all.

More seriously, it instructed *"delete it and run `npm test`"*. Both arms measured:

| | result |
|---|---|
| delete directive, `npm test` — **as documented** | **1237 passed, 0 failed** |
| delete directive, `npm run format`, `npm test` | **5 failed**, 1232 passed |

Without the format step nothing reformats, so the removal changes nothing. Anyone following the instruction literally would have seen a clean run and reasonably concluded the directive was dead. The passage now names the `grep` instead of a line number, includes the missing step, and says why it is load-bearing.

This sits in the *Verification* section, whose subject is claims that ship with their own falsifier — so it now also records that **a falsifier is itself a claim and can rot**.

## `resolveViewOption` and `resolveEffectiveConfig` disagreed

Both read the same `column:` block, but only `resolveEffectiveConfig` applied `coercePixelLength`. A bare `day_spacing: 4` therefore resolved to `4` through one resolver and `'4px'` through the other.

Harmless *today* only because all three `resolveViewOption` call sites pass booleans, where the coercion is a total no-op. But **13 of the 30+ override keys are length-valued** (`day_spacing`, `event_spacing`, `height`, `max_height`, `*_font_size`, `progress_bar_*`, …), so the first length-valued caller would have hit it — the sixth instance of the "derived value diverges" class this review has found.

Made consistent, and pinned by three tests that iterate **every** `COLUMN_OVERRIDE_KEYS` member. Reverting the one-line fix fails two of the three; the third correctly keeps passing, because coercion *should* be a no-op on a non-length key.

## Verification

All ten gates exit 0 — `format`, `tsc --noEmit`, `lint`, `check:format`, `test` (**45 files / 1240 tests**), `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`.

`tsc` caught a type error in my own new test that `npm test` did not, since vitest does not typecheck — the bare number is a runtime shape the type forbids, which is precisely what `coercePixelLength` exists to absorb.

No release-notes entry: comment, documentation and test hygiene with no user-visible behaviour change.
