### PR TITLE
test: guard the column view's event and day state classes

### DIFF
--- a/tests/day-container-classes.test.ts
+++ b/tests/day-container-classes.test.ts
@@ -104,6 +104,40 @@ function renderColumn(config: Types.Config): HTMLElement {
   return container;
 }
 
+/**
+ * `tomorrow` needs the shared fixture, not the weekend span.
+ *
+ * `WEEKEND_SPAN` starts on the 19th, two days after the frozen Wednesday, so no day in
+ * it is ever tomorrow. Every assertion above therefore compares `tomorrow` as absent in
+ * both views and passes whether the class is computed or hardcoded to `false` — which is
+ * exactly what happened: dropping `tomorrow` from `column.ts` left this file green and
+ * was caught only by the list snapshot, which column view has no equivalent of.
+ *
+ * `EVENTS` spans the frozen day and the two after it, so day 1 is genuinely tomorrow and
+ * days 0 and 2 are genuinely not. Asserting the whole boolean run keeps the presence and
+ * the absence in one expectation.
+ */
+const TOMORROW_CONFIG = { days_to_show: 3 };
+const TOMORROW_COLUMN_CONFIG = {
+  ...TOMORROW_CONFIG,
+  view: 'column' as const,
+  column: { show_empty_days: false },
+};
+
+function renderListTomorrow(config: Types.Config): HTMLElement {
+  const days = EventUtils.groupEventsByDay(EVENTS, config, false, 'en', 'list');
+  const container = document.createElement('div');
+  litRender(Render.renderGroupedEvents(days, config, 'en', undefined, null), container);
+  return container;
+}
+
+function renderColumnTomorrow(config: Types.Config): HTMLElement {
+  const days = EventUtils.groupEventsByDay(EVENTS, config, false, 'en', 'column');
+  const container = document.createElement('div');
+  litRender(Column.renderColumnGroupedEvents(days, config, 'en', undefined, null), container);
+  return container;
+}
+
 describe('day container state classes', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -149,6 +183,21 @@ describe('day container state classes', () => {
     // container must not have moved it off the cell.
     const cells = classesOf(renderList(buildConfig(SPAN_CONFIG)), '.date-column');
     expect(cells.map((c) => c.includes('weekend'))).toEqual([false, true, true, false]);
+  });
+
+  it('marks the day after today as tomorrow in list view', () => {
+    const containers = classesOf(renderListTomorrow(buildConfig(TOMORROW_CONFIG)), '.day-table');
+    expect(containers).toHaveLength(3);
+    expect(containers.map((c) => c.includes('tomorrow'))).toEqual([false, true, false]);
+  });
+
+  it('marks the day after today as tomorrow in column view', () => {
+    const containers = classesOf(
+      renderColumnTomorrow(buildConfig(TOMORROW_COLUMN_CONFIG)),
+      '.day-column',
+    );
+    expect(containers).toHaveLength(3);
+    expect(containers.map((c) => c.includes('tomorrow'))).toEqual([false, true, false]);
   });
 });
 

