### PR TITLE
test: pin the today indicator's position for all three indicator types

### DIFF
--- a/tests/today-indicator-position.test.ts
+++ b/tests/today-indicator-position.test.ts
@@ -1,0 +1,88 @@
+import { render as litRender } from 'lit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import { renderTodayIndicator } from '../src/rendering/leaves';
+
+/**
+ * Where the today indicator is actually drawn, for each of the three things it can be.
+ *
+ * `today_indicator` accepts an icon, an emoji or an image path, and all three are rendered
+ * by different branches of the same switch -- an `ha-icon`, a `span` and an `img`. Only the
+ * markup differs; the positioning is meant to be identical, because `today_indicator_position`
+ * is documented once and says nothing about the indicator's type.
+ *
+ * That shared intent was only enforced for the icon branch. Deleting the style binding from
+ * the emoji or image branch left every test green, even though it removes `position:absolute`
+ * outright -- so the indicator stops being positioned at all and drops back into normal flow
+ * somewhere else in the date column. The icon branch losing the same binding failed three
+ * tests, which is what proves the other two are an omission rather than dead markup.
+ *
+ * The list and column views deliberately disagree here, and that is asserted too. List view
+ * positions the indicator absolutely by percentage; column view puts it in the day header and
+ * lets it flow, ignoring `today_indicator_position` entirely. Pinning both halves means the
+ * asymmetry has to be changed on purpose rather than by accident.
+ */
+const POSITION = '20% 80%';
+
+function renderIndicator(
+  value: string,
+  layout: 'absolute' | 'inline',
+): { className: string; style: string } {
+  const config = buildConfig({
+    today_indicator: value,
+    today_indicator_position: POSITION,
+  }) as Types.Config;
+  const container = document.createElement('div');
+
+  litRender(renderTodayIndicator(config, true, layout), container);
+  const node = container.querySelector('.today-indicator');
+
+  return {
+    className: node?.className ?? '(absent)',
+    style: node?.getAttribute('style') ?? '',
+  };
+}
+
+const INDICATORS = [
+  ['icon', 'mdi:star', 'today-indicator mdi'],
+  ['emoji', '🎯', 'today-indicator emoji'],
+  ['image', '/local/today.png', 'today-indicator image'],
+] as const;
+
+describe('today indicator position', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('list view positions every indicator type by percentage', () => {
+    it.each(INDICATORS)('places the %s at the configured position', (_label, value, className) => {
+      const { className: actualClass, style } = renderIndicator(value, 'absolute');
+
+      // The class is asserted alongside the style so a branch cannot pass by rendering
+      // some other type's markup that happens to be positioned correctly.
+      expect(actualClass).toBe(className);
+      expect(style).toContain('position:absolute');
+      expect(style).toContain('left:20%');
+      expect(style).toContain('top:80%');
+    });
+  });
+
+  describe('column view lets the indicator flow instead', () => {
+    it.each(INDICATORS)('gives the %s no positioning at all', (_label, value, className) => {
+      // The paired absence, and a real documented difference rather than a formality:
+      // the column-view indicator sits inside the day header, so absolute positioning
+      // would take it out of that header and `today_indicator_position` does not apply.
+      const { className: actualClass, style } = renderIndicator(value, 'inline');
+
+      expect(actualClass).toBe(className);
+      expect(style).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
test: pin the today indicator's position for all three indicator types

`today_indicator` accepts an icon, an emoji or an image path. All three are
rendered by different branches of the same switch in `leaves.ts` -- an `ha-icon`,
a `span` and an `img` -- and all three are supposed to be positioned identically,
because `today_indicator_position` is documented once and says nothing about the
indicator's type.

That shared intent was only enforced for the icon branch. Deleting
`style=${styleMap(positionStyles)}` from the emoji or the image branch left all
1,647 tests green; deleting it from the icon branch failed three. Same binding,
same file, three lines apart, and only one of the three was load-bearing on any
assertion anywhere.

The failure it allows is not subtle. `positionStyles` is where `position:absolute`
comes from, not just the offsets, so losing it does not nudge the indicator -- it
takes it out of absolute positioning altogether and drops it back into normal flow
somewhere else in the date column. Measured output for `today_indicator_position:
"20% 80%"` is `position:absolute;transform:translate(-50%, -50%);left:20%;top:80%;`
and is byte-identical across all three types, which is what makes the asymmetry an
omission rather than a difference.

Both affected types are documented, not incidental: `layout-appearance.md:286`
offers "Any emoji like 🎯 or ⭐" and the same section documents image paths.

The new file also pins the deliberate list/column disagreement. List view positions
the indicator absolutely by percentage; column view puts it inside the day header
and lets it flow, ignoring `today_indicator_position` entirely -- which the
`renderTodayIndicator` doc comment states and nothing checked. Asserting both
halves means that asymmetry has to be changed on purpose.

Eight falsification mutations all fail the new file with the rest of the suite
excluded: the style binding dropped from each of the three branches in turn, the
inline layout made to use absolute styles, the image branch made to render emoji
markup, the parsed x and y each replaced with a constant, and `position:absolute`
made static.

This completes the `leaves.ts` mutation sweep begun alongside #486. The other
twenty-five bindings swept -- three countdown emissions, three `time-actual`
emissions, both label glyph forms, four weather spans, the calendar-label glyph
class, the empty-day title, the summary colour, the location and description
blocks and the row progress bar -- were all killed by tests that already existed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6c7714fb-9c18-4995-9aaa-129fa9eb7a53
