### PR TITLE
docs: retire the orphaned phase vocabulary and gate citation rot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -920,6 +920,22 @@ both directions, by importing the schema modules. A new field with no string fai
 - Match the existing module layout: `config/`, `interaction/`, `rendering/`,
   `translations/`, `utils/`.
 
+**Cite symbols in comments, never line numbers.** A citation into the five-hundreds of
+`render.ts` was accurate when it was written and became a pointer into empty space the moment
+the v4 refactor cut that file from roughly a thousand lines to five hundred. Six such citations shipped in the test suite, one of them
+naming a README line four times past the end of the file, and nothing failed because no tool
+reads prose. A symbol name — `renderDateWeather` in `leaves.ts` — is greppable, survives
+every edit above it, and tells the reader what to look for rather than where it used to sit.
+`check:docs` now flags any comment citation that points beyond the end of the file it names;
+citations that quote a released tag, such as `v3.6.0 leaves.ts:324`, are exempt because a tag
+is immutable.
+
+**When a planning document is retired, grep for its vocabulary.** `docs/development/column-view.md`
+was deleted once the column view shipped, and nineteen references to its phases survived in
+four test files — still written in the future tense, still describing work as upcoming that
+had already landed. Comments that name a document outlive the document, so deleting one is
+not finished until `grep -rn "Phase [0-9]" src tests` comes back empty.
+
 **A JSDoc block touches the thing it documents — no blank line between them.** This is the
 one style rule in the project that nothing mechanical enforces, so it is the one that
 silently rots. TypeScript still associates a doc comment and its `@param` tags across a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,7 @@ src/
 │   │   ├── synthetic.ts          # UI-only fields, and values invalid while typed
 │   │   ├── localize.ts           # The string hooks `ha-form` calls
 │   │   ├── strings.ts            # English editor strings
+│   │   ├── version.ts            # Build-stamped version the editor reports
 │   │   ├── translations/         # The same keys per language, partial by design
 │   │   └── styles.ts             # Editor chassis CSS
 │   ├── render.ts                 # Card shell and the list view

--- a/docs/features/weather.md
+++ b/docs/features/weather.md
@@ -40,23 +40,23 @@ This flexible configuration allows you to create a personalized experience that 
 | Option                            | Type    | Default                       | Description                                                                                                                        |
 | --------------------------------- | ------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `entity`                          | string  | -                             | Weather entity to use for forecasts                                                                                                |
-| `position`                        | string  | `date`                        | Where to show weather data: `'none'` (nowhere), `'date'` (date column), `'event'` (next to events), or `'both'`                    |
-| `date → show_conditions`          | boolean | `true`                        | Whether to show weather condition icons in date column                                                                             |
-| `date → show_high_temp`           | boolean | `true`                        | Whether to show high temperature in date column                                                                                    |
-| `date → show_low_temp`            | boolean | `false`                       | Whether to show low temperature in date column. The UV index takes this place on days it is shown                                  |
-| `date → show_uv_index`            | boolean | `false`                       | Whether to show UV index in date column                                                                                            |
+| `position`                        | string  | `date`                        | Where to show weather data: `'none'` (nowhere), `'date'` (day header), `'event'` (next to events), or `'both'`                     |
+| `date → show_conditions`          | boolean | `true`                        | Whether to show weather condition icons in the day header                                                                          |
+| `date → show_high_temp`           | boolean | `true`                        | Whether to show high temperature in the day header                                                                                 |
+| `date → show_low_temp`            | boolean | `false`                       | Whether to show low temperature in the day header. The UV index takes this place on days it is shown                               |
+| `date → show_uv_index`            | boolean | `false`                       | Whether to show UV index in the day header                                                                                         |
 | `date → uv_index_threshold`       | number  | `0`                           | Only show UV index when it exceeds this value (0 = always show when enabled)                                                       |
