### PR TITLE
test: pin label_icon_color and the theming property mappings to the DOM

### DIFF
--- a/tests/custom-property-mapping.test.ts
+++ b/tests/custom-property-mapping.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import * as Config from '../src/config/config';
+import type * as Types from '../src/config/types';
+import { generateCustomPropertiesObject } from '../src/rendering/styles';
+
+/**
+ * Whether each theming option reaches the CSS custom property that renders it.
+ *
+ * `generateCustomPropertiesObject` is the entire theming pipeline: roughly fifty options
+ * become custom properties, and the stylesheet reads nothing else. Thirty-one of those
+ * properties were never named in any test, and rewriting a mapping to a hardcoded constant
+ * -- which is exactly what a configured value silently doing nothing looks like -- left the
+ * whole suite green for every one that was tried.
+ *
+ * Every value below is distinct, so the assertions fail not only when a mapping is dropped
+ * but also when two are crossed. That is the failure this file is really aimed at: a
+ * property that carries *a* value looks correct in a browser until someone notices their
+ * location colour is following their time colour.
+ */
+type Pair = readonly [option: string, property: string, value: string];
+
+const PASS_THROUGH: readonly Pair[] = [
+  ['background_color', '--calendar-card-background-color', 'rgb(1, 0, 0)'],
+  ['weekday_font_size', '--calendar-card-font-size-weekday', '101px'],
+  ['day_font_size', '--calendar-card-font-size-day', '102px'],
+  ['month_font_size', '--calendar-card-font-size-month', '103px'],
+  ['event_font_size', '--calendar-card-font-size-event', '104px'],
+  ['time_font_size', '--calendar-card-font-size-time', '105px'],
+  ['location_font_size', '--calendar-card-font-size-location', '106px'],
+  ['description_font_size', '--calendar-card-font-size-description', '107px'],
+  ['weekday_color', '--calendar-card-color-weekday', 'rgb(2, 0, 0)'],
+  ['day_color', '--calendar-card-color-day', 'rgb(3, 0, 0)'],
+  ['month_color', '--calendar-card-color-month', 'rgb(4, 0, 0)'],
+  ['event_color', '--calendar-card-color-event', 'rgb(5, 0, 0)'],
+  ['time_color', '--calendar-card-color-time', 'rgb(6, 0, 0)'],
+  ['location_color', '--calendar-card-color-location', 'rgb(7, 0, 0)'],
+  ['description_color', '--calendar-card-color-description', 'rgb(8, 0, 0)'],
+  ['accent_color', '--calendar-card-line-color-vertical', 'rgb(9, 0, 0)'],
+  ['vertical_line_width', '--calendar-card-line-width-vertical', '108px'],
+  ['day_spacing', '--calendar-card-day-spacing', '109px'],
+  ['event_spacing', '--calendar-card-event-spacing', '110px'],
+  ['additional_card_spacing', '--calendar-card-spacing-additional', '111px'],
+  ['progress_bar_color', '--calendar-card-progress-bar-color', 'rgb(10, 0, 0)'],
+  ['progress_bar_height', '--calendar-card-progress-bar-height', '112px'],
+  ['today_indicator_color', '--calendar-card-today-indicator-color', 'rgb(11, 0, 0)'],
+  ['today_indicator_size', '--calendar-card-today-indicator-size', '113px'],
+  ['week_number_font_size', '--calendar-card-week-number-font-size', '114px'],
+  ['week_number_color', '--calendar-card-week-number-color', 'rgb(12, 0, 0)'],
+  ['week_number_background_color', '--calendar-card-week-number-bg-color', 'rgb(13, 0, 0)'],
+  ['time_icon_size', '--calendar-card-icon-size-time', '115px'],
+  ['location_icon_size', '--calendar-card-icon-size-location', '116px'],
+  ['description_icon_size', '--calendar-card-icon-size-description', '117px'],
+  ['height', '--calendar-card-height', '118px'],
+] as const;
+
+/** Properties that fall back to a fixed value rather than to the browser's default. */
+const FALLBACKS: readonly (readonly [option: string, property: string, fallback: string])[] = [
+  ['time_icon_size', '--calendar-card-icon-size-time', '14px'],
+  ['location_icon_size', '--calendar-card-icon-size-location', '14px'],
+  ['description_icon_size', '--calendar-card-icon-size-description', '14px'],
+  ['height', '--calendar-card-height', 'auto'],
+] as const;
+
+function propsFor(overrides: Record<string, unknown>): Record<string, string> {
+  return generateCustomPropertiesObject(buildConfig(overrides) as Types.Config);
+}
+
+describe('custom property mapping', () => {
+  const configured = propsFor(
+    Object.fromEntries(PASS_THROUGH.map(([option, , value]) => [option, value])),
+  );
+
+  it.each(PASS_THROUGH)('maps %s to %s', (_option, property, value) => {
+    expect(configured[property]).toBe(value);
+  });
+
+  it.each(FALLBACKS)('falls %s back to %s when unset', (option, property, fallback) => {
+    // Paired absence for the four options that carry their own fallback: the pass-through
+    // assertions above cannot tell a working mapping from one that ignores the config and
+    // happens to emit the same string.
+    expect(propsFor({ [option]: undefined })[property]).toBe(fallback);
+  });
+
+  it('emits the derived date column width from the day font size', () => {
+    expect(propsFor({ day_font_size: '20px' })['--calendar-card-date-column-width']).toBe('35px');
+  });
+
+  it('dims the default empty day color and passes a configured one through', () => {
+    const fallback = propsFor({ empty_day_color: Config.DEFAULT_CONFIG.empty_day_color });
+    const custom = propsFor({ empty_day_color: 'rgb(14, 0, 0)' });
+
+    expect(fallback['--calendar-card-empty-day-color']).toContain('color-mix');
+    expect(custom['--calendar-card-empty-day-color']).toBe('rgb(14, 0, 0)');
+  });
+
+  it('covers every property the stylesheet reads', () => {
+    // Without this the table can fall behind the source: a theming option added later would
+    // arrive with no assertion and nothing would say so.
+    const emitted = Object.keys(configured).filter((name) => name.startsWith('--calendar-card-'));
+    const asserted = new Set<string>([
+      ...PASS_THROUGH.map(([, property]) => property),
+      '--calendar-card-date-column-width',
+      '--calendar-card-empty-day-color',
+    ]);
+    const known = new Set<string>([
+      // Asserted in their own dedicated files, listed here so this check stays exhaustive.
+      '--calendar-card-description-max-lines',
+      '--calendar-card-title-max-lines',
+      '--calendar-card-time-max-lines',
+      '--calendar-card-location-max-lines',
+      '--calendar-card-title-display',
+      '--calendar-card-time-display',
+      '--calendar-card-date-column-vertical-alignment',
+      '--calendar-card-event-icon-vertical-alignment',
+      '--calendar-card-event-border-radius',
+      '--calendar-card-max-height',
+      '--calendar-card-weather-date-icon-size',
+      '--calendar-card-weather-date-font-size',
+      '--calendar-card-weather-date-color',
+      '--calendar-card-weather-event-icon-size',
+      '--calendar-card-weather-event-font-size',
+      '--calendar-card-weather-event-max-lines',
+      '--calendar-card-weather-event-condition-display',
+      '--calendar-card-weather-event-color',
+    ]);
+
+    expect(emitted.filter((name) => !asserted.has(name) && !known.has(name))).toEqual([]);
+  });
+});

