### PR TITLE
fix(docs-gate): reconcile the migration table with the options the card reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,20 @@ defaulting to `false` renders nothing and is invisible to it unless a test sets 
 branches were missed that way, including two the suite existed to protect. When you add a
 config option, add a test that turns it on.
 
+🚨 **A test that walks a table's own keys cannot notice a key leaving it.** The idiom
+`for (const key of Object.keys(TABLE)) expect(somethingAbout(key)).toBeDefined()` reads
+like coverage and is not: delete an entry and the loop runs one fewer time, so the suite
+stays green while the table quietly shrinks. This has been found three times — 24 of 54
+`COLUMN_OVERRIDE_KEYS` entries, 2 of 6 `VIEW_SCOPE` entries and 4 of 5
+`DEPRECATED_CONFIG_MAP` entries were each removable with every gate passing. The damage is
+always silent, because these tables describe what the card tells the user rather than what
+it renders: an editor field stops saying an option is inert in this view, or a removed
+option stops being reported at all. **Pin the whole table by value** (`toEqual` on a
+normalized copy) or reconcile it against a second surface, so both directions — a dropped
+entry and an unexplained new one — fail. When sweeping for this, blank one line at a time,
+run `npx tsc --noEmit` first as a cheap kill, and restore with `cp` from a backup, never
+`git checkout --`.
+
 ### The suite runs as four projects, and the split is load-bearing
 
 `vitest.config.mjs` defines a `projects` array, so `npm test` runs the same files under

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1468,6 +1468,7 @@ function report(counts) {
       `${counts.releases} release lines documented, ${counts.links} internal links resolved, ` +
       `${counts.gates} CI gates documented, ` +
       `${counts.enums} enumerated options fully listed, ` +
+      `${counts.removed} removed options migrated, ` +
       `release surfaces agree on v${counts.version}.\n`,
   );
 
@@ -1741,6 +1742,105 @@ function checkEnumValues(enums) {
   return described;
 }
 