--- a/tests/event-state-classes.test.ts
+++ b/tests/event-state-classes.test.ts
@@ -1,0 +1,117 @@
+import { render as litRender } from 'lit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EVENTS, FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as Column from '../src/rendering/column';
+import * as Render from '../src/rendering/render';
+import * as EventUtils from '../src/utils/events';
+
+/**
+ * The event element's state classes are public API, and only list view was guarding them.
+ *
+ * `event-first`, `event-middle`, `event-last` and `past-event` are what the card's own
+ * stylesheet and every card-mod recipe hang rounded corners, separators and dimming on.
+ * `.past-event .event-content { opacity: 0.6 }` in `styles.ts` is not a hook a user has
+ * to opt into — it is how the card shows that an event has already happened, so losing
+ * the class makes finished events look identical to upcoming ones.
+ *
+ * Both renderers compute these classes independently: `render.ts` for the list row and
+ * `column.ts` for the grid cell. Nothing shared enforces that they agree.
+ *
+ * ## Why this was invisible
+ *
+ * List view is covered by a committed DOM snapshot, so replacing `event-middle` or
+ * `past-event` with `false` there fails 14 and 1 snapshot tests respectively. Column view
+ * has 63 tests and no snapshot at all; its assertions target structure and content, and
+ * none of them reads these classes. Both column mutations survived the entire suite.
+ *
+ * That asymmetry is what makes this a coverage gap rather than dead code: the list twin
+ * dying proves the class is observable, so the column twin surviving can only mean
+ * nothing was looking.
+ *
+ * ## Why the first day, and why boolean runs
+ *
+ * The frozen Wednesday carries five events — an all-day, a finished one, one in progress
+ * and two upcoming — which is the smallest set that exercises first, middle, last and
+ * past at once. Asserting the whole boolean run per class keeps each presence paired with
+ * the absences around it, so a class that is always on cannot pass either.
+ *
+ * Only the first day is compared across views. Column view splits multi-day events by
+ * default and list view does not, so the later days legitimately differ in count; the
+ * shared day is what makes a like-for-like comparison meaningful.
+ */
+
+/** Three days from the frozen Wednesday, with finished events kept so `past-event` appears. */
+const LIST_CONFIG = { days_to_show: 3, show_past_events: true };
+
+/** Empty days off so the grid renders the same day set list view does. */
+const COLUMN_CONFIG = {
+  ...LIST_CONFIG,
+  view: 'column' as const,
+  column: { show_empty_days: false },
+};
+
+function render(config: Types.Config, view: 'list' | 'column'): HTMLElement {
+  const days = EventUtils.groupEventsByDay(EVENTS, config, false, 'en', view);
+  const container = document.createElement('div');
+  litRender(
+    view === 'column'
+      ? Column.renderColumnGroupedEvents(days, config, 'en', undefined, null)
+      : Render.renderGroupedEvents(days, config, 'en', undefined, null),
+    container,
+  );
+  return container;
+}
+
+/** Class lists for every event in the first rendered day, in document order. */
+function firstDayEventClasses(view: 'list' | 'column'): string[][] {
+  const container = render(buildConfig(view === 'column' ? COLUMN_CONFIG : LIST_CONFIG), view);
+  const day = container.querySelector(view === 'column' ? '.day-column' : '.day-table');
+  if (day === null) throw new Error(`no day container rendered for ${view} view`);
+  return Array.from(day.querySelectorAll('.event')).map((element) =>
+    Array.from(element.classList).sort(),
+  );
+}
+
+const has = (classes: string[][], name: string): boolean[] =>
+  classes.map((entry) => entry.includes(name));
+
+describe('event state classes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([['list'], ['column']] as const)('marks position within the day in %s view', (view) => {
+    const classes = firstDayEventClasses(view);
+    expect(classes).toHaveLength(5);
+    expect(has(classes, 'event-first')).toEqual([true, false, false, false, false]);
+    expect(has(classes, 'event-middle')).toEqual([false, true, true, true, false]);
+    expect(has(classes, 'event-last')).toEqual([false, false, false, false, true]);
+  });
+
+  it.each([['list'], ['column']] as const)(
+    'marks only the finished event as past in %s view',
+    (view) => {
+      // 08:00–09:00 has ended at the frozen 10:00; 09:30–11:00 is still running and must
+      // not be dimmed, which is what the surrounding falses pin.
+      expect(has(firstDayEventClasses(view), 'past-event')).toEqual([
+        false,
+        true,
+        false,
+        false,
+        false,
+      ]);
+    },
+  );
+
+  it('agrees between the two views on every event state class', () => {
+    // A card-mod rule written against one view has to keep matching in the other.
+    expect(firstDayEventClasses('column')).toEqual(firstDayEventClasses('list'));
+  });
+});


### PR DESCRIPTION
test: guard the column view's event and day state classes

The card publishes a set of state classes on its day containers and event
elements, and `docs/features/theming.md` documents them as the selectors
card-mod recipes are meant to hang off. Three of them were computed by the
column renderer and asserted by nothing: replacing `tomorrow`, `event-middle`
or `past-event` with a hardcoded `false` in `src/rendering/column.ts` left the
entire suite green.

The same three mutations applied to `src/rendering/render.ts` were caught
immediately — 14 tests, 14 tests and 1 test. Every one of those kills came from
`tests/__snapshots__/list-dom.test.ts.snap`. List view is guarded by a
committed DOM serialization, so any attribute it emits is pinned whether or not
a test ever meant to check it. Column view has 63 tests and no snapshot, so it
is guarded by exactly what somebody thought to assert, and nobody asserted
these. A twin dying while its identical sibling survives is what makes this a
coverage gap rather than dead code: the list kill proves the class is
observable, so the column survival can only mean nothing was looking.

`past-event` is the one with a visible effect and no user opt-in.
`styles.ts:478` carries `.past-event .event-content { opacity: 0.6 }`, which is
how the card dims events that have already finished. Dropping the class in
column view makes a finished event render identically to an upcoming one, with
`show_past_events: true` set and no error anywhere.

`tomorrow` was worse than uncovered — it was covered vacuously.
`tests/day-container-classes.test.ts` names it in its own docstring as part of
the contract it protects, and its cross-view agreement test compares the full
class set of both views. But its fixture span starts two days after the frozen
now, so no day in it is ever tomorrow: the class is absent on both sides and
the comparison passes whether it is computed or hardcoded off. The new
assertions use the shared `EVENTS` fixture, whose three days are today,
tomorrow and one after, so the boolean run `[false, true, false]` pins the
presence and the absences that surround it.

The event-level classes get their own file for the same reason the day-level
ones have theirs: the two renderers build the element independently and there
is no shared code path that could enforce agreement between them. Only the
first day is compared across views, because column view splits multi-day events
by default and list view does not, so the later days differ in count for
reasons that have nothing to do with these classes.

All eight mutations — three per view plus `event-first` and `event-last` — were
verified to fail the new assertions with the list snapshot excluded from the
run, so nothing here is passing on the strength of coverage that already
existed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6c7714fb-9c18-4995-9aaa-129fa9eb7a53