--- a/tests/label-icon-color.test.ts
+++ b/tests/label-icon-color.test.ts
@@ -1,0 +1,70 @@
+import { render as litRender } from 'lit';
+import { describe, expect, it } from 'vitest';
+
+import { renderLabel } from '../src/rendering/leaves';
+
+/**
+ * Whether the per-entity `label_icon_color` option actually colours anything.
+ *
+ * The option is normalized in `config.ts`, offered in the visual editor and covered by
+ * three test files -- but every one of them stops at the config object. Nothing asserted
+ * that the colour reaches the DOM, so deleting the label's entire style attribute left the
+ * whole suite green while making the option inert.
+ *
+ * The scoping is asserted alongside the effect, because it is a real documented rule rather
+ * than an implementation detail: `core-settings.md` says the option "only applies to `mdi:`
+ * and other icon labels", and the other three label shapes -- emoji, image, plain text --
+ * are supposed to ignore it. That is what stops a future fix for "my emoji label ignores
+ * label_icon_color" from being applied without a decision.
+ */
+type Shape = readonly [label: string, value: string, expectedTag: string, expectedClass: string];
+
+const COLOR = 'rgb(1, 2, 3)';
+
+const UNAFFECTED: readonly Shape[] = [
+  ['emoji', '🏠', 'span', 'calendar-label label-emoji'],
+  ['image', '/local/label.png', 'img', 'label-image'],
+  ['text', 'Work', 'span', 'calendar-label'],
+] as const;
+
+function renderLabelNode(label: string, color?: string): HTMLElement {
+  const container = document.createElement('div');
+
+  litRender(renderLabel(label, color), container);
+  const node = container.firstElementChild as HTMLElement | null;
+
+  if (!node) throw new Error(`renderLabel produced nothing for ${label}`);
+  return node;
+}
+
+describe('label icon color', () => {
+  it('colors an icon label with the configured value', () => {
+    const node = renderLabelNode('mdi:home', COLOR);
+
+    expect(node.tagName.toLowerCase()).toBe('ha-icon');
+    expect(node.className).toBe('label-icon');
+    expect(node.getAttribute('style')).toBe(`color: ${COLOR};`);
+  });
+
+  it('leaves an icon label unstyled when no color is configured', () => {
+    // Paired absence: proves the assertion above is reading the configured value
+    // rather than a colour the icon would have carried regardless.
+    const node = renderLabelNode('mdi:home');
+
+    expect(node.tagName.toLowerCase()).toBe('ha-icon');
+    expect(node.className).toBe('label-icon');
+    expect(node.getAttribute('style') ?? '').toBe('');
+  });
+
+  describe('does not reach the other label shapes', () => {
+    it.each(UNAFFECTED)('ignores the color on a %s label', (_shape, label, tag, className) => {
+      const node = renderLabelNode(label, COLOR);
+
+      // The tag and class are asserted too, so a branch cannot pass this by rendering
+      // some other unstyled shape instead of the one being tested.
+      expect(node.tagName.toLowerCase()).toBe(tag);
+      expect(node.className).toBe(className);
+      expect(node.getAttribute('style') ?? '').toBe('');
+    });
+  });
+});


