### PR TITLE
test: pin the date-format fallback and the emoji indicator arm

### DIFF
--- a/tests/date-format-style.test.ts
+++ b/tests/date-format-style.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression tests for `getDateFormatStyle`.
+ *
+ * This function decides how every date on the card is ordered — `17. Mar`, `Mar 17`, or
+ * `17 Mar` — from the language alone. It has three outcomes, two of which are named-language
+ * special cases and one of which is the fallback that serves everyone else.
+ *
+ * It had no test of its own. `de` and `hu` were pinned only *incidentally*, by suites that
+ * happen to render a German or English date and would notice the string changing; nothing
+ * referenced the function directly, and no test rendered a date in any of the other
+ * languages. Mutation testing found the consequence: rewriting the fallback `return` to a
+ * different style left all ten gates green while silently reordering the date for the large
+ * majority of shipped languages. Dropping `hr` or `hu` from their branches was invisible for
+ * the same reason.
+ *
+ * So these tests assert the mapping directly and over the whole shipped corpus, rather than
+ * through a rendered date. The point is that the fallback is a real, asserted contract and
+ * not merely the branch nothing happened to exercise.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { TRANSLATIONS, getDateFormatStyle } from '../src/translations/localize';
+
+/**
+ * Every language the card ships, taken from the registry the card actually resolves
+ * against rather than from a directory glob — the same corpus, and for the same reasons,
+ * as `translations.test.ts`.
+ */
+const LANGUAGES = Object.keys(TRANSLATIONS);
+
+/** Languages that render the day, a dot, then the month (`17. Mar`). */
+const DAY_DOT_MONTH = ['de', 'hr'];
+
+/** Languages that render the month before the day (`Mar 17`). */
+const MONTH_DAY = ['en', 'hu'];
+
+describe('date format style', () => {
+  it('resolves against a corpus large enough for the loops below to mean something', () => {
+    // Guards the denominator. Deriving the fallback set by subtraction means an empty or
+    // gutted registry would make every fallback assertion below vacuously true.
+    expect(LANGUAGES.length).toBeGreaterThan(30);
+    for (const code of [...DAY_DOT_MONTH, ...MONTH_DAY]) {
+      expect(LANGUAGES, `${code} must be a shipped language`).toContain(code);
+    }
+  });
+
+  it.each(DAY_DOT_MONTH)('gives %s the day, a dot, then the month', (language) => {
+    expect(getDateFormatStyle(language)).toBe('day-dot-month');
+  });
+
+  it.each(MONTH_DAY)('gives %s the month before the day', (language) => {
+    expect(getDateFormatStyle(language)).toBe('month-day');
+  });
+
+  it('gives every other shipped language the day before the month', () => {
+    const fallback = LANGUAGES.filter(
+      (code) => !DAY_DOT_MONTH.includes(code) && !MONTH_DAY.includes(code),
+    );
+
+    // The branch that carries the majority of the corpus, and the one a mutation could
+    // rewrite without any suite noticing.
+    expect(fallback.length).toBeGreaterThan(25);
+    for (const language of fallback) {
+      expect(getDateFormatStyle(language), language).toBe('day-month');
+    }
+  });
+
+  /**
+   * `en-GB` is the case that makes the fallback load-bearing rather than incidental. It is
+   * an English locale, but the comparison is an exact `=== 'en'`, so it falls through to
+   * `day-month` — which is the correct British ordering. Folding it into the `en` branch
+   * would be a real regression, and only this assertion would see it.
+   */
+  it('leaves en-GB on the British ordering rather than the American one', () => {
+    expect(getDateFormatStyle('en-GB')).toBe('day-month');
+    expect(getDateFormatStyle('en')).toBe('month-day');
+  });
+
+  it('matches languages case-insensitively', () => {
+    expect(getDateFormatStyle('DE')).toBe('day-dot-month');
+    expect(getDateFormatStyle('HU')).toBe('month-day');
+  });
+
+  it('falls back rather than throwing on a missing or unknown language', () => {
+    expect(getDateFormatStyle('')).toBe('day-month');
+    expect(getDateFormatStyle(undefined as unknown as string)).toBe('day-month');
+    expect(getDateFormatStyle('qq')).toBe('day-month');
+  });
+});

--- a/tests/editor-schema.test.ts
+++ b/tests/editor-schema.test.ts
@@ -2145,6 +2145,22 @@ describe('editor: fields that must survive being typed into', () => {
   });
 
   /**
+   * The same field accepts two kinds of value, and only the image half was covered above.
+   * An emoji is complete the moment it is typed, so it commits on the first keystroke
+   * rather than being held pending — the opposite of the image path, and the reason both
+   * arms of the committability test need asserting. Mutation testing found that dropping
+   * the emoji arm left every gate green while the editor silently refused to ever store an
+   * emoji the user typed.
+   */
+  it('commits an emoji indicator on the keystroke that completes it', () => {
+    const start = buildConfig({ today_indicator: 'star.png' });
+    const typed = type(start, 'today_indicator_custom', ['⭐']);
+
+    expect(typed.config.today_indicator).toBe('⭐');
+    expect(typed.pending.today_indicator_custom ?? null).toBeNull();
+  });
+
+  /**
    * Home Assistant's text selector reports every keystroke and turns an emptied field
    * into `undefined`, so binding `height` directly would delete the measurement the
    * moment the box was cleared to retype it — and take the field with it, since the


### PR DESCRIPTION
Found by mutation-testing the test suite: two branches that could be rewritten with all ten gates green.

## `getDateFormatStyle` — the fallback that serves 31 of 35 languages

This function decides how every date on the card is ordered (`17. Mar`, `Mar 17`, `17 Mar`) from the language alone. It had **no test of its own** — no test file referenced it, and `de`/`hu` were pinned only *incidentally* by suites that happen to render a German or English date.

The consequence, measured rather than assumed:

| mutation | before | after |
|---|---|---|
| fallback `return 'day-month'` → `'month-day'` | **survived** | fails 3 |
| drop `hr` from its branch | **survived** | fails 1 |
| drop `de` from its branch | caught (incidentally) | caught |
| drop `en` from its branch | caught (incidentally) | caught |

Rewriting the fallback silently reorders the date for **31 of the 35 shipped languages** — every one except `de`, `hr`, `en`, `hu` — with nothing failing.

The new file asserts the mapping directly over `TRANSLATIONS` (the surface the card actually resolves against, following `translations.test.ts`), **guards its own denominator** so a gutted registry cannot make the fallback loop vacuously true, and pins `en-GB` explicitly — an English locale that must fall through to the British ordering rather than being folded into `en`.

## `isCommittableIndicator` — the untested emoji arm

The custom today-indicator field accepts an image path *or* an emoji, and only the image half was covered. Dropping the emoji arm left every gate green while the editor **silently refused to ever store an emoji the user typed**, holding it pending forever. Added alongside the existing image-path test, which already proves the harness works.

## Falsification

Every test here was proven to fail against the mutation that motivated it, and to pass on pristine source. Source restored and verified clean between plants.

## Gates

All ten green. Test count **1342 → 1352**, files **54 → 55** — matching the predicted delta exactly (9 new + 1 emoji), which confirms nothing was silently skipped.

Tests only; no behaviour change, so no release-notes entry.
