### PR TITLE
docs: correct two miscounted figures in the v4 release notes

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -108,7 +108,7 @@ Translation resolves **per string**, requested language first and English second
 
 - **Weekday Names Were Capitalized Mid-Sentence** - Full weekday names are rendered in exactly one place, in the running text after "until", and 17 of 35 languages stored a capital there — Swedish read `till Måndag, 5 Jan` where it wants `till måndag`. Fixed in ten languages: nine lower-cased against `dayjs`, and Polish given the genitive its preposition governs. Seven more need an inflected form that no in-repo evidence supplies, so they are deliberately left flagged rather than half-fixed
 - **Romanian Diacritics** - Restored throughout the Romanian translation
-- **A Rendering Decision No Longer Reads Translated Text** - Whether an event was a multi-day all-day event was decided by searching its _formatted_ time string for a translated token, asking the renderer to parse back a sentence its own formatter had just built. No defect shipped, but the margin was zero: eight languages translate one of those tokens to two characters, and the search ran against a string that can carry arbitrary event text. It is now derived from the event's own dates
+- **A Rendering Decision No Longer Reads Translated Text** - Whether an event was a multi-day all-day event was decided by searching its _formatted_ time string for a translated token, asking the renderer to parse back a sentence its own formatter had just built. No defect shipped, but the margin was zero: eleven languages translate one of those tokens to two characters, and the search ran against a string that can carry arbitrary event text. It is now derived from the event's own dates
 
 ## ⚡ Performance
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -60,7 +60,7 @@ Translation resolves **per string**, requested language first and English second
 
 ### 🩺 Diagnosing a Released Build
 
-- **Runtime Log Level** - A released build compiles out everything below errors, so all 17 warning sites are invisible to real users — including actionable ones such as an invalid `start_date` falling back to today. Someone filing a bug therefore could not produce the output that would explain it. Running `window.calendarCardProDebug = true` in the browser console and reloading turns the detail back on, and `window.calendarCardProLogLevel = 0..3` selects a level directly. Neither persists, and neither needs a reinstall — the card picks the flag up on its next render (see [Reporting a Bug](https://calendar-card-pro.alexpfau.com/contributing#reporting-a-bug))
+- **Runtime Log Level** - A released build compiles out everything below errors, so all 21 warning sites are invisible to real users — including actionable ones such as an invalid `start_date` falling back to today. Someone filing a bug therefore could not produce the output that would explain it. Running `window.calendarCardProDebug = true` in the browser console and reloading turns the detail back on, and `window.calendarCardProLogLevel = 0..3` selects a level directly. Neither persists, and neither needs a reinstall — the card picks the flag up on its next render (see [Reporting a Bug](https://calendar-card-pro.alexpfau.com/contributing#reporting-a-bug))
 
 ## 🐛 Bug Fixes
 


### PR DESCRIPTION
## What

Two numbers in the v4 release notes are wrong. Neither is drift — both were checked at `42679d9`, the commit that wrote them, with the same method, and both were already wrong there.

## 1. "all 17 warning sites" → 21

`Logger.warn(` call sites in `src/`, comment lines excluded:

| File | Sites |
|---|---:|
| `src/utils/events.ts` | 10 |
| `src/config/view.ts` | 5 |
| `src/calendar-card-pro.ts` | 4 |
| `src/utils/templates.ts` | 2 |
| **Total** | **21** |

At `42679d9` the same count was **22**.

`Logger.deprecation` is correctly excluded — it is the one warning path that calls `console.warn` directly instead of going through the level gate, which is exactly what lets the same section claim the removed-options notice still reaches production builds. One such site.

## 2. "eight languages translate one of those tokens to two characters" → eleven

The tokens are `allDay` and `multiDay` — the pair `format.ts:559-564` composes into the very string the old check searched. Across the 35 language files, **11** translate one of them to two characters:

`bg` до · `cs` do · `he` עד · `hr` do · `pl` do · `ru` до · `sk` do · `sl` do · `uk` до · `zh-CN` 整天/直到 · `zh-TW` 整天/直到

Eight is the Latin-and-Cyrillic subset alone, dropping Hebrew and both Chinese variants; the sentence states no such restriction. Identical count at `42679d9`. The correction strengthens the point the entry makes.

## Everything else in these notes was checked and holds

The surrounding claims were verified rather than assumed:

- **"Five options were deleted from the runtime in the v3.0.0 cleanup"** — `DEPRECATED_CONFIG_MAP` has exactly 5 entries.
- **The `-100px` gutter arithmetic** reproduces exactly. With `day_spacing` defaulting to `'10px'` and 32px of padding: correct threshold `3×140 + 2×10 + 32 = 472`; with the negative gutter `3×140 + 2×(−100) + 32 = 252`; and a 280px card, the browser discarding the negative gap, gives `(280−32)/3 ≈ 83px`. All three stated figures.
- **The warn mechanism.** `Logger.warn` → `simpleLog(LogLevel.WARN, …)`, gated by `effectiveLogLevel() < level` (`logger.ts:248`); production sets `CURRENT_LOG_LEVEL: 0` at `rollup.config.mjs:169-171`. Three distinct warn strings were each found exactly once in `dist/calendar-card-pro.js` — they are suppressed at runtime, not tree-shaken, which is *why* `window.calendarCardProDebug = true` works without a reinstall. The prose needed no change.
- **The entry's own example is real** — "an invalid `start_date` falling back to today" is `src/utils/events.ts:1078`.
- Previously verified in this review: the 42%/46% size claims, "33 of the 64 languages", the 2015–2035 × 7-zone date sweep, the internally consistent 17/10/9/7 language split, and the card-mod claim about both day containers.

## Blast radius

Two lines, one file. `17 warning` and the short-token sentence each appear exactly once repo-wide; neither `README.md` nor `docs/guide/whats-new.md` mirrors either bullet.

## Gates

`npm run format`, `npm run check:format`, `npm run check:docs`, `npm run docs:build` — all exit 0, re-run after the second commit. Docs text only; no source, tests or bundle touched.
