### PR TITLE
Reconcile the documented gate list with the gates CI runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,16 +164,23 @@ npm run check:format
 npm test
 npm run check:i18n
 npm run check:docs
+npm run docs:build
 npm run build
 npm run check:bundle   # after the build — it reads dist/
 ```
 
-Those eight are every npm gate CI runs, so a green local run should mean a green PR.
+Those nine are every npm gate CI runs, so a green local run should mean a green PR.
 `check:docs` is the one that
 surprises people: it is described under _Documenting a change_ below, which makes it look like a
 docs-only concern, but it gates **every** PR. A change touching no `src/` file at all can
 still fail it. Adding a config option without a reference-table row fails it too — which is the
 point.
+
+`docs:build` is not redundant with it. `check:docs` reads the Markdown as text; `docs:build`
+compiles it, so it is the only gate that sees a page VitePress cannot parse. A stray `{{ … }}`
+in prose — easy to write in a Home Assistant card's docs, where that is Jinja rather than Vue —
+passes `check:docs` and fails the build. Check 20 in `check-docs.mjs` reconciles this list
+against `ci.yml`, because it silently went stale once when `docs:build` was added to CI.
 
 Two things to know before trusting it. `tests/list-dom.test.ts` snapshots serialized DOM, so
 an intentional markup change means **reading** the snapshot diff and committing it, not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,13 +145,16 @@ one that leaves relative times quietly in English.
    npm test
    npm run check:i18n    # translation wiring
    npm run check:docs    # docs and config parity — gates every PR, not only docs changes
+   npm run docs:build    # compiles the docs site; catches pages check:docs cannot parse
    npm run build
    npm run check:bundle  # after the build; it reads dist/
    ```
 
    `check:docs` is the one that surprises people: it reads like a docs-only concern but
    gates every PR, and adding a config option without a reference-table row fails it —
-   which is the point.
+   which is the point. `docs:build` is not redundant with it: `check:docs` reads the
+   Markdown as text, while `docs:build` compiles it, so it is the only gate that catches a
+   page VitePress cannot parse.
 
 4. Submit a PR against the **`dev`** branch (not `main` — `main` only receives release
    PRs from `dev`)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,6 +29,7 @@ Want to improve **Calendar Card Pro**? I welcome contributions of all kinds—wh
    npm test
    npm run check:i18n    # translation wiring
    npm run check:docs    # docs and config parity — gates every PR, not only docs changes
