### PR TITLE
test: guard date_vertical_alignment at both ends

### DIFF
--- a/tests/icon-alignment.test.ts
+++ b/tests/icon-alignment.test.ts
@@ -102,6 +102,43 @@ describe('event icon vertical alignment', () => {
   });
 });
 
+describe('date column vertical alignment', () => {
+  const PROP = '--calendar-card-date-column-vertical-alignment';
+
+  /*
+   * Pinned for the same reason as `event_icon_vertical_alignment` above, and missing for
+   * far longer. This option reaches CSS verbatim rather than through a mapping ternary,
+   * so the property value *is* the config value -- which makes it look too trivial to be
+   * worth a test, and is exactly why nothing tested it. `styles.ts` could hardcode any of
+   * the three values and the entire suite stayed green.
+   */
+  it.each(['top', 'middle', 'bottom'] as const)('passes %s through to the property', (option) => {
+    expect(
+      generateCustomPropertiesObject(buildConfig({ date_vertical_alignment: option }))[PROP],
+    ).toBe(option);
+  });
+
+  it('resolves to middle at the default', () => {
+    // Two assertions rather than one, matching the icon option: the first states the
+    // shipped default so the docs cannot drift from the code, the second states that the
+    // default actually reaches CSS. The pre-existing default-only assertion could not
+    // see the second, which is the half that broke.
+    expect(Config.DEFAULT_CONFIG.date_vertical_alignment).toBe('middle');
+    expect(generateCustomPropertiesObject(buildConfig())[PROP]).toBe('middle');
+  });
+
+  it('passes an unrecognised value straight through, unlike the icon option', () => {
+    // The two options genuinely differ here and the difference is worth stating. The icon
+    // option funnels an unknown value into `center` through its ternary; this one hands
+    // the string to CSS, where an invalid `vertical-align` is dropped and the cell falls
+    // back to `baseline`. A future "make the alignments consistent" pass would change
+    // that without any test noticing.
+    expect(
+      generateCustomPropertiesObject(buildConfig({ date_vertical_alignment: 'centre' }))[PROP],
+    ).toBe('centre');
+  });
+});
+
 describe('time text display custom property', () => {
   const PROP = '--calendar-card-time-display';
 

--- a/tests/stylesheet.test.ts
+++ b/tests/stylesheet.test.ts
@@ -961,6 +961,34 @@ describe('card stylesheet', () => {
     });
   });
 
+  describe('date column vertical alignment reaches the date cell', () => {
+    /*
+     * The sibling of the Y5 bug above, and the half nobody guarded. When the icon option
+     * was pinned end to end, `date_vertical_alignment` -- the older option the icon one
+     * was modelled on -- kept a single assertion on its default value and nothing at all
+     * on its wiring.
+     *
+     * Both ends could therefore be severed with every gate green: `styles.ts` could stop
+     * reading the user's config and hardcode a value, or this rule could lose its
+     * `vertical-align` outright, and `npm test`, `check:docs`, `build` and `check:bundle`
+     * all still passed. The option is documented as controlling how a date sits against
+     * its day's events, so either break is silent and plainly visible to the user.
+     */
+    it('the date cell aligns from the configured variable', () => {
+      expect(declared('.date-column', 'vertical-align')).toBe(
+        'var(--calendar-card-date-column-vertical-alignment)',
+      );
+    });
+
+    it('does not hardcode the alignment it is supposed to read', () => {
+      // The Y5 failure mode in its general form. Worth asserting separately here because
+      // `.date-column` is a table cell, whose initial `vertical-align` is `baseline`: a
+      // literal `middle` would look like a sensible default and silently pin every
+      // list-view row to one alignment.
+      expect(declared('.date-column', 'vertical-align')).not.toBe('middle');
+    });
+  });
+
   describe('single-declaration invariants', () => {
     it.each(['.event-title', '.summary'])('%s is declared exactly once', (selector) => {
       // Both were split across two blocks at some point, which made the winning


### PR DESCRIPTION
test: guard date_vertical_alignment at both ends

`date_vertical_alignment` could be disconnected from the card entirely, at
either end, with all ten release gates green.

Two independent mutations proved it. Hardcoding the custom property in
`generateCustomPropertiesObject()` so it ignores the user's config survived
`npm test`, `check:docs`, `tsc`, `lint`, `build` and `check:bundle`. Deleting
`vertical-align` from the `.date-column` rule outright survived all six as
well. Either break silently pins every list-view date to one alignment, and
the option is documented as controlling exactly that -- how a date sits
against its day's events, centred by default, `top` against the first event
and `bottom` against the last.

Nothing caught it because the option resolves to a host custom property and
never to an attribute, so it is invisible to both DOM goldens, and because
the one test named for it asserted only that its default value is `middle`
-- a test that cannot fail when the wiring behind that value is severed.
That is the same vacuity `card_max_height` had.

The asymmetry is the tell. Its sibling `event_icon_vertical_alignment` has a
dedicated file pinning every value it maps to, plus a stylesheet block
pinning every row that reads it -- both written when the Y5 bug shipped. The
older option that one was modelled on never got the same treatment.

Adds the missing halves, mirroring the sibling's structure: all three values
plus the default pinned through to the property, and the `.date-column` rule
pinned to read the variable rather than a literal. Each new assertion was
falsified against the mutation it exists to catch.

While measuring this, the event weather badge was checked too and is
deliberately excluded -- `styles.ts` scopes the icon variable to
`.time-location .event-weather` precisely to keep it off the list-view title
badge, and the docs scope the option to the time, location and description
rows. `ICON_ROWS`'s three entries are correct as they stand.

Test-only: both production bundles are byte-identical.
