### PR TITLE
refactor: resolve the column block at the groupEventsByDay boundary

### DIFF
--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -139,7 +139,7 @@ function deduplicateEvents(
  * Group events by display day.
  *
  * @param rawEvents Calendar events to group
- * @param config Card configuration
+ * @param rawConfig Card configuration, with or without the `column:` block applied
  * @param isExpanded Whether the card is in expanded mode
  * @param language Language code for date calculations
  * @param effectiveView View currently being rendered
@@ -148,19 +148,25 @@ function deduplicateEvents(
  */
 export function groupEventsByDay(
   rawEvents: Types.CalendarEventData[],
-  config: Types.Config,
+  rawConfig: Types.Config,
   isExpanded: boolean,
   language: string,
   effectiveView: Types.EffectiveView = 'list',
   hassLocale?: { language?: string; first_weekday?: string },
 ): Types.EventsByDay[] {
-  const events = deduplicateEvents(
-    rawEvents,
-    config,
-    ViewConfig.resolveViewOption(config, 'filter_duplicates', effectiveView),
-  );
+  // Resolved once, at the boundary, so every read below is view-aware without each
+  // one having to remember to ask for itself. Roughly a dozen override-capable
+  // options are read in this function and its helpers; when only some of them went
+  // through a resolver, the rest silently ignored the `column:` block for any caller
+  // that had not already applied it. Callers in `calendar-card-pro.ts` do pass the
+  // effective config, and this is a no-op on one — the resolver re-reads the same
+  // block and reaches the same answer — so this is here to make the function correct
+  // on its own terms rather than to fix a live defect.
+  const config = ViewConfig.resolveEffectiveConfig(rawConfig, effectiveView);
 
-  const showEmptyDays = ViewConfig.resolveViewOption(config, 'show_empty_days', effectiveView);
+  const events = deduplicateEvents(rawEvents, config, config.filter_duplicates);
+
+  const showEmptyDays = config.show_empty_days;
 
   const compactLimitsApply = !isExpanded && ViewConfig.viewAppliesCompactLimits(effectiveView);
 
@@ -172,14 +178,7 @@ export function groupEventsByDay(
   // cannot vanish from their columns.
   const splitEvents = processMultiDayEvents(
     events,
-    {
-      ...config,
-      split_multiday_events: ViewConfig.resolveViewOption(
-        config,
-        'split_multiday_events',
-        effectiveView,
-      ),
-    },
+    config,
     ViewConfig.viewForcesMultidaySplit(effectiveView),
   );
 

--- a/tests/group-events-view-scope.test.ts
+++ b/tests/group-events-view-scope.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as EventUtils from '../src/utils/events';
+
+/**
+ * `groupEventsByDay` resolves the `column:` block itself, at its own boundary,
+ * rather than trusting every caller to have done it first.
+ *
+ * Roughly a dozen override-capable options are read inside the function and its
+ * helpers. Before this, some went through a resolver and the rest read the
+ * config directly, so a caller that passed a raw config got a mix: a few
+ * options honoured the `column:` block and the others quietly ignored it. Every
+ * production call site did pass the resolved config, so nothing was visibly
+ * broken — but that is a property of the callers, not of the function, and it
+ * is the same shape as the multi-day splitting defect that *was* reachable.
+ *
+ * These tests therefore pass a deliberately **raw** config. Each one pairs the
+ * column assertion with the same config rendered as a list, so a case cannot
+ * pass by the override having no effect in either view.
+ */
+
+/** A timed event that has already finished relative to {@link FROZEN_NOW}. */
+function pastEvent(): Types.CalendarEventData {
+  return {
+    start: { dateTime: '2026-06-17T08:00:00.000Z' },
+    end: { dateTime: '2026-06-17T09:00:00.000Z' },
+    summary: 'Already Over',
+    _entityId: 'calendar.personal',
+  };
+}
+
+/** Every summary rendered for the given view, flattened across days. */
+function summaries(
+  events: Types.CalendarEventData[],
+  config: Types.Config,
+  view: Types.EffectiveView,
+): (string | undefined)[] {
+  return EventUtils.groupEventsByDay(events, config, false, 'en', view).flatMap((day) =>
+    day.events.map((event) => event.summary),
+  );
+}
+
+describe('groupEventsByDay resolves the column block itself', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  it('honours a column empty_day_text override on a raw config', () => {
+    const config = buildConfig({
+      view: 'column',
+      days_to_show: 2,
+      show_empty_days: true,
+      empty_day_text: 'TOP',
+      column: { empty_day_text: 'COL' },
+    } as Partial<Types.Config>);
+
+    expect(summaries([], config, 'column')).toContain('COL');
+    expect(summaries([], config, 'column')).not.toContain('TOP');
+
+    // Control: the same raw config in list view must still read the top-level
+    // value, proving the assertion above tracks the view rather than the block
+    // simply winning everywhere.
+    expect(summaries([], config, 'list')).toContain('TOP');
+  });
+
+  it('honours a column show_past_events override on a raw config', () => {
+    const config = buildConfig({
+      view: 'column',
+      days_to_show: 2,
+      show_past_events: true,
+      column: { show_past_events: false },
+    } as Partial<Types.Config>);
+
+    expect(summaries([pastEvent()], config, 'column')).not.toContain('Already Over');
+
+    // Control: list view keeps the finished event, so the column result is the
+    // override taking effect and not the event being filtered for some other
+    // reason.
+    expect(summaries([pastEvent()], config, 'list')).toContain('Already Over');
+  });
+});


### PR DESCRIPTION
## What

`groupEventsByDay` now resolves the `column:` block itself, at its own boundary, instead of trusting every caller to have done it first.

## Why

Roughly a dozen override-capable options are read inside the function and its helpers. Three of them (`filter_duplicates`, `show_empty_days`, `split_multiday_events`) went through `resolveViewOption`; the rest — `show_past_events`, `empty_day_text`, `show_location`, `show_description`, `show_week_numbers` — read the config directly.

A caller passing a **raw** config therefore got a mix: a few options honoured the `column:` block and the others silently ignored it.

All three production call sites in `calendar-card-pro.ts` pass `this.effectiveConfig`, so nothing was visibly broken. But that is a property of the callers rather than of the function — and it is exactly the shape of the multi-day splitting defect fixed in #453, where a raw config reached a view-aware code path and the disagreement was invisible until someone set both values.

## How

One resolve at the top of the function. That **removes** the dual path rather than extending it:

- the three `resolveViewOption` calls become plain reads;
- the spread that injected a resolved `split_multiday_events` into `processMultiDayEvents`'s config argument is no longer needed.

Net effect: one mechanism instead of two.

### Why this is safe on existing callers

Both resolvers are idempotent on already-resolved input. `resolveEffectiveConfig` returns `{ ...config, ...applied }` and so preserves `config.column`; re-running it re-reads the same block with the same presence test and the same coercion, and reaches the same answer.

Measured, not assumed:

- `resolveViewOption` over already-resolved output: **162/162 identical** (54 keys x 3 configs).
- `resolveEffectiveConfig` applied twice: **8/8 identical** (4 configs x 2 views).

Both probes carried a control that had to disagree — the same comparison against a *raw* config — and it did.

## Falsification

`tests/group-events-view-scope.test.ts` (new, 2 tests) passes a deliberately raw config and asserts a `column:` override is honoured, pairing each case with the same config rendered as a list so it cannot pass by the override being inert in both views.

Reverting `src/utils/events.ts` alone (`git stash push -- src/utils/events.ts`):

| code | result |
|---|---|
| pre-change | **both tests fail** (exit 1) |
| restored | both pass (exit 0) |

So this closed a latent bug rather than being a cosmetic refactor.

## Gates

All ten green: `format`, `tsc --noEmit`, `lint`, `check:format`, `test`, `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`. Suite 1322 -> **1324 tests / 51 files**.

## Release notes

None. No user-visible behaviour change — every production call site already passed the resolved config — so per the house convention this is hygiene rather than a fix worth announcing.
