### PR TITLE
test: pin which options the editor is allowed to call inert

### DIFF
--- a/tests/editor-schema.test.ts
+++ b/tests/editor-schema.test.ts
@@ -747,6 +747,40 @@ describe('editor: applicability', () => {
     }
   });
 
+  it('lists exactly the options that are inert in some view', () => {
+    // The test above only walks whatever keys the table happens to contain, so deleting an
+    // entry satisfies it trivially: the option silently becomes "applies everywhere", the
+    // editor stops warning that it does nothing, and every gate stays green. Two of these
+    // five entries could be removed that way without a single test noticing. Pinning the
+    // membership means an option can neither lose its scope by accident nor gain one
+    // without someone stating, here, which views it is inert in and why.
+    expect(
+      Object.fromEntries(
+        Object.entries(VIEW_SCOPE).map(([key, views]) => [key, [...views].sort()]),
+      ),
+    ).toEqual({
+      // Column view draws the indicator inline and never reads a position.
+      today_indicator_position: ['list'],
+      // Column view stacks the date above its events, so there is nothing to align against.
+      date_vertical_alignment: ['list'],
+      // `viewAppliesCompactLimits` is false for column view, so none of the compact
+      // limiting runs there at all.
+      compact_events_to_show: ['list'],
+      compact_days_to_show: ['list'],
+      compact_events_complete_days: ['list'],
+    });
+
+    expect(
+      Object.fromEntries(
+        Object.entries(ENTITY_VIEW_SCOPE).map(([key, views]) => [key, [...views].sort()]),
+      ),
+    ).toEqual({
+      // A per-calendar opt-out is ignored in column view, so later days of a multi-day
+      // event cannot vanish from the columns they belong to.
+      split_multiday_events: ['list'],
+    });
+  });
+
   it('prefixes the option helper rather than replacing it', () => {
     const helper = computeHelper('en', 'column', {
       name: 'compact_days_to_show',


### PR DESCRIPTION
test: pin which options the editor is allowed to call inert

`VIEW_SCOPE` and `ENTITY_VIEW_SCOPE` are the single source of truth for which
config options do nothing in which view. The editor reads them to append a
"only applies in list layout" note under a field, and `check:i18n` reads them to
insist such a note exists in every language. Nothing read them to check the
membership itself.

The existing coverage test walks `Object.keys(VIEW_SCOPE)` and asserts each key
has a note, which is vacuous under deletion: remove an entry and the loop simply
iterates one fewer key. A delete-one-entry sweep over all six entries, running
the full unit project after each, found two that could be removed with every
test still passing — `today_indicator_position` and
`compact_events_complete_days`. The consequence is quiet rather than loud: the
option keeps having no effect in column view, but the editor stops saying so, so
the field looks live and does nothing.

Both entries are correct as written, confirmed at the point of use rather than
from the table: `renderTodayIndicator` only reads `today_indicator_position` when
`layout !== 'inline'`, and column view is always inline; `compact_events_complete_days`
is read inside `if (compactLimitsApply)`, and `viewAppliesCompactLimits` returns
false for column. So this pins the current, verified truth rather than freezing a
guess.

The new assertion compares the whole table by value in both directions, so an
entry can neither be dropped by accident nor added without someone stating here
which views the option is inert in and why. Re-running the sweep against the pin
kills all six deletions, and planting a spurious `day_spacing` entry fails too.

No production code changes; the shipped bundles are byte-identical.
