### PR TITLE
test: pin that show_countdown_allday off suppresses the countdown

### DIFF
--- a/tests/countdown-allday.test.ts
+++ b/tests/countdown-allday.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as Presentation from '../src/rendering/presentation';
+
+/**
+ * `show_countdown_allday` is the opt-out that suppresses the countdown on all-day
+ * events while leaving it on timed ones. Nothing exercised it: a repository-wide
+ * search for the key found no test at all, and removing its arm from the gate in
+ * `presentation.ts` left the entire suite green.
+ *
+ * That is the usual shape. `show_countdown` itself is well covered because a test
+ * that proves the countdown appears dies when it stops appearing — but the same
+ * test is equally satisfied when the countdown appears somewhere it should not,
+ * which is exactly what turning this option off is meant to prevent. Only an
+ * assertion written against the off value can see that direction.
+ *
+ * The two positive controls matter as much as the guard: without them a harness
+ * that never produces a countdown at all would satisfy every "renders nothing"
+ * assertion here vacuously.
+ */
+const ALL_DAY = {
+  summary: 'Public holiday',
+  start: { date: '2026-06-22' },
+  end: { date: '2026-06-23' },
+};
+
+const TIMED = {
+  summary: 'Standup',
+  start: { dateTime: '2026-06-22T07:00:00.000Z' },
+  end: { dateTime: '2026-06-22T08:00:00.000Z' },
+};
+
+function countdownFor(
+  event: typeof ALL_DAY | typeof TIMED,
+  overrides: Record<string, unknown>,
+): string | null {
+  const config = buildConfig({ show_countdown: true, ...overrides });
+  const presentation = Presentation.buildEventPresentation(
+    event as unknown as Types.CalendarEventData,
+    config,
+    'en',
+    null,
+  );
+  return presentation.contentParts.countdownStr;
+}
+
+describe('show_countdown_allday', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows a countdown on an all-day event when left at its default', () => {
+    expect(countdownFor(ALL_DAY, {})).toBeTruthy();
+  });
+
+  it('shows a countdown on a timed event when the all-day opt-out is off', () => {
+    expect(countdownFor(TIMED, { show_countdown_allday: false })).toBeTruthy();
+  });
+
+  it('suppresses the countdown on an all-day event when turned off', () => {
+    expect(countdownFor(ALL_DAY, { show_countdown_allday: false })).toBeNull();
+  });
+
+  it('suppresses every countdown when show_countdown itself is off', () => {
+    expect(countdownFor(ALL_DAY, { show_countdown: false })).toBeNull();
+    expect(countdownFor(TIMED, { show_countdown: false })).toBeNull();
+  });
+});


### PR DESCRIPTION
test: pin that show_countdown_allday off suppresses the countdown

`show_countdown_allday` is the opt-out that hides the countdown on all-day
events while leaving it on timed ones. Nothing exercised it. A repository-wide
search for the key found no test at all, and dropping its arm from the gate in
`presentation.ts` left the entire suite green:

    mutation: !(isAllDayEvent && !config.show_countdown_allday) && -> true &&
    npm test  exit=0   1608 passed

This came out of a mechanical sweep of every `show_*` gate in the rendering and
event pipeline. Seventeen gates were each mutated so their off value renders
anyway; fifteen were killed by an existing test. Two survived. One of them,
`show_progress_bar` in `presentation.ts`, is inert rather than uncovered — its
only consumer, `leaves.ts:442`, re-checks the same option and is itself killed
by a test, so the presentation-layer check is redundant defence in depth and
removing it changes no output. `show_countdown_allday` was the one real gap.

The shape is the recurring one. `show_countdown` itself is well covered, because
a test that proves the countdown appears dies the moment it stops appearing. But
that same test is equally satisfied when the countdown appears somewhere it
should not, which is precisely what turning this option off is meant to prevent.
Only an assertion written against the off value can see that direction, and those
get written far less often — which is why the off value is so often the
unguarded one, structurally rather than by oversight.

The new file drives `buildEventPresentation` directly, the layer the gate lives
in, and asserts on `contentParts.countdownStr`. Two of its four tests are
positive controls: an all-day event at the default still shows a countdown, and
a timed event still shows one with the all-day opt-out off. Without them a
harness that never produced a countdown at all would satisfy the suppression
assertions vacuously. Falsification kills exactly one test per mutation, and the
controls survive both:

    drop show_countdown_allday arm   1 failed | 3 passed  (the suppression test)
    drop show_countdown arm          1 failed | 3 passed  (the outer control)
    restored                         exit=0

Test-only; no behaviour change, so no release-notes entry.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6c7714fb-9c18-4995-9aaa-129fa9eb7a53
