### PR TITLE
test: pin the compact limiter, the running-event interval and title templates

### DIFF
--- a/tests/compact-limit-and-running-boundaries.test.ts
+++ b/tests/compact-limit-and-running-boundaries.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Boundary pins for the compact-mode event limiter and the "currently running"
+ * predicate.
+ *
+ * Both are half-open comparisons whose edges were reachable but unasserted:
+ *
+ * - `compact_events_to_show` fills days in order until the budget runs out. The
+ *   final day is usually only partially consumed, so the guard that decides
+ *   whether a day still gets a slot has to admit a remainder of exactly one.
+ *   Requiring more than one silently dropped that whole day from the card while
+ *   every other day rendered normally, so nothing looked broken. That remainder
+ *   guard and the budget-exhausted `break` above it mask each other in the
+ *   permissive direction — relaxing either one alone changes nothing, because
+ *   the other still refuses the day — so the second test below deliberately
+ *   pins the pair rather than an individual arm.
+ *
+ * - `isEventCurrentlyRunning` defines a half-open interval: an event is running
+ *   from its start instant up to, but not including, its end instant. Both edges
+ *   are exactly reachable under frozen time, and the predicate drives the
+ *   progress bar and the running state class.
+ *
+ * Every boundary assertion below is paired with its one-millisecond neighbour so
+ * that a mutation which simply shifts the comparison is caught rather than
+ * absorbed.
+ *
+ * Note on the neighbouring day-inclusion test in `groupEventsByDay`: the
+ * `isEventOnOrAfterReference` and `isFutureEvent` disjuncts are both subsumed by
+ * `isOngoingEvent` for any event whose end is not before its start, so their
+ * edges are unobservable by construction and are deliberately not pinned here.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import * as EventUtils from '../src/utils/events';
+import * as FormatUtils from '../src/utils/format';
+
+const midnight = (offset: number) => {
+  const d = new Date(FROZEN_NOW);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + offset);
+  return d;
+};
+
+const at = (offset: number, hour: number) => {
+  const d = midnight(offset);
+  d.setHours(hour, 0, 0, 0);
+  return d;
+};
+
+const timed = (summary: string, offset: number, from: number, to: number) => ({
+  summary,
+  start: { dateTime: at(offset, from).toISOString() },
+  end: { dateTime: at(offset, to).toISOString() },
+  _entityId: 'calendar.personal',
+});
+
+const dayKeys = (days: ReturnType<typeof EventUtils.groupEventsByDay>) =>
+  days.map((day) => FormatUtils.getLocalDateKey(new Date(day.timestamp)));
+
+const summaries = (days: ReturnType<typeof EventUtils.groupEventsByDay>) =>
+  days.map((day) => day.events.map((event) => event.summary));
+
+describe('compact event limit boundary', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('still renders a day when exactly one event slot remains', () => {
+    const config = buildConfig({ compact_events_to_show: 3, days_to_show: 5 });
+    const events = [
+      timed('first-a', 0, 9, 10),
+      timed('first-b', 0, 11, 12),
+      timed('second-a', 1, 9, 10),
+      timed('second-b', 1, 11, 12),
+    ] as never;
+
+    const days = EventUtils.groupEventsByDay(events, config, false, 'en', 'list');
+
+    // The second day has a remainder of exactly one slot; it must survive.
+    expect(dayKeys(days)).toHaveLength(2);
+    expect(summaries(days)[1]).toEqual(['second-a']);
+    // Control: the fully consumed first day is unaffected by the same guard.
+    expect(summaries(days)[0]).toEqual(['first-a', 'first-b']);
+  });
+
+  it('stops adding days once the budget is exhausted', () => {
+    const config = buildConfig({ compact_events_to_show: 2, days_to_show: 5 });
+    const events = [
+      timed('first-a', 0, 9, 10),
+      timed('first-b', 0, 11, 12),
+      timed('second-a', 1, 9, 10),
+    ] as never;
+
+    const days = EventUtils.groupEventsByDay(events, config, false, 'en', 'list');
+
+    expect(dayKeys(days)).toHaveLength(1);
+    expect(summaries(days)[0]).toEqual(['first-a', 'first-b']);
+  });
+});
+
+describe('isEventCurrentlyRunning interval boundaries', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const offsetFromNow = (milliseconds: number) => new Date(Date.now() + milliseconds);
+
+  const event = (start: Date, end: Date) =>
+    ({
+      summary: 'boundary',
+      start: { dateTime: start.toISOString() },
+      end: { dateTime: end.toISOString() },
+    }) as never;
+
+  it('treats the start instant as inclusive', () => {
+    const startsNow = event(offsetFromNow(0), offsetFromNow(3_600_000));
+    const startsInOneMillisecond = event(offsetFromNow(1), offsetFromNow(3_600_000));
+
+    expect(EventUtils.isEventCurrentlyRunning(startsNow)).toBe(true);
+    expect(EventUtils.isEventCurrentlyRunning(startsInOneMillisecond)).toBe(false);
+  });
+
+  it('treats the end instant as exclusive', () => {
+    const endsNow = event(offsetFromNow(-3_600_000), offsetFromNow(0));
+    const endsInOneMillisecond = event(offsetFromNow(-3_600_000), offsetFromNow(1));
+
+    expect(EventUtils.isEventCurrentlyRunning(endsNow)).toBe(false);
+    expect(EventUtils.isEventCurrentlyRunning(endsInOneMillisecond)).toBe(true);
+  });
+});