-| `date → icon_size`                | string  | `14px`                        | Size of weather icons in date column                                                                                               |
-| `date → font_size`                | string  | `12px`                        | Size of weather text in date column                                                                                                |
-| `date → color`                    | string  | `var(--primary-text-color)`   | Color of weather text and icons in date column. Matches the weekday, day number and month it sits beside                           |
+| `date → icon_size`                | string  | `14px`                        | Size of weather icons in the day header                                                                                            |
+| `date → font_size`                | string  | `12px`                        | Size of weather text in the day header                                                                                             |
+| `date → color`                    | string  | `var(--primary-text-color)`   | Color of weather text and icons in the day header. Matches the weekday, day number and month it sits beside                        |
 | `event → show_conditions`         | boolean | `true`                        | List layout: whether to show the condition icon. Column layout: whether to state the condition in words — the icon is always shown |
-| `event → show_temp`               | boolean | `true`                        | Whether to show temperature in event column                                                                                        |
-| `event → show_uv_index`           | boolean | `false`                       | Whether to show UV index in event column                                                                                           |
+| `event → show_temp`               | boolean | `true`                        | Whether to show temperature in the event row                                                                                       |
+| `event → show_uv_index`           | boolean | `false`                       | Whether to show UV index in the event row                                                                                          |
 | `event → uv_index_threshold`      | number  | `0`                           | Only show UV index when it exceeds this value (0 = always show when enabled)                                                       |
 | `event → daily_forecast_fallback` | boolean | `true`                        | Fall back to the daily forecast for timed events beyond the hourly forecast horizon                                                |
 | `event → max_lines`               | number  | `0`                           | Maximum number of lines the event weather row may use (0 = unlimited). Truncated text shows `...`                                  |
-| `event → icon_size`               | string  | `14px`                        | Size of weather icons in event column                                                                                              |
-| `event → font_size`               | string  | `12px`                        | Size of weather text in event column                                                                                               |
+| `event → icon_size`               | string  | `14px`                        | Size of weather icons in the event row                                                                                             |
+| `event → font_size`               | string  | `12px`                        | Size of weather text in the event row                                                                                              |
 | `event → color`                   | string  | `var(--secondary-text-color)` | Color of weather text and icons beside events. Matches the time and location it sits beside                                        |
 
 These sit under the card's `weather` option — see [Weather in the configuration reference](/reference/configuration#weather).
@@ -66,7 +66,7 @@ These sit under the card's `weather` option — see [Weather in the configuratio
 You can choose where weather information appears in your calendar:
 
 - `none`: Hides weather everywhere, without clearing the entity — the card subscribes to no forecast at all
-- `date`: Shows daily forecasts in the date column (left side)
+- `date`: Shows daily forecasts in the day header — the date column in list view, the column heading in column view
 - `event`: Shows hourly forecasts next to event titles
 - `both`: Displays weather in both positions simultaneously
 
@@ -214,7 +214,7 @@ Weather integration is particularly useful for:
 
 The feature automatically matches weather data to the correct time periods:
 
-- Daily forecasts for the date column
+- Daily forecasts for the day header
 - Hourly forecasts for specific event times
 
 Every option on this page lives under the card's weather settings — see [Weather in the configuration reference](/reference/configuration#weather).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -193,13 +193,13 @@ Both height options may be overridden inside a `column:` block, and usually shou
 
 ## 🌦️ Weather
 
-| Option               | Type   | Default | Description                                                                                                                    |
-| -------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `weather`            | object | -       | Weather configuration object containing the settings below                                                                     |
-| `weather → entity`   | string | -       | Home Assistant weather entity to use for forecasts                                                                             |
-| `weather → position` | string | `date`  | Where to show weather data: `none` (nowhere), `date` (in date column), `event` (next to events), or `both` (in both positions) |
-| `weather → date`     | object | -       | Configuration for weather display in the date column                                                                           |
-| `weather → event`    | object | -       | Configuration for weather display next to events                                                                               |
+| Option               | Type   | Default | Description                                                                                                                       |
+| -------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `weather`            | object | -       | Weather configuration object containing the settings below                                                                        |
+| `weather → entity`   | string | -       | Home Assistant weather entity to use for forecasts                                                                                |
+| `weather → position` | string | `date`  | Where to show weather data: `none` (nowhere), `date` (in the day header), `event` (next to events), or `both` (in both positions) |
+| `weather → date`     | object | -       | Configuration for weather display in the day header                                                                               |
+| `weather → event`    | object | -       | Configuration for weather display next to events                                                                                  |
 
 ### Weather Position Options
 

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1474,6 +1474,7 @@ function report(counts) {
       `${counts.removed} removed options migrated, ` +
       `${counts.reachable} pages reachable from the navigation, ` +
       `${counts.themed} theme defaults documented, ` +
+      `${counts.citations} line citations resolved, ` +
       `release surfaces agree on v${counts.version}.\n`,
   );
 
