### PR TITLE
ci: surface docs-gate failures as inline pull request annotations

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -22,6 +22,13 @@ const REFERENCE_DOC = join(DOCS_DIR, 'reference/configuration.md');
 
 const STRICT = process.argv.includes('--strict');
 
+/**
+ * GitHub renders `::error::` and `::warning::` lines as inline annotations on the pull
+ * request. Locally they would be noise, so the plain symbols stay outside CI. Mirrors
+ * `check-i18n.mjs`, so a docs failure surfaces the same way an i18n failure does.
+ */
+const IN_CI = Boolean(process.env.GITHUB_ACTIONS);
+
 const errors = [];
 const warnings = [];
 
@@ -1466,12 +1473,12 @@ function report(counts) {
 
   if (errors.length) {
     console.log(`${errors.length} error(s):`);
-    for (const e of errors) console.log(`  ✗ ${e}`);
+    for (const e of errors) console.log(IN_CI ? `::error::${e}` : `  ✗ ${e}`);
     console.log('');
   }
   if (warnings.length) {
     console.log(`${warnings.length} warning(s):`);
-    for (const w of warnings) console.log(`  ⚠ ${w}`);
+    for (const w of warnings) console.log(IN_CI ? `::warning::${w}` : `  ⚠ ${w}`);
     console.log('');
   }
 


### PR DESCRIPTION
ci: surface docs-gate failures as inline pull request annotations

`check-i18n.mjs` and `check-bundle.mjs` both emit GitHub workflow commands, so an
i18n or bundle failure lands as an annotation on the pull request, next to the
line that caused it. `check-docs.mjs` emitted none, despite having by far the most
error sites of the three. Its failures were readable only by opening the workflow
log and scrolling, which is the one moment a reviewer is least likely to do it.

The gate now mirrors `check-i18n.mjs` exactly: an `IN_CI` constant keyed off
`GITHUB_ACTIONS`, and `::error::` / `::warning::` in place of the `✗` / `⚠`
symbols when it is set. Outside CI nothing changes, because the annotation syntax
would just be noise in a terminal.

This is presentation only. No check was added, removed or altered, and the exit
code is computed exactly as before — so it does not make the gate stricter and
does not invalidate any other pull request's green run.

Verified in all three states: with a planted error and warning the local run
prints the symbols and the `GITHUB_ACTIONS=true` run prints the annotations, and
a clean tree in CI mode emits neither.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6c7714fb-9c18-4995-9aaa-129fa9eb7a53
