### PR TITLE
test: snapshot the column view DOM

### DIFF
--- a/tests/__snapshots__/column-dom-snapshot.test.ts.snap
+++ b/tests/__snapshots__/column-dom-snapshot.test.ts.snap
@@ -1,0 +1,2119 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`column view DOM > renders a single day 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(1, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>"
+`;
+
+exports[`column view DOM > renders a single event 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(3, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column tomorrow future-day " style="grid-column:2;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:3;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>"
+`;
+
+exports[`column view DOM > renders day, week and month separators 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(20, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column tomorrow future-day " style="grid-column:2;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:3;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day weekend " style="grid-column:4;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Sat
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      20
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day weekend " style="grid-column:5;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Sun
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      21
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:6;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Mon
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      22
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:7;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Tue
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      23
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:8;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      24
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:9;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      25
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:10;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      26
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day weekend " style="grid-column:11;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Sat
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      27
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day weekend " style="grid-column:12;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Sun
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      28
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:13;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Mon
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      29
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:14;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Tue
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      30
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:15;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      1
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jul
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:16;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      2
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jul
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:17;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      3
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jul
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day weekend " style="grid-column:18;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Sat
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      4
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jul
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day weekend " style="grid-column:19;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Sun
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      5
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jul
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:20;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Mon
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      6
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jul
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="column-separator column-separator-day" style="grid-column:2;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:3;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:4;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:5;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-week" style="grid-column:6;grid-row:1;width:2px;background-color:#03a9f450;margin-inline-start:calc(-0.5 * (10px + 2px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:7;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:8;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:9;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:10;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:11;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:12;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-week" style="grid-column:13;grid-row:1;width:2px;background-color:#03a9f450;margin-inline-start:calc(-0.5 * (10px + 2px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:14;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-month" style="grid-column:15;grid-row:1;width:3px;background-color:var(--primary-text-color);margin-inline-start:calc(-0.5 * (10px + 3px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:16;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:17;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:18;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-day" style="grid-column:19;grid-row:1;width:1px;background-color:var(--secondary-text-color);margin-inline-start:calc(-0.5 * (10px + 1px));"></div>
+<div class="column-separator column-separator-week" style="grid-column:20;grid-row:1;width:2px;background-color:#03a9f450;margin-inline-start:calc(-0.5 * (10px + 2px));"></div>
+</div>"
+`;
+
+exports[`column view DOM > renders past events 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(3, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle past-event " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Past standup
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>8:00 AM - 9:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column tomorrow future-day " style="grid-column:2;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:3;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>"
+`;
+
+exports[`column view DOM > renders the default configuration 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(3, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column tomorrow future-day " style="grid-column:2;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:3;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>"
+`;
+
+exports[`column view DOM > renders the optional content rows 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(3, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content with-week-number ">
+<div class="column-week-number" style="">
+<div class="week-number">25</div>
+</div>
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="progress-bar progress-bar-row">
+<div class="progress-bar-filled" style="width: 33%"></div>
+</div>
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span class="time-text"><span>2:00 PM - 3:00 PM</span><span class="time-countdown">in 4 hours</span></span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span class="time-text"><span>4:00 PM - 5:00 PM</span><span class="time-countdown">in 6 hours</span></span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column tomorrow future-day " style="grid-column:2;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content with-week-number ">
+<div class="column-week-number" style="visibility:hidden;">
+<div class="week-number">25</div>
+</div>
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span class="time-text"><span>All day</span><span class="time-countdown">in a day</span></span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:3;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content with-week-number ">
+<div class="column-week-number" style="visibility:hidden;">
+<div class="week-number">25</div>
+</div>
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span class="time-text"><span>All day</span><span class="time-countdown">in 2 days</span></span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span class="time-text"><span>10:00 AM - 10:30 AM</span><span class="time-countdown">in 2 days</span></span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>"
+`;
+
+exports[`column view DOM > renders unsplit multi-day events 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(3, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column tomorrow future-day " style="grid-column:2;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day, until Friday, Jun 19</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:3;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>"
+`;
+
+exports[`column view DOM > renders weather on both surfaces 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(3, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather"><ha-icon></ha-icon><span class="weather-temp-high">24°</span></div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Public holiday
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+<div class="event-weather"><ha-icon></ha-icon><span class="event-weather-text"><span>24°</span></span></div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Currently running review
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>9:30 AM - 11:00 AM</span>
+</div>
+</div>
+<div class="event-weather"><ha-icon></ha-icon><span class="event-weather-text"><span>17°</span></span></div>
+</div>
+</div>
+</div>
+<div class=" event event-middle " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+<div class="event-weather"><ha-icon></ha-icon><span class="event-weather-text"><span>24°</span></span></div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Dentist
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>4:00 PM - 5:00 PM</span>
+</div>
+</div>
+<div class="event-weather"><ha-icon></ha-icon><span class="event-weather-text"><span>23°</span></span></div>
+<div class="location">
+<ha-icon icon="mdi:map-marker-outline"></ha-icon>
+<span>12 High Street</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column tomorrow future-day " style="grid-column:2;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather"><ha-icon></ha-icon><span class="weather-temp-high">21°</span></div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+<div class="event-weather"><ha-icon></ha-icon><span class="event-weather-text"><span>21°</span></span></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:3;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+<div class="weather"><ha-icon></ha-icon><span class="weather-temp-high">17°</span></div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Conference
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>All day</span>
+</div>
+</div>
+<div class="event-weather"><ha-icon></ha-icon><span class="event-weather-text"><span>17°</span></span></div>
+</div>
+</div>
+</div>
+<div class=" event event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Delivery window
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>10:00 AM - 10:30 AM</span>
+</div>
+</div>
+<div class="event-weather"><ha-icon></ha-icon><span class="event-weather-text"><span>16°</span></span></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>"
+`;
+
+exports[`column view DOM > renders with no events 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(3, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column tomorrow future-day " style="grid-column:2;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Thu
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      18
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class=" day-column future-day " style="grid-column:3;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Fri
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      19
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title empty-day-title" style="color: var(--calendar-card-empty-day-color)">
+          ✓ No upcoming events
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>"
+`;
+
+exports[`column view DOM > suppresses empty day columns 1`] = `
+"<div class="column-grid" style="grid-template-columns:repeat(1, minmax(0, 1fr));column-gap:10px;--calendar-card-column-header-gap:8px;">
+<div class=" day-column today " style="grid-column:1;grid-row:1;">
+<div class="column-day-header">
+<div class=" column-date-content ">
+<div class="weekday" style="font-size:14px;color:var(--primary-text-color);">
+      Wed
+    </div>
+<div class="day" style="font-size:26px;color:var(--primary-text-color);">
+      17
+    </div>
+<div class="month" style="font-size:12px;color:var(--primary-text-color);">
+            Jun
+          </div>
+</div>
+</div>
+<div class="column-events">
+<div class=" event event-first event-last " style="border-inline-start: var(--calendar-card-line-width-vertical) solid #03a9f4; background-color: ;">
+<div class="event-content">
+<div class="summary-row">
+<div class="summary">
+<span class="event-title " style="color: var(--primary-text-color)">
+          Upcoming one-to-one
+        </span>
+</div>
+<!--?-->
+</div>
+<div class="time-location">
+<div class="time">
+<div class="time-actual">
+<ha-icon icon="mdi:clock-outline"></ha-icon>
+<span>2:00 PM - 3:00 PM</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>"
+`;

--- a/tests/column-dom-snapshot.test.ts
+++ b/tests/column-dom-snapshot.test.ts
@@ -1,0 +1,135 @@
+import { render as litRender } from 'lit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EVENTS, FROZEN_NOW, SINGLE_EVENT, WEATHER, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as Column from '../src/rendering/column';
+import * as EventUtils from '../src/utils/events';
+
+/**
+ * Serialized column-view markup, one snapshot per branch that changes the shape.
+ *
+ * The list view has had a snapshot since it was written; the column view, added in v4,
+ * has only targeted assertions. That difference is measurable rather than theoretical.
+ * Mutating each key of the list view's two `classMap` objects and each of its six style
+ * bindings -- fifteen mutations -- was caught every time, by fifteen to nineteen tests
+ * apiece, almost entirely by the snapshot. The same sweep against the column view left
+ * three class keys and two style bindings alive, and each had to be found by hand and
+ * guarded individually.
+ *
+ * A snapshot is the only thing that covers markup nobody thought to assert, which is
+ * exactly the markup that breaks quietly. The column view is new, so it will change more
+ * than the list view will.
+ *
+ * These are intentionally in their own file: `column-dom.test.ts` holds sixty-odd targeted
+ * assertions, and mixing a snapshot in would mean re-reading a large diff whenever one of
+ * those fails for an unrelated reason.
+ *
+ * When a snapshot changes, read the diff and confirm the change was intended before
+ * updating it -- see AGENTS.md. Deleting the file is never the fix.
+ */
+function serialize(container: HTMLElement): string {
+  return container.innerHTML
+    .replace(/<!--\?lit\$[0-9]+\$-->/g, '')
+    .replace(/<!---->/g, '')
+    .replace(/>\s+</g, '>\n<')
+    .trim();
+}
+
+function renderColumn(
+  events: Types.CalendarEventData[],
+  config: Types.Config,
+  { language = 'en', weather }: { language?: string; weather?: Types.WeatherForecasts } = {},
+): string {
+  // 'column' is deliberate: `groupEventsByDay` resolves per-view overrides, so grouping
+  // the list way would render column markup from list-grouped days.
+  const days = EventUtils.groupEventsByDay(events, config, false, language, 'column');
+  const container = document.createElement('div');
+  litRender(Column.renderColumnGroupedEvents(days, config, language, weather, null), container);
+  return serialize(container);
+}
+
+describe('column view DOM', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  it('renders the default configuration', () => {
+    expect(renderColumn(EVENTS, buildConfig())).toMatchSnapshot();
+  });
+
+  it('renders a single event', () => {
+    expect(renderColumn(SINGLE_EVENT, buildConfig())).toMatchSnapshot();
+  });
+
+  it('renders with no events', () => {
+    expect(renderColumn([], buildConfig())).toMatchSnapshot();
+  });
+
+  it('suppresses empty day columns', () => {
+    // `show_empty_days` defaults to true for this view (`view.ts:353`), the opposite of the
+    // list view, so `true` here would have re-rendered the default and asserted nothing.
+    expect(
+      renderColumn(SINGLE_EVENT, buildConfig({ column: { show_empty_days: false } })),
+    ).toMatchSnapshot();
+  });
+
+  it('renders past events', () => {
+    expect(renderColumn(EVENTS, buildConfig({ show_past_events: true }))).toMatchSnapshot();
+  });
+
+  it('renders unsplit multi-day events', () => {
+    // Splitting is forced on for this view (`view.ts:354`), so only the column override that
+    // turns it back off produces markup the default case does not already cover.
+    expect(
+      renderColumn(EVENTS, buildConfig({ column: { split_multiday_events: false } })),
+    ).toMatchSnapshot();
+  });
+
+  it('renders the optional content rows', () => {
+    expect(
+      renderColumn(
+        EVENTS,
+        buildConfig({
+          show_location: true,
+          show_description: true,
+          show_countdown: true,
+          show_week_numbers: 'iso',
+          show_progress_bar: true,
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('renders day, week and month separators', () => {
+    // All three separator widths default to zero, so without them `renderColumnSeparator`
+    // never runs and the `column-separator-${kind}` suffix is never serialized. Twenty days
+    // from the frozen mid-June date is enough to cross both a week and a month boundary.
+    expect(
+      renderColumn(
+        EVENTS,
+        buildConfig({
+          days_to_show: 20,
+          day_separator_width: '1px',
+          week_separator_width: '2px',
+          month_separator_width: '3px',
+        }),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('renders weather on both surfaces', () => {
+    expect(
+      renderColumn(EVENTS, buildConfig({ weather: { entity: 'weather.home', position: 'both' } }), {
+        weather: WEATHER,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('renders a single day', () => {
+    // Compact mode is deliberately list-scoped (`view.ts:161-162`) and would render the
+    // default column markup, so the day count is the axis that varies here instead.
+    expect(renderColumn(EVENTS, buildConfig({ days_to_show: 1 }))).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
test: snapshot the column view DOM

The list view has been snapshotted since it was written. The column view, added in
v4, has only ever had targeted assertions, and that difference turns out to be
measurable rather than theoretical.

Mutating every key of the list renderer's two `classMap` objects and every one of its
six inline style bindings -- fifteen mutations in total -- was caught every single
time, by fifteen to nineteen tests apiece, overwhelmingly by the snapshot. Running the
identical sweep against the column renderer left three class keys and two style
bindings alive, and each one had to be found by hand and then guarded individually in
PRs #484 through #487. The snapshot is what covers the markup nobody thought to assert,
which is precisely the markup that breaks quietly.

Ten cases, each proven to serialize markup no other case already produces. Three of the
first draft's cases were byte-identical to another case and asserted nothing extra,
because they set options this view does not honour:

  - `show_empty_days` defaults to true here, the opposite of the list view
    (`view.ts:353`), so the meaningful case is the column override that turns it off.
  - `split_multiday_events` is forced on for this view (`view.ts:354`), so only the
    column override that turns it back off renders anything new.
  - compact mode is deliberately list-scoped (`view.ts:161-162`), so the day count is
    the axis that varies instead.

Falsified with twelve mutations run against this file alone: the three class keys that
originally survived, an element tag swap, a class typo, a dropped class attribute, the
`day-column` key, the week-number wrapper, the separator kind suffix, and the week and
month separator branches. The separator mutation survived the first round, which is how
the tenth case was found -- all three separator widths default to zero, so nothing in
the first nine cases ever rendered a separator at all.

Kept in its own file: `column-dom.test.ts` holds sixty-odd targeted assertions, and
mixing a snapshot in would mean re-reading a large serialized diff whenever one of those
fails for an unrelated reason.