+// ---------------------------------------------------------------------------
+// Check 22 — the migration table lists exactly the options the card still reports
+// ---------------------------------------------------------------------------
+
+const NUMBER_WORDS = ['Zero', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight'];
+
+/**
+ * The removed-key maps in config.ts, keyed by the option a user may still have.
+ *
+ * `findDeprecatedKeys` walks these to tell a reader which option replaced theirs,
+ * so they are the authority on what the migration table has to say.
+ */
+function readDeprecatedMaps() {
+  const src = readFileSync(CONFIG_TS, 'utf8');
+  const read = (name) => {
+    const block = src.match(new RegExp(`export const ${name}[^=]*=\\s*\\{([\\s\\S]*?)\\n\\};`));
+    const pairs = new Map();
+    if (!block) return pairs;
+    for (const m of block[1].matchAll(/^\s{2}([a-z0-9_]+):\s*'([a-z0-9_]+)'/gm))
+      pairs.set(m[1], m[2]);
+    return pairs;
+  };
+  const maps = {
+    card: read('DEPRECATED_CONFIG_MAP'),
+    entity: read('DEPRECATED_ENTITY_CONFIG_MAP'),
+  };
+  assertFound(maps.card, 'removed card options', CONFIG_TS);
+  assertFound(maps.entity, 'removed per-entity options', CONFIG_TS);
+  return maps;
+}
+
+/**
+ * Every removed option must appear in the migration table, naming its replacement.
+ *
+ * The runtime notice and this table are written from the same map but checked by
+ * nothing in common: the test that walks `DEPRECATED_CONFIG_MAP` asserts one message
+ * per key it finds, so dropping a key drops an assertion with it and stays green. A
+ * reader upgrading from v2 then gets neither a console notice nor a table row, and the
+ * option they still have simply stops working with no explanation anywhere.
+ */
+function checkDeprecatedTable(maps) {
+  const page = join(DOCS_DIR, 'features/editor.md');
+  const text = readFileSync(page, 'utf8');
+  const where = relative(ROOT, page);
+
+  const documented = new Map();
+  for (const m of text.matchAll(/^\|\s*`([a-z0-9_]+)`\s*\|\s*`([a-z0-9_]+)`\s*\|$/gm)) {
+    documented.set(m[1], m[2]);
+  }
+
+  for (const [oldKey, newKey] of maps.card) {
+    const listed = documented.get(oldKey);
+    if (!listed) {
+      error(
+        `${where}: \`${oldKey}\` is reported at runtime as removed but has no migration ` +
+          `table row, so a reader who still has it is told to change something the docs ` +
+          `never mention. Add a row pointing at \`${newKey}\`.`,
+      );
+    } else if (listed !== newKey) {
+      error(
+        `${where}: the migration table sends \`${oldKey}\` to \`${listed}\`, but the card ` +
+          `reports \`${newKey}\`. One of the two is wrong.`,
+      );
+    }
+  }
+
+  for (const [oldKey, newKey] of documented) {
+    if (!maps.card.has(oldKey)) {
+      error(
+        `${where}: the migration table lists \`${oldKey}\` → \`${newKey}\`, but the card no ` +
+          `longer reports it, so nobody configuring it is warned. Either restore it to ` +
+          `DEPRECATED_CONFIG_MAP or drop the row.`,
+      );
+    }
+  }
+
+  // The count is prose, so nothing else can catch it drifting from the table beneath it.
+  const stated = text.match(/^([A-Z][a-z]+) options were removed in v[\d.]+\./m);
+  const expected = NUMBER_WORDS[maps.card.size];
+  if (stated && expected && stated[1] !== expected) {
+    error(
+      `${where}: the page opens "${stated[1]} options were removed" while the card reports ` +
+        `${maps.card.size}. Write "${expected}".`,
+    );
+  }
+
+  for (const oldKey of maps.entity.keys()) {
+    if (!new RegExp(`\`${oldKey}\`[^\n]*entities`).test(text)) {
+      error(
+        `${where}: \`${oldKey}\` is also reported on a per-entity entry, but the page never ` +
+          `says so, so anyone who set it under \`entities:\` reads the table and concludes ` +
+          `it does not apply to them.`,
+      );
+    }
+  }
+
+  return maps.card.size;
+}
+
 function main() {
   const defaults = readDefaults();
   const rows = readReferenceRows();
@@ -1773,6 +1873,7 @@ function main() {
   const gates = checkGateLists();
   const version = checkReleaseVersion();
   const enums = checkEnumValues(readEnumOptions());
+  const removed = checkDeprecatedTable(readDeprecatedMaps());
 
   process.exit(
     report({
@@ -1785,6 +1886,7 @@ function main() {
       links,
       gates,
       enums,
+      removed,
       version,
     }),
   );


### PR DESCRIPTION
fix(docs-gate): reconcile the migration table with the options the card reports

`DEPRECATED_CONFIG_MAP` is what `findDeprecatedKeys` walks to tell someone their
`row_spacing` was removed and `day_spacing` replaced it. The same five pairs are
written out again as a table in the editor docs. Nothing compared the two.

The test that looks like it covers this walks `Object.entries(DEPRECATED_CONFIG_MAP)`
and asserts one message per key it finds, so removing a key removes an assertion
along with it. Blanking each entry in turn and running the full suite, four of the
five could be deleted with every gate green — only `row_spacing` survived, and only
because an unrelated test names it in a spot check. The consequence is quiet: a user
upgrading from v2 with that option gets no console notice, the option keeps doing
nothing, and the docs still promise a warning that no longer exists.

Check 22 reads both maps out of config.ts and reconciles them against the table in
`docs/features/editor.md` in both directions — a reported option with no row, a row
for something no longer reported, a row pointing at the wrong replacement, the
"Five options were removed" count drifting from the table beneath it, and the
per-entity note that keeps `entities:` users from concluding the table excludes them.
Re-running the deletion sweep against the gate now kills all six entries, including
the four that survived before.

AGENTS.md gains the general form, because this is the third instance: 24 of 54
`COLUMN_OVERRIDE_KEYS`, 2 of 6 `VIEW_SCOPE` and now 4 of 5 `DEPRECATED_CONFIG_MAP`
entries were each removable with a green suite, all through the same "walk the
table's own keys" idiom. These tables describe what the card tells the user rather
than what it draws, so nothing visual catches them.

Gate-only and docs-only; no production code changes and the bundles are unchanged.