@@ -2016,6 +2017,87 @@ function checkThemeDefaults(rows) {
   return reconciled;
 }
 
+// Check 25 - no source comment cites a line number that no longer exists
+
+/**
+ * Flags `file.ext:NNN` citations in comments that point past the end of the file they
+ * name.
+ *
+ * Line numbers in prose rot silently. The v4 refactor split `render.ts` from ~1050 lines
+ * down to 523, and six citations across the test suite were left pointing into empty
+ * space — one of them named a README line four times past the end of that file. Nothing
+ * failed, because no tool reads comments.
+ *
+ * This only flags citations that are provably wrong (beyond EOF), not every numeric
+ * reference: historical citations to a released tag (`v3.6.0 leaves.ts:324`) and recorded
+ * measurement tables are legitimate and stable. The fix for a flagged citation is to name
+ * the symbol instead of the line, which is greppable and survives edits.
+ *
+ * Historical citations opt out by naming their release in the same line, which is why the
+ * example above is spelled out in prose rather than shown literally.
+ */
+function checkCitations() {
+  const CITE = /([A-Za-z0-9_./-]+\.(?:ts|md|mjs))[: ]+(\d+)/g;
+  const SCAN = ['src', 'tests', 'scripts'];
+  const lineCounts = new Map();
+  const byBasename = new Map();
+
+  const walk = (dir, out = []) => {
+    for (const name of readdirSync(dir)) {
+      if (name === 'node_modules' || name === '__snapshots__' || name.startsWith('.')) continue;
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) walk(full, out);
+      else out.push(full);
+    }
+    return out;
+  };
+
+  const all = [
+    ...SCAN.flatMap((d) => walk(join(ROOT, d))),
+    ...walk(DOCS_DIR),
+    join(ROOT, 'README.md'),
+    join(ROOT, 'AGENTS.md'),
+    join(ROOT, 'CONTRIBUTING.md'),
+  ];
+  for (const file of all) {
+    const base = file.slice(file.lastIndexOf(sep) + 1);
+    if (!byBasename.has(base)) byBasename.set(base, file);
+  }
+
+  let checked = 0;
+  for (const file of all) {
+    if (!/\.(ts|mjs|md)$/.test(file)) continue;
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      const trimmed = line.trim();
+      const isComment =
+        trimmed.startsWith('*') ||
+        trimmed.startsWith('//') ||
+        trimmed.startsWith('#') ||
+        trimmed.includes('<!--');
+      if (!isComment) return;
+      // Historical citations name the release they describe and stay valid forever.
+      if (/v\d+\.\d+\.\d+/.test(line)) return;
+      for (const match of line.matchAll(CITE)) {
+        const target = byBasename.get(match[1].slice(match[1].lastIndexOf('/') + 1));
+        if (!target || target === file) continue;
+        if (!lineCounts.has(target)) {
+          lineCounts.set(target, readFileSync(target, 'utf8').split('\n').length);
+        }
+        const total = lineCounts.get(target);
+        checked += 1;
+        if (Number(match[2]) > total) {
+          error(
+            `${relative(ROOT, file)}:${i + 1} cites ${match[1]}:${match[2]}, but that file has ` +
+              `${total} lines. Name the symbol instead of the line number.`,
+          );
+        }
+      }
+    });
+  }
+  return checked;
+}
+
 function main() {
   const defaults = readDefaults();
   const rows = readReferenceRows();
@@ -2051,6 +2133,7 @@ function main() {
   const removed = checkDeprecatedTable(readDeprecatedMaps());
   const reachable = checkPageReachability(docs, readNavRoutes());
   const themed = checkThemeDefaults(readThemeTable());
+  const citations = checkCitations();
 
   process.exit(
     report({
@@ -2066,6 +2149,7 @@ function main() {
       removed,
       reachable,
       themed,
+      citations,
       version,
     }),
   );

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -356,7 +356,7 @@ export interface EventsByDay {
   month: string;
   timestamp: number;
   events: CalendarEventData[];
-  weekNumber?: number | null; // Changed from number | undefined to number | null
+  weekNumber?: number | null;
   isFirstDayOfWeek?: boolean;
   isFirstDayOfMonth?: boolean;
   monthNumber?: number;

--- a/tests/column-dom-snapshot.test.ts
+++ b/tests/column-dom-snapshot.test.ts
@@ -68,7 +68,7 @@ describe('column view DOM', () => {
   });
 
   it('suppresses empty day columns', () => {
-    // `show_empty_days` defaults to true for this view (`view.ts:353`), the opposite of the
+    // `show_empty_days` defaults to true for this view (`COLUMN_DEFAULT_OVERRIDES`), the opposite of the
     // list view, so `true` here would have re-rendered the default and asserted nothing.
     expect(
       renderColumn(SINGLE_EVENT, buildConfig({ column: { show_empty_days: false } })),
@@ -80,7 +80,7 @@ describe('column view DOM', () => {
   });
 
   it('renders unsplit multi-day events', () => {
-    // Splitting is forced on for this view (`view.ts:354`), so only the column override that
+    // Splitting is forced on for this view (`COLUMN_DEFAULT_OVERRIDES`), so only the column override that
     // turns it back off produces markup the default case does not already cover.
     expect(
       renderColumn(EVENTS, buildConfig({ column: { split_multiday_events: false } })),
@@ -128,7 +128,7 @@ describe('column view DOM', () => {
   });
 
   it('renders a single day', () => {
-    // Compact mode is deliberately list-scoped (`view.ts:161-162`) and would render the
+    // Compact mode is deliberately list-scoped (`VIEW_SCOPE` in `view.ts`) and would render the
     // default column markup, so the day count is the axis that varies here instead.
     expect(renderColumn(EVENTS, buildConfig({ days_to_show: 1 }))).toMatchSnapshot();
   });

--- a/tests/column-dom.test.ts
+++ b/tests/column-dom.test.ts
@@ -11,7 +11,7 @@ import * as Render from '../src/rendering/render';
 import * as EventUtils from '../src/utils/events';
 
 /**
- * Phase 4b — the column view's DOM.
+ * The column view's DOM.
  *
  * The list view has a snapshot gate whose job is to prove nothing changed. This file
  * has the opposite job: the column view is new, so there is no prior output to be
@@ -959,8 +959,8 @@ describe('column view DOM', () => {
       // not, because `renderEventContent` reads only `show_progress_bar` — every other
       // display decision arrives pre-resolved in `contentParts` from
       // `buildEventPresentation`, which both views call identically. So this asserts
-      // that the two views share the rendering leaf, and Phase 2's presentation layer
-      // is what guarantees they share the decisions feeding it.
+      // that the two views share the rendering leaf, and `buildEventPresentation` is
+      // what guarantees they share the decisions feeding it.
       //
       // `split_multiday_events` is set on both sides so the two views group the same
       // events. Column raises it by default (spec §D6); leaving the list on the default

--- a/tests/compact-column-inert.test.ts
+++ b/tests/compact-column-inert.test.ts
@@ -96,7 +96,8 @@ function realEventCount(days: Types.EventsByDay[]): number {
  * Group with a per-entity cap, wiring `_matchedConfig` by reference.
  *
  * Production sets `_matchedConfig` at fetch time to the very object in `config.entities`
- * (`events.ts:805`), and the bucket key is derived by identity lookup against that array.
+ * (`processEvents` in `events.ts`), and the bucket key is derived by identity lookup
+ * against that array.
  * Building the config first and reading the normalized entry back out reproduces that,
  * rather than passing a lookalike literal that would land in the fallback bucket.
  */

--- a/tests/day-container-classes.test.ts
+++ b/tests/day-container-classes.test.ts
@@ -72,7 +72,8 @@ const WEEKEND_SPAN: Types.CalendarEventData[] = [
 const SPAN_CONFIG = { days_to_show: 10 };
 
 /**
- * Column view ships `show_empty_days: true` (`view.ts:317`) because a grid has to fill
+ * Column view ships `show_empty_days: true` (`COLUMN_DEFAULT_OVERRIDES` in `view.ts`)
+ * because a grid has to fill
  * every column, so it renders 10 day containers where list view renders the 4 that hold
  * events. Turning it off is what makes the two day *sets* comparable; without it a
  * cross-view assertion compares Friday against Wednesday and fails for a reason that has

--- a/tests/editor-schema.test.ts
+++ b/tests/editor-schema.test.ts
@@ -2698,8 +2698,8 @@ describe('editor: per-calendar settings', () => {
    * The defect in the editor this replaces, and the reason four of these are dropdowns.
    *
    * The card reads them presence-first — `getEntitySetting(…) ?? config.show_time`
-   * (`presentation.ts:124`), and `typeof … !== 'undefined'` for the split
-   * (`events.ts:898`) — so absent means *follow the card*. Bound to a checkbox, that
+   * (`buildEventPresentation` in `presentation.ts`), and `typeof … !== 'undefined'` for
+   * the split (`shouldSplitEvent` in `events.ts`) — so absent means *follow the card*. Bound to a checkbox, that
    * state renders as "off", which is a different instruction, and the first touch
    * writes a literal `false` that no checkbox can take back.
    */
@@ -3261,7 +3261,8 @@ describe('editor: per-calendar settings', () => {
   /**
    * Per-entity and card-level `split_multiday_events` are the same word for two
    * different scopes. The card-level key is a real column override — `column:
-   * { split_multiday_events: false }` skips the split entirely (`events.ts:225`) —
+   * { split_multiday_events: false }` skips the split entirely
+   * (`viewForcesMultidaySplit` in `events.ts`) —
    * while the per-entity one is ignored in column view, because a column that omitted
    * the later days of an event would be a claim about a day that is not true.
    */

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -4,8 +4,8 @@ import type * as Types from '../src/config/types';
 /**
  * Fixtures and helpers for the list-view DOM equality gate (`tests/list-dom.test.ts`).
  *
- * Kept separate from the test so that Phase 1's shared leaf renderers, and later the
- * column view, can reuse exactly the same event data. The whole point of the gate is
+ * Kept separate from the test so that the shared leaf renderers and the column view can
+ * reuse exactly the same event data. The whole point of the gate is
  * that both views are fed identical input; that only holds if the input has one home.
  */
 
@@ -118,8 +118,8 @@ export const SINGLE_EVENT: Types.CalendarEventData[] = [
 /**
  * Weather forecasts covering the fixture dates.
  *
- * Included because Phase 1's **first** extraction is weather (`render.ts:526-575`), and
- * a gate that passes no forecasts leaves that step unprotected — `weatherForecasts` is
+ * Included because weather is drawn by shared leaves (`renderDateWeather` in `leaves.ts`),
+ * and a gate that passes no forecasts leaves it unprotected — `weatherForecasts` is
  * optional, so every weather branch short-circuits to `nothing` and the snapshots would
  * agree perfectly with a broken extraction.
  *

--- a/tests/list-dom.test.ts
+++ b/tests/list-dom.test.ts
@@ -9,21 +9,21 @@ import * as Render from '../src/rendering/render';
 import * as EventUtils from '../src/utils/events';
 
 /**
- * Phase 0 Stage 2 — the list-view DOM equality gate.
+ * The list-view DOM equality gate.
  *
- * Phase 1 extracts the list's leaf renderers into shared functions so the column view
- * can reuse them. The list's own DOM is supposed to come out **byte-identical**; that
- * is the entire safety argument for calling Phase 1 low-risk. This file is what makes
- * that claim checkable instead of asserted.
+ * The list's leaf renderers live in `leaves.ts` and are shared with the column view, so
+ * a change made for one view can silently alter the other. The list's DOM is supposed to
+ * stay **byte-identical** across any such change; this file is what makes that checkable
+ * instead of asserted.
  *
  * ## What is rendered, and into what
  *
  * The pipeline under test is `groupEventsByDay` → `renderGroupedEvents` → Lit, which is
  * exactly what `calendar-card-pro.ts` `render()` does for the populated case. The card
  * element itself is deliberately **not** constructed. Doing so would require a fake
- * `hass`, a mocked `callApi` (`events.ts:1167`), and awaiting an async fetch — none of
- * which this gate is about, and all of which could fail for reasons unrelated to the
- * DOM. Rendering the pure functions directly isolates the surface Phase 1 changes.
+ * `hass`, a mocked `callApi`, and awaiting an async fetch — none of which this gate is
+ * about, and all of which could fail for reasons unrelated to the DOM. Rendering the
+ * pure functions directly isolates the shared rendering surface.
  *
  * The two functions kept together on purpose: grouping decides day boundaries,
  * ordering and which events survive, and rendering turns that into the table. A change
@@ -36,7 +36,7 @@ import * as EventUtils from '../src/utils/events';
  * two different days produces two different DOMs. Fake timers freeze `Date.now()` and
  * the `new Date()` constructor globally, which covers dayjs too since dayjs has no
  * independent clock. This needs **zero production changes** — no `now` parameter
- * threaded through the very functions Phase 1 is extracting.
+ * threaded through the shared leaf renderers.
  *
  * ## Baselines and the update path
  *
@@ -238,7 +238,7 @@ describe('list view DOM', () => {
 
   it('renders split multi-day events', () => {
     // `split_multiday_events` decomposes the Conference fixture across days, which is
-    // one of the paths Phase 1's shared renderers must preserve.
+    // one of the paths the shared leaf renderers must preserve.
     //
     // Until column view arrived this snapshot was byte-identical to the default one,
     // and the test asserted nothing. Splitting used to live in `processEvents`, on the
@@ -294,13 +294,13 @@ describe('list view DOM', () => {
     ).toMatchSnapshot();
   });
 
-  // Weather is pinned in its own block because Phase 1 extracts it FIRST, and because it
+  // Weather is pinned in its own block because it is drawn by shared leaves, and because it
   // is the one part of the render that stays inert unless forecasts are supplied — the
   // rest of this file would pass unchanged against a completely broken weather renderer.
 
   it('renders weather on the date column', () => {
     // `position: 'date'` drives `findDailyForecast` inside `renderDateColumn`
-    // (`render.ts:526-575`) — the exact block Phase 1 lifts out first.
+    // (`renderDateWeather` in `leaves.ts`).
     expect(
       renderList(EVENTS, buildConfig({ weather: { entity: 'weather.home', position: 'date' } }), {
         weather: WEATHER,
@@ -309,7 +309,7 @@ describe('list view DOM', () => {
   });
 
   it('renders weather on events', () => {
-    // A separate render site (`renderEventWeather`, `render.ts:1050+`) reading the
+    // A separate render site (`renderEventWeather` in `leaves.ts`) reading the
     // hourly forecast. Pinned separately so an extraction that fixes one and breaks the
     // other cannot pass.
     expect(
@@ -331,7 +331,7 @@ describe('list view DOM', () => {
             entity: 'weather.home',
             position: 'both',
             date: { show_low_temp: true, show_high_temp: true, show_conditions: true },
-            event: { show_conditions: true, show_high_temp: true },
+            event: { show_conditions: true },
           },
         }),
         { weather: WEATHER },
@@ -341,8 +341,8 @@ describe('list view DOM', () => {
 
   it('suppresses the low temp when a UV index is shown', () => {
     // `showLowTemp` is `show_low_temp === true && !showUvIndex && templow !== undefined`
-    // (`render.ts:545-546`) — an interaction between two independent flags, which is
-    // exactly the kind of condition an extraction silently drops. Both flags are on
+    // (`renderDateWeather` in `leaves.ts`) — an interaction between two independent flags,
+    // which is exactly the kind of condition a refactor silently drops. Both flags are on
     // here, so the snapshot must contain `weather-uv-index` and must NOT contain
     // `weather-temp-low`; the assertions below state that outright rather than trusting
     // a reader to notice an absence in 1300 lines of snapshot.
@@ -371,10 +371,9 @@ describe('list view DOM', () => {
 
   it('renders the today indicator', () => {
     // `today_indicator` defaults to `false`, so `renderTodayIndicator` returns `nothing` in
-    // every other test — and `parseIndicatorPosition` (`render.ts:358-382`) is only reachable
-    // through it. That function is one of Phase 1's four **named** extraction targets, so
-    // without this case the gate would have been silent on a quarter of the work it exists to
-    // protect. Asserted directly as well as snapshotted, so "renders nothing" cannot pass.
+    // every other test — and `parseIndicatorPosition` (`leaves.ts`) is only reachable through
+    // it. That function is one of the shared leaf renderers, so without this case the gate
+    // would be silent on part of the surface it exists to protect. Asserted directly as well as snapshotted, so "renders nothing" cannot pass.
     const out = renderList(EVENTS, buildConfig({ today_indicator: 'dot' }));
 
     expect(out).toContain('today-indicator-container');
@@ -383,7 +382,7 @@ describe('list view DOM', () => {
 
   it('renders a custom today indicator position', () => {
     // `parseIndicatorPosition` turns a CSS-like `"x y"` string into inline styles (documented
-    // in README.md:841-843; default `'15% 50%'`). Pinning a non-default position is what
+    // in `docs/features/layout-appearance.md`; default `'15% 50%'`). Pinning a non-default position is what
     // distinguishes "the function ran" from "the function ran and its output reached the DOM".
     const out = renderList(
       EVENTS,
@@ -400,14 +399,14 @@ describe('list view DOM', () => {
     // Both default to `false`. The progress bar additionally requires a *running* event, which
     // is why the fixture set contains one straddling `FROZEN_NOW` — without it this config
     // would render no bar and the snapshot would look like coverage while providing none.
-    // Both branches live in the `.event-content` subtree, Phase 1's third extraction target.
+    // Both branches live in the `.event-content` subtree, drawn by the shared leaves.
     //
-    // Note for whoever extracts this: `show_progress_bar` is checked **twice** — once at
-    // `render.ts:902` when computing `progressPercentage`, and again at `:954`/`:973` when
-    // rendering. Either guard alone is dead code, because the first already forces
+    // Note for whoever refactors this: `show_progress_bar` is checked **twice** — once in
+    // `buildEventPresentation` when computing `progressPercentage`, and again in the
+    // event-content leaves when rendering. Either guard alone is dead code, because the first already forces
     // `progressPercentage` to `null`. Mutation-testing confirmed this: removing either one
     // in isolation changes no output at all, while removing both fails 13 of these 18 tests.
-    // The redundancy is harmless, but it means a Phase 1 extraction that keeps only one of
+    // The redundancy is harmless, but it means a refactor that keeps only one of
     // the two guards is still correct — don't treat dropping one as a regression.
     const out = renderList(EVENTS, buildConfig({ show_countdown: true, show_progress_bar: true }));
 
@@ -754,16 +753,15 @@ describe('list view DOM', () => {
   // and an empty html`` template. The rendered DOM cannot tell `''` from `nothing`,
   // so no behavioural test can pin them; only reading the source can.
   //
-  // Phase 1 moved the event leaves out of render.ts into leaves.ts. This guard failed
-  // at that moment by design, and each idiom below was re-read and confirmed unchanged
-  // before the regexes were repointed. It is expected to fail again at each later
-  // extraction seam, for the same reason. When it does: repoint, having first confirmed
+  // Moving the event leaves out of render.ts into leaves.ts made this guard fail by
+  // design, and each idiom below was re-read and confirmed unchanged before the regexes
+  // were repointed. It is expected to fail again at each later extraction seam, for the
+  // same reason. When it does: repoint, having first confirmed
   // every idiom survived byte-for-byte. Do not delete it, and do not "fix" it by relaxing
   // a regex to match whatever the new code happens to say.
   //
-  // Phase 2 will cut the `${index === 0 ? html`…` : ''}` seam in render.ts, when the
-  // column container grows its own date rendering. That idiom is asserted here too so
-  // the same forcing function applies to it.
+  // The `${index === 0 ? html`…` : ''}` seam in render.ts is asserted here too, so the
+  // same forcing function applies to it.
   it('preserves no-output idioms at extraction seams', () => {
     const renderSource = readFileSync(`${process.cwd()}/src/rendering/render.ts`, 'utf8');
     const leavesSource = readFileSync(`${process.cwd()}/src/rendering/leaves.ts`, 'utf8');

--- a/tests/view-config.test.ts
+++ b/tests/view-config.test.ts
@@ -537,9 +537,9 @@ describe('validateColumnOverrides', () => {
     expect(warnMock.mock.calls[0][0]).toContain('loaded from Home Assistant');
   });
 
-  it('accepts the column-only options now that Phase 4b implements them', () => {
-    // These three were reported as "planned but not implemented yet" until Phase 4b
-    // built them. The message was correct then and would be a lie now, so this test
+  it('accepts the column-only options now that the column view implements them', () => {
+    // These three were reported as "planned but not implemented yet" until the column
+    // view built them. The message was correct then and would be a lie now, so this test
     // inverts: the keys must validate silently.
     const config = buildConfig();
     config.column = {


### PR DESCRIPTION
docs: retire the orphaned phase vocabulary and gate citation rot

`docs/development/column-view.md` — the phased implementation plan the v4 column
view was built from — was deleted in faa1b1f once the work shipped. AGENTS.md was
updated in the same era and no other file referenced the retired document, so the
deletion looked complete. It was not: nineteen references to its phases survived
in four test files, still written in the future tense about work that had already
landed. A reader following "Phase 1 extracts the list's leaf renderers" or "Phase 2
will cut the seam" would go looking for a plan that no longer exists.

The same refactor left a second kind of debris. Comments that cited `file.ts:NNN`
were accurate when written and rotted the moment the code moved. `render.ts` went
from roughly a thousand lines to five hundred when the leaf renderers were lifted
into `leaves.ts`, and six citations across the test suite were left pointing past
the end of the file they named — one of them at a README line four times beyond
that file's length. Several more stayed in range but landed on unrelated content:
a citation meant for the column defaults table pointed at a bare JSDoc asterisk,
and one meant for the API call pointed at a date parser.

Nothing failed, in either case, because no tool reads prose.

The vocabulary is now gone: `grep -rn "Phase [0-9]" src tests` returns nothing.
Every stale citation is replaced with the symbol it meant — `renderDateWeather` in
`leaves.ts`, `buildEventPresentation` in `presentation.ts`, `COLUMN_DEFAULT_OVERRIDES`
in `view.ts` — which is greppable, survives edits above it, and tells the reader what
to look for rather than where it used to sit.

Check 25 in `check:docs` stops this recurring. It flags any comment citation whose
line number exceeds the length of the file it names, across `src`, `tests`, `scripts`,
`docs`, README, AGENTS.md and CONTRIBUTING.md. It deliberately does not ban numeric
citations outright: references that quote a released tag, such as `v3.6.0 leaves.ts:324`,
name an immutable artifact and are exempt, as are recorded measurement tables. The check
caught a beyond-EOF citation inside its own explanatory comment on its first run, and
again in the AGENTS.md paragraph written to describe it; both were rephrased. Five
planted mutations confirm it: beyond-EOF citations naming a `.ts`, a `.md` and the
README are each caught, an in-range citation produces no error, and a citation carrying
a release tag is correctly ignored.

Three smaller leftovers ride along. `docs/features/weather.md` still described weather
placement in list-view terms — "date column", "event column", "left side" — fifteen
times, while `docs/features/theming.md` already described the same three custom
properties as belonging to "the day header". Two pages disagreed about where the same
pixels are drawn. The weather wording now matches theming's; `date_vertical_alignment`
keeps "date column" because that option genuinely is list-only. `docs/architecture.md`
listed fourteen of the fifteen editor-root modules, omitting `version.ts`. And a test
set `weather.event.show_high_temp`, which the event scope never reads — the union type
let it compile, and the unchanged DOM snapshot proves it was inert.

Comment- and docs-only apart from one deleted changelog note on a type member, so no
release-notes entry.