--- a/tests/config-integrity.test.ts
+++ b/tests/config-integrity.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildConfig } from './fixtures';
 import type * as Types from '../src/config/types';
+import { SYNTHETIC_FIELDS } from '../src/rendering/editor/synthetic';
 import * as EventUtils from '../src/utils/events';
 import '../src/calendar-card-pro';
-import { SYNTHETIC_FIELDS } from '../src/rendering/editor/synthetic';
 
 /**
  * Three ways a valid configuration could be silently replaced by a different

--- a/tests/title-templates.test.ts
+++ b/tests/title-templates.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as Types from '../src/config/types';
+import * as Templates from '../src/utils/templates';
+
+/**
+ * The title-template subsystem had no test call sites at all: a sweep of seven
+ * mutations across `src/utils/templates.ts` — dropping `{%` detection, dropping
+ * `{{` detection, removing the resubscribe dedup guard, neutralising both
+ * stale-version guards, skipping the version bump in `destroy()`, and deleting
+ * the teardown error handling — left the entire suite green. That covers every
+ * branch a user can reach through `title:`, which the card consults at five
+ * separate call sites, so a template that stopped being recognised or a stale
+ * render that overwrote a newer one would have shipped silently.
+ *
+ * These tests pin the two syntaxes documented in `docs/features/title-templates.md`
+ * and the subscription lifecycle rules that keep a slow or superseded render
+ * from replacing the title the user is currently looking at.
+ */
+
+/** One captured `render_template` subscription. */
+interface Captured {
+  handler: (message: unknown) => void;
+  message: { type: string; template: string; report_errors?: boolean };
+}
+
+/**
+ * Build a Home Assistant stub that records every `render_template` subscription
+ * and hands back a controllable unsubscribe function.
+ */
+function makeHass(options: { unsubscribe?: () => void } = {}) {
+  const captured: Captured[] = [];
+  const hass = {
+    connection: {
+      subscribeMessage: (handler: (message: unknown) => void, message: Captured['message']) => {
+        captured.push({ handler, message });
+        return Promise.resolve(options.unsubscribe ?? (() => undefined));
+      },
+    },
+  } as unknown as Types.Hass;
+
+  return { hass, captured };
+}
+
+/** Let the un-awaited `void this._subscribe(...)` chain settle. */
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('title template detection', () => {
+  it('recognizes both documented Jinja2 syntaxes and nothing else', () => {
+    // Both forms are documented, so dropping either one silently disables a
+    // syntax the docs still promise.
+    expect(Templates.isTemplate('{{ states("sensor.x") }}')).toBe(true);
+    expect(Templates.isTemplate('{% if true %}Yes{% endif %}')).toBe(true);
+
+    // Controls: a literal title must never be sent to `render_template`.
+    expect(Templates.isTemplate('My Calendar')).toBe(false);
+    expect(Templates.isTemplate('Braces { and } alone')).toBe(false);
+    expect(Templates.isTemplate(undefined)).toBe(false);
+    expect(Templates.isTemplate(42)).toBe(false);
+  });
+});
+
+describe('template result and error handling', () => {
+  it('delivers rendered results and normalizes non-string payloads', async () => {
+    const onResult = vi.fn();
+    const onError = vi.fn();
+    const { hass, captured } = makeHass();
+
+    await Templates.subscribeToTemplate(hass, '{{ x }}', { onResult, onError });
+    expect(captured).toHaveLength(1);
+
+    captured[0].handler({ result: 'Upcoming' });
+    expect(onResult).toHaveBeenCalledWith('Upcoming');
+
+    // Home Assistant may return a number or null; the title is a string.
+    captured[0].handler({ result: 7 });
+    expect(onResult).toHaveBeenCalledWith('7');
+    captured[0].handler({ result: null });
+    expect(onResult).toHaveBeenCalledWith('');
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('swallows warning-level messages but surfaces real errors', async () => {
+    const onResult = vi.fn();
+    const onError = vi.fn();
+    const { hass, captured } = makeHass();
+
+    await Templates.subscribeToTemplate(hass, '{{ x }}', { onResult, onError });
+
+    // A warning must not reach the card, so the last good title survives.
+    captured[0].handler({ error: 'undefined variable', level: 'WARNING' });
+    expect(onError).not.toHaveBeenCalled();
+
+    // Presence control: a non-warning error does reach the card, which proves
+    // the assertion above is about the level and not about errors never firing.
+    captured[0].handler({ error: 'TemplateSyntaxError', level: 'ERROR' });
+    expect(onError).toHaveBeenCalledWith('TemplateSyntaxError');
+  });
+
+  it('returns no unsubscribe handle when there is nothing to subscribe to', async () => {
+    const onResult = vi.fn();
+    const onError = vi.fn();
+    const { hass } = makeHass();
+
+    expect(await Templates.subscribeToTemplate(undefined, '{{ x }}', { onResult, onError })).toBe(
+      undefined,
+    );
+    expect(await Templates.subscribeToTemplate(hass, '', { onResult, onError })).toBe(undefined);
+  });
+});
+
+describe('template subscription lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not resubscribe while the template and connection are unchanged', async () => {
+    const { hass, captured } = makeHass();
+    const subscription = new Templates.TemplateSubscription({
+      onResult: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    subscription.update(hass, '{{ x }}');
+    await flush();
+    expect(captured).toHaveLength(1);
+
+    // Repeating an identical update must be inert even after the resubscribe
+    // debounce would have elapsed.
+    subscription.update(hass, '{{ x }}');
+    await vi.advanceTimersByTimeAsync(400);
+    expect(captured).toHaveLength(1);
+
+    // Presence control: a genuinely changed template does resubscribe, so the
+    // assertion above is about deduplication and not about subscription being
+    // broken outright.
+    subscription.update(hass, '{{ y }}');
+    await vi.advanceTimersByTimeAsync(400);
+    expect(captured).toHaveLength(2);
+
+    subscription.destroy();
+  });
+
+  it('suppresses results that arrive after the subscription was destroyed', async () => {
+    const onResult = vi.fn();
+    const { hass, captured } = makeHass();
+    const subscription = new Templates.TemplateSubscription({ onResult, onError: vi.fn() });
+
+    subscription.update(hass, '{{ x }}');
+    await flush();
+
+    // Presence control: while live, results reach the card.
+    captured[0].handler({ result: 'Live' });
+    expect(onResult).toHaveBeenCalledWith('Live');
+    onResult.mockClear();
+
+    // After teardown a late render must not overwrite the current title.
+    subscription.destroy();
+    captured[0].handler({ result: 'Stale' });
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes a subscription that completed after being superseded', async () => {
+    const unsubscribe = vi.fn();
+    const { hass } = makeHass({ unsubscribe });
+    const subscription = new Templates.TemplateSubscription({
+      onResult: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    // Destroying before the in-flight subscribe resolves must still release it,
+    // otherwise the websocket subscription leaks for the life of the page.
+    subscription.update(hass, '{{ x }}');
+    subscription.destroy();
+    await flush();
+
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('survives an unsubscribe handle that throws', async () => {
+    const unsubscribe = vi.fn(() => {
+      throw new Error('connection already closed');
+    });
+    const { hass } = makeHass({ unsubscribe });
+    const subscription = new Templates.TemplateSubscription({
+      onResult: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    subscription.update(hass, '{{ x }}');
+    await flush();
+
+    // A disconnected websocket must not take the card down during teardown.
+    expect(() => subscription.destroy()).not.toThrow();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
test: pin the compact limiter, the running-event interval and title templates

Three mutation sweeps found coverage gaps that every existing test was blind
to. All three are pinned here; no source behaviour changes.

The compact-mode limiter (`src/utils/events.ts:557`) admits a day only while
at least one event slot remains. Raising that bound to require more than one
remaining slot deleted an entire day from the card — the normal case for the
last, partially-consumed day — while every other day rendered correctly, so
nothing looked broken. The budget-exhausted `break` above it and this
remainder guard mask each other in the permissive direction: relaxing either
one alone changes nothing, because the other still refuses the day. The
second test therefore pins the pair rather than an individual arm, and the
docstring records that so the pairing is not mistaken for redundancy later.

`isEventCurrentlyRunning` (`:1052`) treats an event as running on a half-open
interval — inclusive at the start, exclusive at the end. Both bounds could be
flipped with the suite green. A test that builds its own `new Date()` cannot
see this, because the function calls `new Date()` internally and the two
instants differ by a few milliseconds, which turns "starts exactly now" into
"started 2 ms ago" and absorbs the mutation. These tests freeze time and
derive every offset from the frozen instant, and pair each boundary with its
one-millisecond neighbour.

The title-template subsystem had no test call sites at all. Seven mutations
across `src/utils/templates.ts` all survived the full suite: dropping `{%`
detection, dropping `{{` detection, removing the resubscribe dedup guard,
neutralising both stale-version guards, skipping the version bump in
`destroy()`, and deleting the teardown error handling. That is every branch a
user reaches through `title:`, which the card consults at five call sites. A
template that stopped being recognised, a superseded render that overwrote a
newer title, or a leaked websocket subscription would all have shipped
silently. The new tests cover both syntaxes documented in
docs/features/title-templates.md, result normalisation, the warning-versus-
error distinction that keeps the last good title on screen, and the
subscription lifecycle rules. All seven mutations are now caught, along with
a control that inverts the warning-level check.

Also reorders two imports in tests/config-integrity.test.ts to clear the
repository's only remaining lint warning, which `--fix` could not resolve.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6c7714fb-9c18-4995-9aaa-129fa9eb7a53
