### PR TITLE
docs: correct the editor-translation fallback rationale in check:i18n

### DIFF
--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -751,7 +751,8 @@ async function checkEditorTranslations(languages) {
     // with no file of its own, aliased onto another language's — passes both, and every
     // Dutch user silently gets the German editor. Aliasing is never what was meant: a
     // language with no editor file is supposed to be absent from this map entirely, so
-    // that `hasEditorTranslations()` can fall the whole language back to English.
+    // that `lookup()` finds no entry for it and falls each key through to EDITOR_STRINGS,
+    // which is English.
     const expected = basename(imports.get(identifier), '.json').toLowerCase();
     if (expected !== key) {
       error(


### PR DESCRIPTION
## What

Corrects a comment in `scripts/check-i18n.mjs` that explains the editor-translation alias check by naming `hasEditorTranslations()` — a function the v4 editor rework removed.

## Why it is wrong twice

`hasEditorTranslations()` implemented an **all-or-nothing** fallback: a language either translated the whole editor, or the editor rendered entirely in English. The comment still describes that shape. So it is stale in two independent ways — it names a function that no longer exists anywhere in `src/`, and it describes a fallback the surviving code does not implement.

```
$ grep -rn "hasEditorTranslations" src/ scripts/ tests/ docs/ AGENTS.md
scripts/check-i18n.mjs:754:    // that `hasEditorTranslations()` can fall the whole language back to English.
```

One hit, and it is the comment itself.

## What actually happens now

`lookup()` in `src/rendering/editor/localize.ts` does a **per-key** fallback:

```ts
const translated = EDITOR_LANGUAGE_STRINGS[language.toLowerCase()]?.[key];
if (translated !== undefined) return translated;
return EDITOR_STRINGS[key];
```

A language absent from the map falls through to English one key at a time; a *partial* file falls through only for the keys it omits. That is why partial editor files are supported by design, and why there is deliberately no `en.json` — English lives in `strings.ts`.

## Verification

Probe with a control, run through the real module:

| | result |
|---|---|
| `'nl'` present in `EDITOR_LANGUAGE_STRINGS` | `false` |
| **PROBE** `lookup('nl', 'search')` | `"Search Settings"` — equals `EDITOR_STRINGS['search']` |
| **CONTROL** `lookup('de', 'search')` | `"Einstellungen suchen"` — differs from English |

The control differing is what makes the probe meaningful: the fallback is doing real work rather than trivially matching. Map holds 10 languages (`de, en-gb, et, it, lt, lv, nb, pl, sk, sv`). The temporary probe file was deleted; `git status --porcelain` shows only the comment change.

## Scope

The check itself is **unchanged and still correct** — aliasing `nl: deEditor` would hand every Dutch user the German editor, and the existing error message already states the right remedy ("remove the entry so `nl` falls back to English"), which stays accurate under per-key fallback. Only the rationale needed to catch up.

No release-notes entry: comment-only hygiene with no user-visible effect.

## Gates

All ten green: `format`, `tsc --noEmit`, `lint`, `check:format`, `test`, `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`.
