### PR TITLE
ci(release): refuse to build a release from a commit that is not on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,30 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Full history, so the ancestry check below has something to walk. The default
+          # shallow fetch hands it a single commit with no relationship to any branch.
+          fetch-depth: 0
+
+      # A `v*` tag on *any* commit reaches this workflow — the trigger cannot tell a
+      # release tag on main from one pushed to a feature branch by mistake, and the
+      # version check below compares the tag text to package.json, which a release
+      # branch carrying the bumped version passes cleanly. So without this step,
+      # tagging the wrong branch produces a complete, publishable draft release whose
+      # two assets are built from unreviewed code, and the only signal that anything is
+      # wrong is a draft appearing where you expected one.
+      #
+      # Placed before the install so it costs seconds, and stated as ancestry rather
+      # than "is the tag on main" so that tagging an older commit that main has since
+      # moved past still passes — that is a legitimate patch release.
+      - name: Verify tag is on main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA}, which is not an ancestor of origin/main. Release tags are created on main after the dev -> main release PR has merged; see AGENTS.md § Release process."
+            exit 1
+          fi
+          echo "Ancestry check passed: ${GITHUB_SHA} is reachable from main."
 
       # Read the Node version from .nvmrc, exactly as ci.yml does. This job is the one
       # that runs `npm ci` against the lockfile and publishes what every user downloads,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -600,7 +600,11 @@ vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements.
 4. **Fast-forward `dev` back onto `main`** — `git push origin origin/main:dev`. The merge
    commit from step 3 exists only on `main`; without this, `dev` starts the next cycle a
    commit behind. See _`dev` must never fall behind `main`_.
-5. Tag `main` with `vX.Y.Z` and push the tag.
+5. Tag `main` with `vX.Y.Z` and push the tag. It has to be `main`: the workflow triggers
+   on any `v*` tag, so it now refuses to build unless the tagged commit is an ancestor of
+   `origin/main`. Tagging `dev` — which carries the same bumped version and therefore
+   passes the tag/`package.json` check — would otherwise have produced a complete,
+   publishable draft release built from code that never went through the release PR.
 6. `.github/workflows/release.yml` builds and creates a **draft** GitHub release. It
    attaches `dist/*.js` and nothing else — since the two-file split that is **both**
    `calendar-card-pro.js` and `editor.js`. Publish it manually.


### PR DESCRIPTION
Found by review pass 8. `release.yml` triggers on `v*` with **no constraint on where the tag sits**, and its only guard compares the tag text to `package.json`:

```yaml
on:
  push:
    tags:
      - 'v*'
```

A release branch carries the bumped version by definition, so **tagging the wrong branch passes that check**. The result is a complete, publishable draft release — correct version string, both assets, curated notes — built from code that never went through the `dev` → `main` release PR. The only signal that anything is wrong is a draft appearing where you expected one.

## Measured against this repository

| | |
|---|---|
| `git rev-list --count origin/main..origin/feature/column-view-v4` | **449** |
| `git merge-base --is-ancestor <v4 head> origin/main` | **false** |
| version guard replayed with `GITHUB_REF_NAME=v4.0.0` | **accepts it** |

So the failure mode is live right now: a `v4.0.0` tag pushed to this branch instead of `main` would build and attach both HACS-distributed files.

## The fix

An ancestry check placed **immediately after checkout, before the install**, so it costs seconds rather than a full lint + build cycle:

```bash
git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
  echo "::error::Tag ... is not an ancestor of origin/main."
  exit 1
fi
```

Stated as **ancestry**, not equality with `main`'s tip, so that tagging an older commit `main` has since moved past — a legitimate patch release — still passes.

`fetch-depth: 0` on the checkout is required for it. The default shallow fetch hands the check a single commit with no relationship to any branch, so without it the guard would fail *every* release rather than only the wrong ones.

## Verification

The step's exact shell was replayed locally against three commits:

| commit | expected | result |
|---|---|---|
| `feature/column-view-v4` head (449 ahead, not an ancestor) | blocked | **blocked** |
| `origin/main` tip | allowed | **allowed** |
| `origin/main~3` (older commit, patch-release case) | allowed | **allowed** |

The workflow YAML parses and the step order is as intended — `Checkout` → `Verify tag is on main` → `Setup Node.js` → …

All ten gates exit 0: `format`, `tsc --noEmit`, `lint`, `check:format`, `test` (45 files / 1240 tests), `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`.

AGENTS.md § Release process step 5 now says *why* the tag has to be on `main`, so a maintainer who hits the guard finds the reason rather than working around it.

No release-notes entry: CI infrastructure with no user-visible behaviour change.
