### PR TITLE
test: cover weather rendering when optional forecast fields are absent

### DIFF
--- a/tests/weather-optional-fields.test.ts
+++ b/tests/weather-optional-fields.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Weather forecast entries carry two optional numeric fields, `templow` and `uv_index`.
+ * Home Assistant's weather entity contract makes `temperature` and `condition` required
+ * but leaves both of these to the integration, so a perfectly valid forecast can omit
+ * either one. The render sites guard for that -- `show_low_temp` additionally requires
+ * `templow !== undefined`, and the UV badge requires a value at or above the threshold.
+ *
+ * Nothing exercised those guards. The shared `WEATHER` fixture populates both fields for
+ * every day, precisely so the opt-in branches are reachable, which means the absent-data
+ * path was never rendered. Deleting the `templow` guard left the whole suite green while
+ * a forecast without a low temperature rendered a bare `/` and degree sign next to the
+ * high, so the guard was both load-bearing and unprotected.
+ *
+ * Each absence case is paired with a presence control, so a change that stops rendering
+ * the field at all cannot pass by making the absence assertion trivially true.
+ *
+ * The UV badge's two conditions -- `uv_index !== undefined` and the threshold comparison
+ * -- mask each other: `undefined >= n` is false for every threshold, so neutralising
+ * either one alone leaves behaviour unchanged and no test can distinguish it. Both are
+ * therefore deliberately kept, and the assertions below pin the combined outcome, which
+ * does fail when both conditions are removed together.
+ */
+import { render } from 'lit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW, SINGLE_EVENT, WEATHER, buildConfig } from './fixtures';
+import * as Types from '../src/config/types';
+import * as Leaves from '../src/rendering/leaves';
+
+function withoutField(field: 'templow' | 'uv_index', bucket: 'daily' | 'hourly') {
+  const clone = JSON.parse(JSON.stringify(WEATHER)) as Types.WeatherForecasts;
+  for (const entry of Object.values(clone[bucket] ?? {})) {
+    delete (entry as unknown as Record<string, unknown>)[field];
+  }
+  return clone;
+}
+
+function dateWeatherHtml(weather: Types.WeatherForecasts, dateOverrides: Record<string, unknown>) {
+  const config = buildConfig({
+    weather: { entity: 'weather.home', position: 'date', date: dateOverrides },
+  });
+  const host = document.createElement('div');
+  render(Leaves.renderDateWeather(new Date(FROZEN_NOW), config, weather), host);
+  return host.innerHTML;
+}
+
+function eventWeatherHtml(
+  weather: Types.WeatherForecasts,
+  eventOverrides: Record<string, unknown>,
+) {
+  const config = buildConfig({
+    weather: { entity: 'weather.home', position: 'event', event: eventOverrides },
+  });
+  const host = document.createElement('div');
+  render(Leaves.renderEventWeather(SINGLE_EVENT[0], config, weather, 'title'), host);
+  return host.innerHTML;
+}
+
+describe('weather rendering with optional forecast fields absent', () => {
+  // `renderEventWeather` suppresses the badge for an event that has already ended, so
+  // the fixture event is only in the future while the clock is frozen at FROZEN_NOW.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('omits the low temperature when the forecast has no templow', () => {
+    const overrides = { show_low_temp: true };
+
+    // Control: the fixture supplies templow, so the opt-in branch really does render.
+    expect(dateWeatherHtml(WEATHER, overrides)).toContain('weather-temp-low');
+
+    const html = dateWeatherHtml(withoutField('templow', 'daily'), overrides);
+    expect(html).not.toContain('weather-temp-low');
+    // The high temperature is unaffected, so this is an omission and not a blank render.
+    expect(html).toContain('weather-temp-high');
+  });
+
+  it('never emits a bare degree sign for a missing low temperature', () => {
+    // Removing the guard rendered `<span class="weather-temp-low">/°</span>`. Assert on
+    // the visible text so the regression is caught however the markup is restructured.
+    const html = dateWeatherHtml(withoutField('templow', 'daily'), { show_low_temp: true });
+    expect(html).not.toContain('/°');
+  });
+
+  it('omits the date UV badge when the forecast has no uv_index', () => {
+    const overrides = { show_uv_index: true };
+
+    expect(dateWeatherHtml(WEATHER, overrides)).toContain('weather-uv-index');
+
+    expect(dateWeatherHtml(withoutField('uv_index', 'daily'), overrides)).not.toContain(
+      'weather-uv-index',
+    );
+  });
+
+  it('falls back to the low temperature when the UV index is absent', () => {
+    // `show_low_temp` is suppressed while a UV badge shows. With no uv_index the badge
+    // cannot render, so the low temperature must take its place rather than both vanishing.
+    const html = dateWeatherHtml(withoutField('uv_index', 'daily'), {
+      show_uv_index: true,
+      show_low_temp: true,
+    });
+    expect(html).not.toContain('weather-uv-index');
+    expect(html).toContain('weather-temp-low');
+  });
+
+  it('omits the event UV badge when the hourly forecast has no uv_index', () => {
+    const overrides = { show_uv_index: true };
+
+    // The shared fixture's hourly entries carry no uv_index, so the control has to add
+    // one rather than remove it. Building the control this way also proves the fixture
+    // itself is the reason this branch had never rendered.
+    const withUv = JSON.parse(JSON.stringify(WEATHER)) as Types.WeatherForecasts;
+    for (const entry of Object.values(withUv.hourly ?? {})) {
+      (entry as unknown as Record<string, unknown>).uv_index = 7;
+    }
+    expect(eventWeatherHtml(withUv, overrides)).toContain('weather-uv-index');
+
+    expect(eventWeatherHtml(WEATHER, overrides)).not.toContain('weather-uv-index');
+  });
+});


