### PR TITLE
test(start-date,weather,editor): pin the three lookup vocabularies nothing exercised

### DIFF
--- a/tests/editor-schema.test.ts
+++ b/tests/editor-schema.test.ts
@@ -2755,6 +2755,34 @@ describe('editor: per-calendar settings', () => {
     }
   });
 
+  /**
+   * The split shares the tristate machinery but not its vocabulary: its two
+   * decided states are offered as `split` and `whole` rather than `show` and
+   * `hide`, and those two words are mapped in a second table. The round-trip
+   * above covers only the `show`/`hide` pair, so both split words could be
+   * dropped from that table with every gate green — after which choosing
+   * "Split" in the editor writes nothing at all, and the calendar silently
+   * keeps inheriting from the card.
+   */
+  it('round-trips the two decided states of the split', () => {
+    const cases: Array<[boolean, string]> = [
+      [true, 'split'],
+      [false, 'whole'],
+    ];
+
+    for (const [stored, offered] of cases) {
+      const entry = {
+        entity: 'calendar.a',
+        split_multiday_events: stored,
+      } as Types.EntityConfig;
+
+      expect(toEntityFormData(entry).split_multiday_events, offered).toBe(offered);
+      expect(fromEntityFormData('calendar.a', { split_multiday_events: offered }), offered).toEqual(
+        { entity: 'calendar.a', split_multiday_events: stored },
+      );
+    }
+  });
+
   it('writes a bare entity id for a calendar that carries no settings', () => {
     expect(fromEntityFormData('calendar.a', { label: '', color: '', show_time: 'inherit' })).toBe(
       'calendar.a',

--- a/tests/start-date-weekdays.test.ts
+++ b/tests/start-date-weekdays.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Weekday vocabulary of the `start_date` grammar.
+ *
+ * `docs/features/start-date-offset.md` publishes fourteen spellings —
+ * `monday | tuesday | … | sunday`, and the abbreviations `mon, tue, wed, thu,
+ * fri, sat, sun` — and the worked examples lean on them in both roles the
+ * grammar offers: as the anchor (`saturday`, `monday+1w`) and as a jump
+ * operand (`today+sat`, `start_of_week+mon`, "then +tue, +wed, +thu, +fri").
+ *
+ * Nothing exercised that vocabulary. Deleting any one of the fourteen entries
+ * from the `WEEKDAYS` table left every gate green, and the two roles fail
+ * differently and quietly: as an anchor the parser falls through to
+ * `{ kind: 'nomatch' }`, so the card silently starts from today instead of the
+ * requested weekday, and as an operand it becomes `unrecognized operand`.
+ *
+ * The unknown-token cases are the control. They are what makes the fourteen
+ * `ok` assertions mean something — they prove the parser rejects a word it does
+ * not know, so accepting one it does is a decision rather than a default.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseStartDateExpression } from '../src/utils/start-date';
+
+/** Wednesday, so that "already on it" and "roll forward" both get exercised. */
+const NOW = new Date(2025, 0, 8, 12, 0, 0);
+
+const FIRST_DAY_MONDAY = 1;
+
+/** Every spelling the documentation promises, with the weekday it names. */
+const SPELLINGS: ReadonlyArray<readonly [string, number]> = [
+  ['sunday', 0],
+  ['sun', 0],
+  ['monday', 1],
+  ['mon', 1],
+  ['tuesday', 2],
+  ['tue', 2],
+  ['wednesday', 3],
+  ['wed', 3],
+  ['thursday', 4],
+  ['thu', 4],
+  ['friday', 5],
+  ['fri', 5],
+  ['saturday', 6],
+  ['sat', 6],
+];
+
+describe('start_date weekday vocabulary', () => {
+  it.each(SPELLINGS)('resolves %s as an anchor', (spelling, weekday) => {
+    const result = parseStartDateExpression(spelling, FIRST_DAY_MONDAY, NOW);
+
+    expect(result.kind, spelling).toBe('ok');
+    expect(result.kind === 'ok' && result.date.getDay(), spelling).toBe(weekday);
+  });
+
+  it.each(SPELLINGS)('resolves %s as a jump operand', (spelling, weekday) => {
+    const result = parseStartDateExpression(`today+${spelling}`, FIRST_DAY_MONDAY, NOW);
+
+    expect(result.kind, spelling).toBe('ok');
+    expect(result.kind === 'ok' && result.date.getDay(), spelling).toBe(weekday);
+  });
+
+  it('reads an abbreviation as the same day as its full name', () => {
+    const pairs: ReadonlyArray<readonly [string, string]> = [
+      ['sunday', 'sun'],
+      ['monday', 'mon'],
+      ['tuesday', 'tue'],
+      ['wednesday', 'wed'],
+      ['thursday', 'thu'],
+      ['friday', 'fri'],
+      ['saturday', 'sat'],
+    ];
+
+    for (const [full, short] of pairs) {
+      const long = parseStartDateExpression(full, FIRST_DAY_MONDAY, NOW);
+      const brief = parseStartDateExpression(short, FIRST_DAY_MONDAY, NOW);
+
+      expect(long.kind === 'ok' && long.date.getTime(), full).toBe(
+        brief.kind === 'ok' && brief.date.getTime(),
+      );
+    }
+  });
+
+  it('stays on the named weekday when today already is that weekday', () => {
+    const result = parseStartDateExpression('wednesday', FIRST_DAY_MONDAY, NOW);
+
+    expect(result.kind === 'ok' && result.date.getDate()).toBe(8);
+  });
+
+  it('rolls forward rather than back when the weekday has passed this week', () => {
+    const result = parseStartDateExpression('monday', FIRST_DAY_MONDAY, NOW);
+
+    expect(result.kind === 'ok' && result.date.getDate()).toBe(13);
+  });
+
+  it('does not accept a word outside the published vocabulary as an anchor', () => {
+    expect(parseStartDateExpression('funday', FIRST_DAY_MONDAY, NOW).kind).toBe('nomatch');
+  });
+
+  it('does not accept a word outside the published vocabulary as an operand', () => {
+    const result = parseStartDateExpression('today+funday', FIRST_DAY_MONDAY, NOW);
+
+    expect(result.kind).toBe('error');
+    expect(result.kind === 'error' && result.message).toContain('funday');
+  });
+});

--- a/tests/weather-night-icons.test.ts
+++ b/tests/weather-night-icons.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Night variants of the forecast icons.
+ *
+ * `getWeatherIcon` swaps three conditions for a night-appropriate icon between
+ * 18:00 and 06:00, because the daytime icon for them is actively wrong after
+ * dark — `sunny` draws a sun, and an hourly forecast row at 22:00 showing a sun
+ * is the kind of thing a user reports as a bug.
+ *
+ * The table had no coverage: each of its three entries could be deleted with
+ * every gate green, and the failure is silent rather than loud — the lookup
+ * falls back to `CONDITION_ICON_MAP` and simply draws the day icon at night.
+ *
+ * The daytime and non-night-mapped cases are the controls. They prove the swap
+ * is conditional on the hour and on the specific condition, so a night
+ * assertion passing means the night branch ran rather than the whole table
+ * having been replaced by one icon.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import * as Types from '../src/config/types';
+import * as WeatherUtils from '../src/utils/weather';
+
+/** The three conditions whose daytime icon is wrong after dark. */
+const NIGHT_SWAPPED: ReadonlyArray<readonly [string, string]> = [
+  ['sunny', 'mdi:weather-night'],
+  ['partlycloudy', 'mdi:weather-night-partly-cloudy'],
+  ['lightning-rainy', 'mdi:weather-lightning'],
+];
+
+/**
+ * Drive one hourly forecast entry through the real subscription path and return
+ * the icon the card would render for it.
+ *
+ * @param condition - Home Assistant condition code
+ * @param hour - Local hour of the forecast entry
+ * @returns The resolved MDI icon name
+ */
+async function iconFor(condition: string, hour: number): Promise<string | undefined> {
+  let handler: ((message: { forecast: Array<Types.WeatherForecast> }) => void) | undefined;
+
+  const hass = {
+    connection: {
+      subscribeMessage: async (
+        callback: (message: { forecast: Array<Types.WeatherForecast> }) => void,
+      ) => {
+        handler = callback;
+        return () => undefined;
+      },
+    },
+  } as unknown as Types.Hass;
+
+  const config = { weather: { entity: 'weather.home' } } as unknown as Types.Config;
+
+  let received: Record<string, Types.WeatherData> = {};
+  await WeatherUtils.subscribeToWeatherForecast(hass, config, 'hourly', (forecasts) => {
+    received = forecasts;
+  });
+
+  handler?.({
+    forecast: [
+      {
+        datetime: new Date(2025, 0, 8, hour, 0, 0).toISOString(),
+        condition,
+        temperature: 10,
+      } as Types.WeatherForecast,
+    ],
+  });
+
+  return Object.values(received)[0]?.icon;
+}
+
+describe('night forecast icons', () => {
+  it.each(NIGHT_SWAPPED)('draws %s with its night icon after dark', async (condition, icon) => {
+    expect(await iconFor(condition, 22)).toBe(icon);
+  });
+
+  it.each(NIGHT_SWAPPED)('draws %s with its daytime icon by day', async (condition) => {
+    expect(await iconFor(condition, 12)).toBe(WeatherUtils.CONDITION_ICON_MAP[condition]);
+  });
+
+  it.each(NIGHT_SWAPPED)('changes the icon %s is drawn with after dark', async (condition) => {
+    expect(await iconFor(condition, 22)).not.toBe(await iconFor(condition, 12));
+  });
+
+  it('leaves a condition without a night variant alone after dark', async () => {
+    expect(await iconFor('rainy', 22)).toBe(WeatherUtils.CONDITION_ICON_MAP.rainy);
+  });
+
+  it('treats the early morning as night too', async () => {
+    expect(await iconFor('sunny', 3)).toBe('mdi:weather-night');
+  });
+
+  it('treats the hour the sun is still up as day', async () => {
+    expect(await iconFor('sunny', 17)).toBe(WeatherUtils.CONDITION_ICON_MAP.sunny);
+  });
+});


### PR DESCRIPTION
test(start-date,weather,editor): pin the three lookup vocabularies nothing exercised

A delete-one-entry sweep across the nine remaining `Record<string, T>` lookup
tables in `src/` — 49 entries in total — found 17 that could be removed with
every one of the ten gates still green. Fourteen of them are the entire weekday
vocabulary of the `start_date` grammar, three are the night variants of the
forecast icons, and two are the words the per-calendar split is stored under.

The weekday table is the one that matters most, because it is a published
contract. `docs/features/start-date-offset.md` lists all fourteen spellings —
the seven full names and the seven abbreviations — and the worked examples use
them in both roles the grammar offers: as the anchor (`saturday`, `monday+1w`)
and as a jump operand (`today+sat`, `start_of_week+mon`, and the one-card-per-
weekday row that runs `+tue, +wed, +thu, +fri`). Neither role had a single test.
The two roles also fail differently, and the worse one fails quietly: as an
anchor an unknown word falls through to `{ kind: 'nomatch' }`, so the card
silently starts from today instead of the requested weekday, while as an operand
it at least surfaces `unrecognized operand`. The weekday names that do appear in
the suite are all there for `first_day_of_week`, which is a different code path
with its own mapping, so the coverage looked present without being present.

The night icons fail the same quiet way. `getWeatherIcon` swaps three conditions
for a night-appropriate icon between 18:00 and 06:00 because their daytime icon
is actively wrong after dark — `sunny` draws a sun, and an hourly forecast row
at 22:00 showing a sun reads as a bug. Delete an entry and the lookup falls back
to the daytime table and simply draws the wrong icon.

The split words are narrower but reach the stored config: `split_multiday_events`
shares the tristate machinery with the three `show_*` options but not its
vocabulary, offering `split`/`whole` where they offer `show`/`hide`. The existing
round-trip test covers only the `show`/`hide` pair, so both split words could be
dropped from the value table and choosing "Split" in the editor would then write
nothing at all, leaving the calendar silently inheriting from the card.

Each pin carries its own control, because a table test that only asserts the
valid cases resolve is satisfied by a parser that resolves everything. The
weekday pin asserts that a word outside the vocabulary is rejected in both
roles; the icon pin asserts the same condition draws differently by day than by
night, and that a condition with no night variant is left alone after dark.

Every entry was falsified individually: deleting `WEEKDAYS.mon` or
`WEEKDAYS.saturday` fails three tests each, deleting `NIGHT_ICONS.sunny` fails
three and `NIGHT_ICONS['lightning-rainy']` two, and deleting either split word
fails the new round-trip.

One survivor was deliberately not pinned. `ENTITY_TRISTATE_STORED[INHERIT]` maps
to `undefined`, which is also what a missing key returns, and its only reverse
consumer matches on that value — so removing it is a semantic no-op rather than
a defect, and a test for it would assert nothing.

No production code changes; both tables predate the column view.
