### PR TITLE
test(editor): guard the synthetic field table against a silent deletion

### DIFF
--- a/tests/editor-schema.test.ts
+++ b/tests/editor-schema.test.ts
@@ -50,6 +50,7 @@ import { buildLayoutSchema, widthTableRows } from '../src/rendering/editor/schem
 import { EDITOR_STRINGS } from '../src/rendering/editor/strings';
 import { exceptionSubforms } from '../src/rendering/editor/subforms';
 import {
+  SYNTHETIC_FIELDS,
   deriveSyntheticData,
   isCommittableOffset,
   isSyntheticKey,
@@ -675,6 +676,33 @@ describe('editor: change detection', () => {
   it('compares nested blocks structurally, not by identity', () => {
     expect(changedKeys({ column: { x: 1 } }, { column: { x: 1 } })).toEqual([]);
     expect(changedKeys({ column: { x: 1 } }, { column: { x: 2 } })).toEqual(['column']);
+  });
+
+  /**
+   * Walking `SYNTHETIC_FIELDS` to assert something about each entry cannot notice a
+   * deleted entry — the loop simply runs one fewer time. Deleting `card_max_height`
+   * left the whole suite green even though the field then stopped deriving its value,
+   * silently discarded every edit, and wrote its own name into the stored YAML. Pin
+   * the membership instead, so both a removal and an unreviewed addition fail here.
+   */
+  it('holds the exact set of synthetic keys', () => {
+    expect(Object.keys(SYNTHETIC_FIELDS).sort()).toEqual([
+      'calendars',
+      'card_height',
+      'card_max_height',
+      'height_mode',
+      'language_mode',
+      'location_country_mode',
+      'location_country_pattern',
+      'start_date_fixed',
+      'start_date_mode',
+      'start_date_offset',
+      'time_format',
+      'today_indicator_custom',
+      'today_indicator_icon',
+      'today_indicator_style',
+      'week_number_mode',
+    ]);
   });
 
   it('recognises every synthetic key it must keep out of the config', () => {
@@ -2222,6 +2250,25 @@ describe('editor: fields that must survive being typed into', () => {
     expect(
       fieldNames(() => buildLayoutSchema({ view: 'list', config: cleared.config, language: 'en' })),
     ).toContain('card_max_height');
+  });
+
+  /**
+   * The assertions above hold whether or not the field is synthetic at all — clearing it
+   * is meant to be a no-op, so a version that never handled the key passed them too. These
+   * are the three that fail when it stops being synthetic: the field renders empty over a
+   * configured maximum, a typed measurement never reaches `max_height`, and the synthetic
+   * name itself is written into the user's YAML.
+   */
+  it('derives, commits and hides the maximum-height measurement', () => {
+    const config = buildConfig({ height: 'auto', max_height: '600px' });
+    const before = { ...config, ...deriveSyntheticData(config) } as Record<string, unknown>;
+    expect(before.card_max_height).toBe('600px');
+
+    const applied = applyFormChange(config, before, { ...before, card_max_height: '900px' }, {});
+    const stored = toStoredConfig(applied.config);
+
+    expect(stored.max_height).toBe('900px');
+    expect(stored).not.toHaveProperty('card_max_height');
   });
 
   it('never lets a held measurement reach the stored configuration', () => {


### PR DESCRIPTION
test(editor): guard the synthetic field table against a silent deletion

`SYNTHETIC_FIELDS` maps the editor's fifteen synthetic form fields — the controls that
have no config key of their own, like the height mode selector and the two measurement
boxes — to the code that derives their displayed value and applies an edit. Removing
one entry by entry showed fourteen were killed by some existing test. The fifteenth,
`card_max_height`, could be deleted with the entire suite green.

The table is typed `Readonly<Record<string, SyntheticField>>`, so TypeScript cannot
object to a missing key either, and its sibling `card_height` is covered — an asymmetry
rather than a deliberate exclusion.

A test named for the field does exist. It clears the box and asserts the configured
maximum survives and the field is still rendered. Both assertions hold whether or not
the field is synthetic at all: clearing it is meant to be a no-op, so a build that
never handled the key passed them too. It was a test that could not fail.

Measured against a control with the entry present, deleting it produces three
user-visible symptoms the suite could not see. The box renders empty over a configured
`max_height: 600px`. Typing `900px` leaves `max_height` at `600px` — the edit is
silently discarded. And `card_max_height` is written into the stored YAML as if it were
a real option.

Two guards, both falsified. A behavioural test asserts the derived value, the committed
edit and the absence of the synthetic key from the stored config; deleting the entry
fails it. A membership pin fixes the exact set of fifteen keys, because walking a table
to assert something about each entry cannot notice a deleted one — the loop just runs
one fewer time. That pattern has now been the root cause four separate times, so the
pin is proven in both directions: deleting an entry fails it, and so does adding one.

Test-only: no production code changed and both bundles are byte-identical. All ten
gates pass; the suite moves from 1506 to 1508 tests across the same 70 files.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6c7714fb-9c18-4995-9aaa-129fa9eb7a53