### PR DESCRIPTION
Two coverage gaps found by continuing the style-binding sweep across `src/rendering`, both the same shape: an option is normalized, offered in the editor and named in tests, but nothing asserts that its value reaches the DOM.

## 1. `label_icon_color` never reached the DOM in any test

A per-entity option shipped in v2.4 (#302), referenced by three test files -- `config.test.ts`, `entity-config-reprocess.test.ts`, `editor-schema.test.ts`. Every one stops at the config object. Replacing `renderLabel`'s style attribute with `nothing`, which makes the option do nothing at all, left all 1,653 tests passing; the three files naming the option would still have passed, because a correctly normalized config that is then ignored looks identical to them.

The documented scoping is pinned alongside the effect. `core-settings.md` says the option "only applies to `mdi:` and other icon labels", and the measured behaviour agrees -- emoji, image and plain-text labels render unstyled even when a colour is set. Asserting that means a future "my emoji label ignores `label_icon_color`" report has to be answered with a decision rather than a one-line change.

Seven mutations all fail the new file in isolation. The seventh initially passed, which exposed a hole in the test rather than the source -- it asserted the icon's tag but not its class, so mislabelled markup slipped through. Both icon cases now assert the class.

## 2. Thirty-one theming properties were never named in any test

`generateCustomPropertiesObject` is the whole theming pipeline: ~50 options become CSS custom properties and the stylesheet reads nothing else. Thirty-one of the fifty-four emitted properties appeared in no test. Hardcoding a mapping -- what an ignored option looks like -- left the suite green for every one tried: description colour, accent line width, progress bar colour, time icon size, the empty-day dimming branch.

The gap was structural. Six files do call the generator, but each asserts one narrow feature (icon alignment, max-lines, weather badges, progress bar width), and their presence made the surface look attended to.

Every value in the new table is distinct, so a crossed pair fails as loudly as a dropped one -- the real target, because a property carrying the *wrong* value still looks plausible until someone notices their location colour following their time colour. The four options with their own fallback are asserted in both directions. A closing exhaustiveness assertion fails when the generator emits a property this file neither asserts nor explicitly defers; it caught one omission while being written.

Eleven mutations all fail the new file in isolation, including a brand-new unasserted property.

## Verification

All ten gates exit 0. Suite: 82 files / 1696 tests, up from 80 / 1653.

No release-notes entry -- test-only, per the standing policy.
