### PR TITLE
Pin every enumerated option's editor dropdown to its type union

### DIFF
--- a/tests/editor-schema.test.ts
+++ b/tests/editor-schema.test.ts
@@ -4029,3 +4029,115 @@ describe('editor: exceptions for the union-typed options', () => {
     expect(data.week_number_mode).toBe('none');
   });
 });
+
+/**
+ * An enumerated option has two independent surfaces: the type union in `types.ts` that
+ * defines its vocabulary, and the visual editor's dropdown that offers it. `check:docs`
+ * pins the union against the reference table, so a value cannot be added to the type
+ * without being documented — but nothing pinned it against the editor. A value could be
+ * added to the union, documented, and still be unselectable in the UI, which is how a
+ * reader ends up shown an option the editor will not let them choose.
+ */
+describe('editor: enumerated options offer their whole vocabulary', () => {
+  /**
+   * Where the editor surfaces each enumerated config key, and any value that exists only
+   * in the editor because the union spells it a way a dropdown cannot.
+   */
+  const EDITOR_FIELD: Record<string, { field: string; editorOnly?: readonly string[] }> = {
+    view: { field: 'view' },
+    first_day_of_week: { field: 'first_day_of_week' },
+    // The union's third member is `null`, which is not a string literal and which the
+    // editor spells `none` because a dropdown cannot offer an absent value.
+    show_week_numbers: { field: 'week_number_mode', editorOnly: ['none'] },
+    position: { field: 'position' },
+    min_days_fallback: { field: 'min_days_fallback' },
+  };
+
+  /**
+   * Every enumerated config option, read from the types rather than listed, so a new one
+   * is discovered instead of quietly going unchecked.
+   *
+   * @returns Each option's name mapped to the string literals its union allows
+   */
+  function unionValues(): Map<string, string[]> {
+    const source = readFileSync(join(process.cwd(), 'src/config/types.ts'), 'utf-8');
+    const literals = (text: string) =>
+      (text.match(/'[a-z0-9_-]+'/g) ?? []).map((s) => s.slice(1, -1));
+
+    const aliases = new Map<string, string[]>();
+    for (const match of source.matchAll(/^export type ([A-Za-z]+)\s*=\s*([^;]+);/gm)) {
+      const values = literals(match[2]);
+      if (match[2].includes('|') && values.length > 1) aliases.set(match[1], values);
+    }
+
+    const found = new Map<string, string[]>();
+    for (const name of ['Config', 'EntityConfig', 'WeatherConfig', 'ColumnOverrides']) {
+      const block = source.match(new RegExp(`export interface ${name}\\s*\\{([\\s\\S]*?)\\n\\}`));
+      if (!block) continue;
+
+      for (const line of block[1].split('\n')) {
+        const field = line.match(/^ {2}([a-z0-9_]+)\??:\s*(.+?);/);
+        if (!field) continue;
+
+        const type = field[2].trim();
+        const values = type.includes('|') ? literals(type) : (aliases.get(type) ?? []);
+        if (values.length > 1) found.set(field[1], values);
+      }
+    }
+    return found;
+  }
+
+  /**
+   * Every dropdown the editor builds, across the configurations that surface them all.
+   *
+   * A panel only offers what the configuration in front of it calls for, so the weather
+   * and column dropdowns exist only once those features are configured.
+   *
+   * @returns Each dropdown's field name mapped to the values it offers
+   */
+  function editorOptions(): Map<string, string[]> {
+    const configs = [
+      buildConfig({}),
+      buildConfig({ view: 'column' }),
+      buildConfig({ weather: { entity: 'weather.home' } }),
+      buildConfig({ view: 'column', weather: { entity: 'weather.home' } }),
+    ] as Types.Config[];
+
+    const found = new Map<string, string[]>();
+    for (const config of configs) {
+      for (const panel of PANELS) {
+        const schema = panel.build({ view: config.view, config, language: 'en' });
+        for (const { node } of walkSchema(schema)) {
+          const options = (node as { selector?: { select?: { options?: unknown[] } } }).selector
+            ?.select?.options;
+          if (!node.name || !options) continue;
+
+          found.set(
+            node.name,
+            options.map((option) =>
+              typeof option === 'string' ? option : (option as SelectOption).value,
+            ),
+          );
+        }
+      }
+    }
+    return found;
+  }
+
+  it('maps every enumerated option the types declare', () => {
+    // Discovered rather than listed, so adding a sixth enumerated option fails here
+    // instead of silently skipping the vocabulary check below.
+    expect([...unionValues().keys()].sort()).toEqual(Object.keys(EDITOR_FIELD).sort());
+  });
+
+  it.each(Object.entries(EDITOR_FIELD))(
+    'offers every value %s accepts',
+    (option, { field, editorOnly = [] }) => {
+      const expected = [...unionValues().get(option)!, ...editorOnly].sort();
+      const offered = editorOptions().get(field);
+
+      expect(offered, `the editor builds no dropdown named ${field}`).toBeDefined();
+      expect([...offered!].sort()).toEqual(expected);
+    },
+  );
+});


### PR DESCRIPTION
Pin every enumerated option's editor dropdown to its type union

An enumerated config option lives on two surfaces that nothing kept in
step. The type union in `types.ts` defines the vocabulary, and a
hand-written literal array in one of five files under
`src/rendering/editor/schemas/` decides what the visual editor actually
offers. `check:docs` check 21 pins the union against the reference
table, so a value cannot reach the type without being documented — but
it says nothing about the editor. A value could be added to the union,
faithfully documented, and remain unselectable in the UI.

Proven by planting. Adding `'scroll'` to `ColumnMinDaysFallback` and
leaving the editor's two-value array alone was caught, but only by
`check:docs`, and only because the reference row had not been updated.
Updating that row too — the natural next step for anyone adding a value
— left `tsc`, `lint`, `test`, `check:docs` and `check:i18n` all at exit
0 while the editor still offered `list` and `cramp`. A reader would have
found `scroll` documented and had no way to choose it.

This matters most for the two options the plant used, because `view` and
`min_days_fallback` are new in v4 and their vocabularies are the ones
most likely to grow.

The guard is a test rather than a docs check, because the comparison is
code against code and needs the real schema builders: three of the five
dropdowns are inline literals, `view` resolves through `ViewConfig.VIEWS`,
and `show_week_numbers` is offered under the synthetic name
`week_number_mode` with `null` spelled `none`. Building the panels and
walking them sidesteps all of that. Both directions are pinned, so a
union that grows past its dropdown and a dropdown that keeps a value the
union dropped each fail. The enum set is discovered from the types rather
than listed, so a sixth enumerated option fails the exhaustiveness pin
instead of quietly going unchecked.

Falsified three ways: adding a union value fails the vocabulary test,
removing an editor value fails it, and adding a sixth enum fails the
pin. All ten gates pass; 1573 to 1579 tests.
