### PR TITLE
docs: list every value an option accepts in the reference table

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -193,13 +193,13 @@ Both height options may be overridden inside a `column:` block, and usually shou
 
 ## 🌦️ Weather
 
-| Option               | Type   | Default | Description                                                                                                  |
-| -------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------ |
-| `weather`            | object | -       | Weather configuration object containing the settings below                                                   |
-| `weather → entity`   | string | -       | Home Assistant weather entity to use for forecasts                                                           |
-| `weather → position` | string | `date`  | Where to show weather data: `date` (in date column), `event` (next to events), or `both` (in both positions) |
-| `weather → date`     | object | -       | Configuration for weather display in the date column                                                         |
-| `weather → event`    | object | -       | Configuration for weather display next to events                                                             |
+| Option               | Type   | Default | Description                                                                                                                    |
+| -------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `weather`            | object | -       | Weather configuration object containing the settings below                                                                     |
+| `weather → entity`   | string | -       | Home Assistant weather entity to use for forecasts                                                                             |
+| `weather → position` | string | `date`  | Where to show weather data: `none` (nowhere), `date` (in date column), `event` (next to events), or `both` (in both positions) |
+| `weather → date`     | object | -       | Configuration for weather display in the date column                                                                           |
+| `weather → event`    | object | -       | Configuration for weather display next to events                                                                               |
 
 ### Weather Position Options
 

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1460,6 +1460,7 @@ function report(counts) {
       `${counts.fields} config fields, ${counts.docs} pages, ${counts.complete} complete examples, ` +
       `${counts.releases} release lines documented, ${counts.links} internal links resolved, ` +
       `${counts.gates} CI gates documented, ` +
+      `${counts.enums} enumerated options fully listed, ` +
       `release surfaces agree on v${counts.version}.\n`,
   );
 
@@ -1657,6 +1658,82 @@ function checkGateLists() {
   return gates.length;
 }
 
