### PR TITLE
Guard the column view's inline style bindings and drop a redundant branch

### DIFF
--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -591,13 +591,6 @@ export function groupEventsByDay(
       } else {
         endDateForEmptyDays = new Date(referenceDate);
       }
-    } else if (
-      compactLimitsApply &&
-      config.compact_days_to_show &&
-      !config.compact_events_to_show
-    ) {
-      endDateForEmptyDays = new Date(referenceDate);
-      endDateForEmptyDays.setDate(endDateForEmptyDays.getDate() + effectiveDaysToShow - 1);
     } else if (compactLimitsApply && config.compact_events_to_show) {
       if (days.length > 0) {
         const lastDayTimestamp = Math.max(...days.map((d) => d.timestamp));
@@ -606,6 +599,11 @@ export function groupEventsByDay(
         endDateForEmptyDays = new Date(referenceDate);
       }
     } else {
+      // Everything else pads to the full window, including a compact day limit with no
+      // event limit: `effectiveDaysToShow` has already been narrowed to that limit above,
+      // so that case needs no branch of its own. It used to have one, whose body was a
+      // byte-for-byte copy of this block, which read as a special case while doing nothing
+      // a reader could distinguish from the default.
       endDateForEmptyDays = new Date(referenceDate);
       endDateForEmptyDays.setDate(endDateForEmptyDays.getDate() + effectiveDaysToShow - 1);
     }

--- a/tests/column-inline-style.test.ts
+++ b/tests/column-inline-style.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Column-view inline style bindings.
+ *
+ * ## Why this file exists
+ *
+ * Both views paint two things directly onto the event element's `style` attribute
+ * rather than through a CSS custom property: the per-calendar accent border and the
+ * event background colour that `event_background_opacity` turns on. The two bindings
+ * are written out character-for-character identically in `render.ts` (list) and
+ * `column.ts` (column).
+ *
+ * Only one of the two copies was guarded. `tests/list-dom.test.ts` keeps a committed
+ * DOM snapshot, and that snapshot happens to contain the `style` attribute 363 times,
+ * so dropping either binding from the list view fails 17 snapshot tests immediately.
+ * The column view has 63 tests and no snapshot at all — its assertions are targeted at
+ * classes, structure and shared content, and none of them reads `style`. Deleting both
+ * bindings from `column.ts` left the entire suite green.
+ *
+ * That asymmetry is the whole point: the killed list-view sibling proves the effect is
+ * observable, so the surviving column mutation was a coverage gap rather than dead
+ * code. Because the two views share `presentation.ts`, a change made for the list view
+ * reaches the column view too — and until now, only one of them would have told us if
+ * it went wrong there.
+ *
+ * The list assertions below are deliberately duplicated from the snapshot's implicit
+ * coverage. They are the control: if the shape of these assertions were wrong, they
+ * would fail on the view that is already known to be correct.
+ */
+import { render as litRender } from 'lit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EVENTS, FROZEN_NOW, buildConfig } from './fixtures';
+import * as Types from '../src/config/types';
+import * as Column from '../src/rendering/column';
+import * as Render from '../src/rendering/render';
+import * as EventUtils from '../src/utils/events';
+
+/** Renders one view and returns the inline `style` of its first event element. */
+function eventStyle(view: Types.EffectiveView, overrides: Partial<Types.Config> = {}): string {
+  const config = buildConfig(overrides as never);
+  const days = EventUtils.groupEventsByDay(EVENTS, config, false, 'en', view);
+  const container = document.createElement('div');
+  litRender(
+    view === 'column'
+      ? Column.renderColumnGroupedEvents(days, config, 'en', undefined, null)
+      : Render.renderGroupedEvents(days, config, 'en', undefined, null),
+    container,
+  );
+  const element = container.querySelector('.event');
+  expect(element, `expected the ${view} view to render an .event element`).not.toBeNull();
+  return element?.getAttribute('style') ?? '';
+}
+
+describe('column view inline style bindings', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('the per-calendar accent border', () => {
+    it('paints the configured accent colour onto the column event', () => {
+      expect(eventStyle('column', { accent_color: '#ff0000' })).toContain('solid #ff0000');
+    });
+
+    it('paints the same accent colour onto the list event', () => {
+      // Control: already covered by the list DOM snapshot, so a failure here means the
+      // assertion shape is wrong rather than the column view being broken.
+      expect(eventStyle('list', { accent_color: '#ff0000' })).toContain('solid #ff0000');
+    });
+  });
+
+  describe('the event background colour', () => {
+    it('draws a background on the column event once an opacity is configured', () => {
+      expect(eventStyle('column', { event_background_opacity: 50 })).toContain(
+        'background-color: #03a9f4',
+      );
+    });
+
+    it('draws the same background on the list event', () => {
+      expect(eventStyle('list', { event_background_opacity: 50 })).toContain(
+        'background-color: #03a9f4',
+      );
+    });
+
+    it('leaves the column background empty at the default opacity', () => {
+      // Paired with the presence test above: without it, a binding that never draws
+      // anything would satisfy this assertion for entirely the wrong reason.
+      expect(eventStyle('column', {})).toContain('background-color: ;');
+    });
+  });
+});


### PR DESCRIPTION
Guard the column view's inline style bindings and drop a redundant branch

Two findings from a mutation sweep over the compact-mode gates and the
rendering layer, both in the same area and neither user-visible today.

Column-view inline styles were completely unguarded
---------------------------------------------------
Both views paint two things straight onto the event element's `style`
attribute rather than through a CSS custom property: the per-calendar
accent border, and the event background that `event_background_opacity`
turns on. The two bindings are written character-for-character
identically in `render.ts` and `column.ts`.

Only the list copy was covered, and only incidentally. `list-dom.test.ts`
keeps a committed DOM snapshot which happens to contain the `style`
attribute 363 times, so replacing either binding with a literal fails 17
snapshot tests at once. The column view has 63 tests and no snapshot at
all; its assertions target classes, structure and shared content, and
none of them reads `style`. Replacing both column bindings left the
entire 1630-test suite green.

The asymmetry is what makes this a coverage gap rather than dead code:
the killed list-view sibling proves the effect is observable, so the
surviving column mutation could only mean nothing was looking. Because
both views share `presentation.ts`, a change made for the list view
reaches the column view too, and until now only one of the two would
have reported it going wrong there.

`tests/column-inline-style.test.ts` pins both bindings in the column
view, repeats each assertion against the list view as a control, and
pairs the background presence test with an absence test at the default
opacity so a binding that never draws anything cannot satisfy it. All
four mutations now die against the new file alone.

A redundant empty-days branch
-----------------------------
The empty-day padding chain in `groupEventsByDay` had a dedicated arm for
"compact day limit set, compact event limit not set" whose body was a
byte-for-byte copy of the chain's final `else`. Its own condition
included `!config.compact_events_to_show`, which guarantees the next arm
cannot match, so removing it always lands on that identical fallback --
`effectiveDaysToShow` has already been narrowed to the compact limit
further up, so the case needs no branch of its own.

No test could ever have distinguished it, which is why the sweep flagged
it as a survivor: this is redundant code rather than missing coverage.
Equivalence was proved directly rather than inferred from a green suite,
with a differential probe sweeping 288 configurations (expanded state,
empty/populated events, `show_empty_days`, both views, both compact
limits at three values each, two day counts) and serialising the day
list with per-day event counts. Output was identical before and after,
288 of 288.

The final `else` now carries a comment recording that it also covers the
compact day-limit case, so the next reader does not re-add the branch.