+   npm run docs:build    # compiles the docs site; catches pages check:docs cannot parse
    npm run build
    npm run check:bundle  # after the build; it reads dist/
    ```

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1459,6 +1459,7 @@ function report(counts) {
     `${counts.defaults} defaults in code, ${counts.rows} rows in the reference, ` +
       `${counts.fields} config fields, ${counts.docs} pages, ${counts.complete} complete examples, ` +
       `${counts.releases} release lines documented, ${counts.links} internal links resolved, ` +
+      `${counts.gates} CI gates documented, ` +
       `release surfaces agree on v${counts.version}.\n`,
   );
 
@@ -1597,6 +1598,65 @@ function checkReleaseVersion() {
   return version;
 }
 
+// ---------------------------------------------------------------------------
+// Check 20 — the documented gate list matches the gates CI actually runs
+// ---------------------------------------------------------------------------
+
+/**
+ * Three files tell a contributor which commands to run before pushing, and all three
+ * claim the list is complete: "every npm gate CI runs, so a green local run should mean
+ * a green PR". Nothing checked that claim, so adding a step to `ci.yml` silently made all
+ * three wrong — which is exactly what happened when `docs:build` was added to CI and the
+ * lists were not updated. The promise then inverts: the docs send you to a green local run
+ * that still fails the pull request.
+ *
+ * `ci.yml` is the source of truth. Extra entries fail too, so a list cannot drift by
+ * naming a gate CI dropped.
+ */
+function checkGateLists() {
+  const normalize = (line) =>
+    line
+      .trim()
+      .replace(/\s+#.*$/, '')
+      .replace(/\s+/g, ' ');
+
+  const workflow = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8');
+  const gates = workflow
+    .split('\n')
+    .map((line) => line.match(/^\s*run:\s*((?:npm|npx)\s.+)$/))
+    .filter(Boolean)
+    .map((match) => normalize(match[1]))
+    // Installing dependencies is not a gate a contributor reruns as a check.
+    .filter((command) => command !== 'npm ci');
+  assertFound(gates, 'npm gate commands', join(ROOT, '.github/workflows/ci.yml'));
+
+  // Each file states the list once, in the only fenced block that reaches check:bundle.
+  for (const file of ['AGENTS.md', 'CONTRIBUTING.md', 'docs/contributing.md']) {
+    const text = readFileSync(join(ROOT, file), 'utf8');
+    const block = [...text.matchAll(/```(?:bash|sh)\n([\s\S]*?)```/g)]
+      .map((match) => match[1])
+      .find((body) => body.includes('check:bundle'));
+    if (!block) {
+      error(`${file}: no gate list found — the check cannot run blind, so fix the parser.`);
+      continue;
+    }
+    const listed = block.split('\n').map(normalize).filter(Boolean);
+    for (const gate of gates) {
+      if (!listed.includes(gate)) {
+        error(
+          `${file} omits \`${gate}\`, which ci.yml runs. The file promises the list is every gate CI runs, so a contributor following it would push a red pull request.`,
+        );
+      }
+    }
+    for (const command of listed) {
+      if (!gates.includes(command)) {
+        error(`${file} lists \`${command}\`, which ci.yml does not run.`);
+      }
+    }
+  }
+  return gates.length;
+}
+
 function main() {
   const defaults = readDefaults();
   const rows = readReferenceRows();
@@ -1626,6 +1686,7 @@ function main() {
   checkCrossLinks(docs);
   checkAgentsDuplication();
   checkAgentsLinks();
+  const gates = checkGateLists();
   const version = checkReleaseVersion();
 
   process.exit(
@@ -1637,6 +1698,7 @@ function main() {
       complete,
       releases,
       links,
+      gates,
       version,
     }),
   );


### PR DESCRIPTION
## What was wrong

`AGENTS.md`, `CONTRIBUTING.md` and `docs/contributing.md` each list the commands to run before pushing, and each states the list is **complete** — "every npm gate CI runs, so a green local run should mean a green PR".

Nothing checked that claim. When `docs:build` was added to `ci.yml` (in #436, my own PR), none of the three lists were updated, so all three began promising the opposite of what they deliver: follow them exactly, get a green local run, push a red PR.

## Why it is material, not cosmetic

`check:docs` reads the Markdown **as text**. `docs:build` **compiles** it. So `docs:build` is the only gate that sees a page VitePress cannot parse — and the realistic trigger in *this* project is prose containing `{{ … }}`, which is Jinja in Home Assistant but a Vue interpolation to VitePress.

Proven by planting a malformed interpolation inline in an existing paragraph, so no other rule could fire:

| run | `check:docs` | `docs:build` |
|---|---|---|
| clean control | 0 | 0 |
| `{{ 1 + }}` planted inline | **0 — passes** | **1 — fails** |
| restored | 0 | 0 |

VitePress: `[vite:vue] docs/features/column-view.md (7:62): Error parsing JavaScript expression`.

## What changed

- `docs:build` added to all three lists, in CI's own position; "Those eight" → "Those nine".
- A short paragraph in each explaining why the two docs gates are not redundant.
- **Check 20** in `check-docs.mjs` reconciles the three lists against `ci.yml` in *both* directions: a gate CI runs that a file omits, and a command a file lists that CI does not run. It fails closed when the list cannot be located, so it cannot pass blind.

## Falsification

| case | result |
|---|---|
| doc omits a CI gate | exit 1 — `CONTRIBUTING.md omits \`npm run docs:build\`` |
| doc lists a non-CI gate | exit 1 — `docs/contributing.md lists \`npm run nonexistent:gate\`` |
| CI gains a gate, docs unchanged | exit 1 — `AGENTS.md omits \`npm run brand:new:gate\`` |
| gate list unfindable | exit 1 — `no gate list found — the check cannot run blind` |
| restored | exit 0 |

All ten gates green: `format`, `tsc --noEmit`, `lint`, `check:format`, `test`, `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`. Summary line now reports `9 CI gates documented`.

No release-notes entry: contributor tooling and docs hygiene, no user-visible change.