### PR DESCRIPTION
test: cover weather rendering when optional forecast fields are absent

Home Assistant's weather entity contract requires `temperature` and `condition` on every
forecast entry but leaves `templow` and `uv_index` to the integration, so a perfectly
valid forecast can omit either. Both render sites in `leaves.ts` account for that: the
low temperature additionally requires `templow !== undefined`, and the UV badge requires
a value at or above the configured threshold.

Neither absent-data path had ever been rendered. The shared `WEATHER` fixture populates
both fields for every entry, and its docstring says so explicitly -- they are populated
precisely so the opt-in branches are reachable. The consequence was that the guards
protecting the *other* case ran in no test at all. Deleting the `templow` guard left the
entire suite green, while a forecast without a low temperature rendered a stray slash and
degree sign beside the high temperature:

    <span class="weather-temp-high">24°</span><span class="weather-temp-low">/°</span>

So the guard was both load-bearing and completely unprotected.

This adds five cases covering the date and event scopes. Every absence assertion is
paired with a presence control, because an assertion that some markup is missing passes
trivially if the feature stops rendering altogether -- the control fails first in that
case and names the real cause. The event-scope control has to *add* `uv_index` rather
than remove it, since the fixture's hourly entries carry none; building it that way also
demonstrates why that branch had never rendered.

The UV badge's two conditions mask each other. Because `undefined >= n` is false for
every threshold, neutralising either condition alone leaves behaviour unchanged and no
test can distinguish it. Both are kept deliberately and the tests pin the combined
outcome, which does fail when the two are removed together.

Falsification, run against this file alone: dropping the `templow` guard is caught;
neutralising both UV conditions together is caught. Two single-arm mutations survive by
construction, as described above, and a third -- removing the low temperature's deference
to the UV badge -- survives here but is caught by the existing suite, so it is covered
elsewhere rather than being a gap.

A related asymmetry was examined and deliberately not changed. The high temperature has
no data-presence guard at all, unlike its two siblings. That path is unreachable:
`temperature` is required both by Home Assistant's forecast contract and by this repo's
own `WeatherForecast` type, so adding a guard would add unreachable code.

Test-only; no release-notes entry.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6c7714fb-9c18-4995-9aaa-129fa9eb7a53