+// ---------------------------------------------------------------------------
+// Check 21 — every value an option accepts is named in its reference row
+// ---------------------------------------------------------------------------
+
+/**
+ * String-literal unions in types.ts, keyed by option name.
+ *
+ * The union is the complete set of values a user may write, so it is the only
+ * authority on what the reference row has to list. One level of alias
+ * indirection is resolved so `position?: WeatherPosition` is covered too.
+ */
+function readEnumOptions() {
+  const src = readFileSync(TYPES_TS, 'utf8');
+  const literals = (text) => (text.match(/'[a-z0-9_-]+'/g) || []).map((s) => s.slice(1, -1));
+
+  const aliases = new Map();
+  for (const m of src.matchAll(/^export type ([A-Za-z]+)\s*=\s*([^;]+);/gm)) {
+    const values = literals(m[2]);
+    if (values.length > 1 && m[2].includes('|')) aliases.set(m[1], values);
+  }
+
+  const out = new Map();
+  for (const name of [...USER_FACING_INTERFACES, 'ColumnOverrides']) {
+    const block = src.match(new RegExp(`export interface ${name}\\s*\\{([\\s\\S]*?)\\n\\}`));
+    if (!block) continue;
+    for (const line of block[1].split('\n')) {
+      const field = line.match(/^\s{2}([a-z0-9_]+)\??:\s*(.+?);\s*(?:\/\/.*)?$/);
+      if (!field) continue;
+      const type = field[2].trim();
+      const values = type.includes('|') ? literals(type) : aliases.get(type) || [];
+      if (values.length > 1) out.set(field[1], values);
+    }
+  }
+  assertFound(out, 'enumerated options', TYPES_TS);
+  return out;
+}
+
+/**
+ * An option's own reference row must name every value its type allows.
+ *
+ * Nothing else can see this. The field is present, so check 2 passes; its default is
+ * correct, so check 1 passes; and the feature page may document the value in full.
+ * `weather → position` gained `none` and its row still offered the three older values,
+ * which is how a reader learns an option cannot do something it can.
+ */
+function checkEnumValues(enums) {
+  const lines = readFileSync(REFERENCE_DOC, 'utf8').split('\n');
+  let described = 0;
+
+  for (const [field, values] of enums) {
+    const rows = lines.filter((line) =>
+      new RegExp(`^\\|\\s*\`(?:[a-z0-9_]+ → )?${field}\``).test(line),
+    );
+    // Check 2 already requires every option to be documented somewhere.
+    if (!rows.length) continue;
+    described++;
+    for (const row of rows) {
+      const missing = values.filter((value) => !new RegExp(`\\b${value}\\b`).test(row));
+      if (missing.length) {
+        error(
+          `${relative(ROOT, REFERENCE_DOC)}: the \`${field}\` row never mentions ` +
+            `${missing.map((v) => `\`${v}\``).join(', ')}, so a reader cannot discover ` +
+            `${missing.length > 1 ? 'those values' : 'that value'}. The type accepts ` +
+            `${values.map((v) => `\`${v}\``).join(' | ')}.`,
+        );
+      }
+    }
+  }
+
+  if (described === 0) {
+    console.error(`\n✗ FATAL: no enumerated option matched a reference row — fix the parser.\n`);
+    process.exit(2);
+  }
+  return described;
+}
+
 function main() {
   const defaults = readDefaults();
   const rows = readReferenceRows();
@@ -1688,6 +1765,7 @@ function main() {
   checkAgentsLinks();
   const gates = checkGateLists();
   const version = checkReleaseVersion();
+  const enums = checkEnumValues(readEnumOptions());
 
   process.exit(
     report({
@@ -1699,6 +1777,7 @@ function main() {
       releases,
       links,
       gates,
+      enums,
       version,
     }),
   );


### PR DESCRIPTION
## What

`weather → position` gained a fourth value, `none`, in v4. Its row in
`docs/reference/configuration.md` still listed only `date`, `event` and `both`.

The value is fully real:

- `WeatherConfig.position?: 'none' | 'date' | 'event' | 'both'` in `types.ts`
- offered by the editor (`src/rendering/editor/schemas/weather.ts:69`)
- acted on in `src/utils/weather.ts:33`
- documented three times on `docs/features/weather.md` (lines 16, 43 and 68),
  including prose explaining that it hides weather everywhere without clearing
  the entity, so the card subscribes to no forecast at all

So the reference — the page whose whole job is to be the complete option list —
told the reader the card could not do something it can.

## Why nothing caught it

`check:docs` reconciles the option's *presence* (check 2) and its *default*
(check 1). Both pass. The feature page is complete, so nothing looked
underdocumented from that side either. The description cell of a reference row
was simply not read by anything.

## Check 21

A string-literal union in `types.ts` is the complete set of values a user may
write, so it is the only authority on what the row has to list. Check 21 parses
those unions — resolving one level of type alias — and requires every literal to
appear in that option's own row.

Five enumerated options are covered. That is six interface members:
`show_week_numbers` exists on both `Config` and `ColumnOverrides` and collapses to
one option name, and every reference row matching a name is checked, so the
shared and column-scoped rows are both covered.

The reader is deliberately the same shape as the rest of the file: regex over
`types.ts`, `USER_FACING_INTERFACES`, and a fatal exit if it ever matches zero
rows, so it cannot pass by parsing nothing.

## Falsification

Two independent plants, each restored afterwards:

| Plant | Result |
|---|---|
| remove `none` from the `weather → position` row | exit 1 — ``the `position` row never mentions `none` `` |
| remove `cramp` from the `min_days_fallback` row | exit 1 — ``the `min_days_fallback` row never mentions `cramp` `` |
| restore | exit 0 |

I also cross-checked the regex reader against an independent TypeScript-AST pass
over the same interfaces: both find the same six members, so the gate is not
weaker than the compiler on this corpus.

## Gates

All ten green in the required order; only the two intended files changed.

No release-notes entry: documentation and tooling only, no behaviour change.
