### PR TITLE
test: guard the numeric options nothing asserted at their off value

### DIFF
--- a/tests/max-lines.test.ts
+++ b/tests/max-lines.test.ts
@@ -75,6 +75,7 @@ describe('per-field max-lines custom properties', () => {
  */
 describe('the weather row line limit', () => {
   const PROP = '--calendar-card-weather-event-max-lines';
+  const DISPLAY = '--calendar-card-weather-event-condition-display';
 
   function withWeather(event: Record<string, unknown>) {
     return buildConfig({
@@ -97,6 +98,24 @@ describe('the weather row line limit', () => {
     // The shallow-merge case: this block is what a real user's YAML produces.
     expect(generateCustomPropertiesObject(withWeather({ show_conditions: true }))[PROP]).toBe(
       'none',
+    );
+  });
+
+  // The companion display property, guarded for the same reason as the title above
+  // and found the same way: mutating this ternary to either constant left the whole
+  // suite green, while the identical mutation on the title's display property was
+  // killed. The clamp value alone is inert -- `-webkit-line-clamp` only applies to a
+  // `-webkit-box`, so the two properties have to agree or the limit silently does
+  // nothing. Asserting the count without the display is how a clamp can read as
+  // configured and still never truncate.
+  it('leaves the weather condition inline at the default so the row is layout-neutral', () => {
+    expect(generateCustomPropertiesObject(buildConfig())[DISPLAY]).toBe('inline');
+    expect(generateCustomPropertiesObject(withWeather({ max_lines: 0 }))[DISPLAY]).toBe('inline');
+  });
+
+  it('blockifies the weather condition only once a limit is actually set', () => {
+    expect(generateCustomPropertiesObject(withWeather({ max_lines: 2 }))[DISPLAY]).toBe(
+      '-webkit-box',
     );
   });
 });

--- a/tests/off-value-guards.test.ts
+++ b/tests/off-value-guards.test.ts
@@ -1,9 +1,10 @@
 import { render as litRender } from 'lit';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { FROZEN_NOW, buildConfig } from './fixtures';
+import { FROZEN_NOW, SINGLE_EVENT, WEATHER, buildConfig } from './fixtures';
 import * as Types from '../src/config/types';
 import * as Leaves from '../src/rendering/leaves';
+import * as Presentation from '../src/rendering/presentation';
 import * as EventUtils from '../src/utils/events';
 import * as FormatUtils from '../src/utils/format';
 import '../src/calendar-card-pro';
@@ -202,5 +203,116 @@ describe('hide_when_empty leaves an empty card visible when off', () => {
 
   it('leaves an empty card visible at the default', () => {
     expect(hiddenWith(false)).toBe(false);
+  });
+});
+
+/**
+ * The same sweep, extended from boolean options to numeric ones whose "off"
+ * value is `0` or unset. Three more gates survived and are pinned below.
+ *
+ * These are harder to see than the boolean cases, because `0` is not a
+ * disabled feature — it is a different, equally valid setting that happens to
+ * render nothing extra. `uv_index_threshold: 0` means "never suppress", and a
+ * background opacity of `0` means "draw no background", so in both cases the
+ * default output is indistinguishable from the option not working at all.
+ */
+describe('uv_index_threshold suppresses the badge below the threshold', () => {
+  /**
+   * The threshold is the whole point of the option: it exists so a user only
+   * sees a UV badge on days that warrant one. Both scopes asserted that the
+   * badge *appears* — mutating the comparison to `false` killed 1 test in the
+   * date scope and 7 in the event scope — but mutating it to `true`, which
+   * makes the threshold do nothing at all, left the suite green in both.
+   *
+   * The fixture forecast carries `uv_index: 7`, so a threshold of 7 must still
+   * show the badge and a threshold of 8 must hide it. Both are asserted, so
+   * neither passes in a harness that simply never renders UV.
+   */
+  const DATE = new Date(FROZEN_NOW);
+
+  // `renderEventWeather` drops the badge for an event that has already ended,
+  // so the clock has to sit inside the fixture day or every case below returns
+  // empty markup and the absence assertions pass for the wrong reason.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function dateBadge(uv_index_threshold: number) {
+    const config = buildConfig({
+      weather: {
+        entity: 'weather.home',
+        position: 'date',
+        date: { show_uv_index: true, uv_index_threshold },
+      },
+    } as never);
+    const container = document.createElement('div');
+    litRender(Leaves.renderDateWeather(DATE, config, WEATHER), container);
+    return container.querySelector('.weather-uv-index');
+  }
+
+  function eventBadge(uv_index_threshold: number) {
+    const config = buildConfig({
+      weather: {
+        entity: 'weather.home',
+        position: 'event',
+        event: { show_uv_index: true, uv_index_threshold },
+      },
+    } as never);
+    const container = document.createElement('div');
+    // The hourly fixtures carry no `uv_index` at all, so a timed event that
+    // resolves to one can never show the badge. Empty the hourly map to take
+    // the documented daily fallback, which is the forecast that has the index.
+    const forecasts = { ...WEATHER, hourly: {} };
+    litRender(
+      Leaves.renderEventWeather(SINGLE_EVENT[0], config, forecasts, 'title', null),
+      container,
+    );
+    return container.querySelector('.weather-uv-index');
+  }
+
+  it('shows the date badge when the index reaches the threshold', () => {
+    expect(dateBadge(7)?.textContent).toBe('UV7');
+  });
+
+  it('hides the date badge when the index is below the threshold', () => {
+    expect(dateBadge(8)).toBeNull();
+  });
+
+  it('shows the event badge when the index reaches the threshold', () => {
+    expect(eventBadge(7)?.textContent).toBe('UV7');
+  });
+
+  it('hides the event badge when the index is below the threshold', () => {
+    expect(eventBadge(8)).toBeNull();
+  });
+});
+
+describe('event_background_opacity draws a background once it is set', () => {
+  /**
+   * The inverse direction to the UV case. Forcing the opacity to a constant 50
+   * killed 17 tests, so "no background at the default" is thoroughly covered —
+   * but forcing it to a constant 0, which removes the background from every
+   * card that asks for one, left the suite green. `event_background_opacity`
+   * appeared only in `config.test.ts`, which normalizes the value and never
+   * renders it, so nothing connected the accepted number to any output.
+   */
+  const presentation = (event_background_opacity: number) =>
+    Presentation.buildEventPresentation(
+      SINGLE_EVENT[0],
+      buildConfig({ event_background_opacity }),
+      'en',
+      null,
+    );
+
+  it('emits no background colour at the default of 0', () => {
+    expect(presentation(0).entityAccentBackgroundColor).toBe('');
+  });
+
+  it('emits a background colour once an opacity is configured', () => {
+    expect(presentation(50).entityAccentBackgroundColor).not.toBe('');
   });
 });


### PR DESCRIPTION
test: guard the numeric options nothing asserted at their off value

Extends the off-value mutation sweep from boolean options to numeric ones
whose "off" value is 0 or unset. Every numeric gate in the rendering
pipeline was replaced with a constant in both directions and the suite
re-run; a surviving mutation proves nothing depends on that value.

Fifteen of nineteen mutations were killed -- the four *_max_lines clamps
and their display companions are well covered. Four survived, in three
options:

* weather.event.max_lines display. `max-lines.test.ts` already guards the
  title's display property, with a comment recording that an unconditional
  `-webkit-box` measurably tightened every event row on a live build. The
  weather condition has the identical pairing and no such guard, so both
  directions survived. The clamp count alone is inert: `-webkit-line-clamp`
  only applies to a `-webkit-box`, so the two properties have to agree or a
  configured limit silently never truncates.

* uv_index_threshold, in both the date and event scopes. Suppressing the
  badge is the entire purpose of the option, and it is the one direction
  neither scope asserted. Mutating the comparison to `false` killed 1 test
  in the date scope and 7 in the event scope, so "the badge appears" is
  covered; mutating it to `true`, which makes the threshold do nothing at
  all, left the whole suite green in both.

* event_background_opacity. The inverse: forcing a constant 50 killed 17
  tests, so "no background at the default" is thoroughly covered, while
  forcing a constant 0 -- which removes the background from every card that
  asks for one -- left the suite green. The option appeared only in
  config.test.ts, which normalizes the value and never renders it, so
  nothing connected the accepted number to any output.

Two harness faults surfaced while writing these, both caught because the
paired presence control failed rather than the absence assertion passing
quietly. The hourly forecast fixtures carry no uv_index at all, so a timed
event resolving to one can never show the badge; the tests empty the hourly
map to take the documented daily fallback. And renderEventWeather drops the
badge for an event that has already ended, so the new describe freezes the
clock -- without it every case returns empty markup and both absence
assertions pass for the wrong reason.

Test-only; no runtime change.
