### PR TITLE
test: cover the per-event weather forecast matching algorithm

### DIFF
--- a/tests/weather-forecast-matching.test.ts
+++ b/tests/weather-forecast-matching.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Forecast processing and per-event forecast matching.
+ *
+ * `findForecastForEvent` is how every event row gets its weather. When no hourly
+ * forecast exists for the event's own hour it walks the day's forecasts and picks
+ * the nearest one, and that walk had no direct coverage at all: no test called
+ * `findForecastForEvent` or `findDailyForecast`, and the rendering snapshots only
+ * ever exercised the exact-hour match. Eleven separate mutations of the matching
+ * loop and the processing step survived the entire suite, including seeding the
+ * distance at zero (which disables the nearest-hour fallback outright), dropping
+ * `Math.abs` (which makes the earliest hour of the day always win), and reading
+ * the date instead of the hour out of the composite key.
+ *
+ * The failure mode is quiet in all of them — the row falls back to the daily
+ * forecast or renders no weather, rather than throwing.
+ *
+ * Controls are paired with every assertion: the exact-match case proves the walk
+ * is only reached when it should be, the same-day case proves the day filter is
+ * doing work rather than the lookup happening to miss, and the daily-fallback
+ * pair proves a returned `undefined` is a real miss and not a disabled lookup.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import * as Types from '../src/config/types';
+import * as WeatherUtils from '../src/utils/weather';
+
+/**
+ * Drive forecast entries through the real subscription path.
+ *
+ * `processForecastData` is private, and the subscription is its only caller, so
+ * this is the honest entry point rather than a reimplementation of the keying.
+ *
+ * @param entries - Raw Home Assistant forecast entries
+ * @param forecastType - Which forecast stream to process
+ * @returns The processed record, keyed as the card keys it
+ */
+async function process(
+  entries: Array<Partial<Types.WeatherForecast>>,
+  forecastType: 'daily' | 'hourly',
+): Promise<Record<string, Types.WeatherData>> {
+  let handler: ((message: { forecast: Array<Types.WeatherForecast> }) => void) | undefined;
+
+  const hass = {
+    connection: {
+      subscribeMessage: async (
+        callback: (message: { forecast: Array<Types.WeatherForecast> }) => void,
+      ) => {
+        handler = callback;
+        return () => undefined;
+      },
+    },
+  } as unknown as Types.Hass;
+
+  const config = { weather: { entity: 'weather.home' } } as unknown as Types.Config;
+
+  let received: Record<string, Types.WeatherData> = {};
+  await WeatherUtils.subscribeToWeatherForecast(hass, config, forecastType, (forecasts) => {
+    received = forecasts;
+  });
+
+  handler?.({ forecast: entries as Array<Types.WeatherForecast> });
+
+  return received;
+}
+
+/**
+ * Build an hourly forecast entry on 2026-06-17 at a given local hour.
+ *
+ * @param hour - Local hour of day
+ * @param condition - Condition code, used as the identity of the entry
+ * @param day - Day of month, for the cross-day control
+ * @returns A raw forecast entry
+ */
+function hourly(hour: number, condition: string, day = 17): Partial<Types.WeatherForecast> {
+  return {
+    datetime: new Date(2026, 5, day, hour, 0, 0).toISOString(),
+    condition,
+    temperature: 10,
+  };
+}
+
+/**
+ * Build a timed calendar event on 2026-06-17 at a given local hour.
+ *
+ * @param hour - Local hour of day
+ * @returns A calendar event with a timed start
+ */
+function timedEvent(hour: number): Types.CalendarEventData {
+  return {
+    start: { dateTime: new Date(2026, 5, 17, hour, 0, 0).toISOString() },
+    end: { dateTime: new Date(2026, 5, 17, hour + 1, 0, 0).toISOString() },
+  } as Types.CalendarEventData;
+}
+
+describe('hourly forecast matching', () => {
+  it('prefers the forecast for the event hour over any neighbour', async () => {
+    const forecasts = await process([hourly(12, 'sunny'), hourly(14, 'rainy')], 'hourly');
+
+    expect(WeatherUtils.findForecastForEvent(timedEvent(12), forecasts)?.condition).toBe('sunny');
+  });
+
+  it('falls back to the nearest hour of the same day', async () => {
+    const forecasts = await process([hourly(9, 'sunny'), hourly(15, 'rainy')], 'hourly');
+
+    expect(WeatherUtils.findForecastForEvent(timedEvent(14), forecasts)?.condition).toBe('rainy');
+  });
+
+  it('measures distance in both directions, not only backwards', async () => {
+    // 06:00 is twelve hours before the event, 20:00 is two hours after it. A
+    // signed comparison makes the earliest hour of the day win every time.
+    const forecasts = await process([hourly(6, 'sunny'), hourly(20, 'rainy')], 'hourly');
+
+    expect(WeatherUtils.findForecastForEvent(timedEvent(18), forecasts)?.condition).toBe('rainy');
+  });
+
+  it('resolves an equal-distance tie to the earlier hour', async () => {
+    const forecasts = await process([hourly(11, 'sunny'), hourly(13, 'rainy')], 'hourly');
+
+    expect(WeatherUtils.findForecastForEvent(timedEvent(12), forecasts)?.condition).toBe('sunny');
+  });
+
+  it('accepts midnight as the nearest hour', async () => {
+    // Hour zero is the one hour a truthiness check on the index would discard.
+    const forecasts = await process([hourly(0, 'sunny')], 'hourly');
+
+    expect(WeatherUtils.findForecastForEvent(timedEvent(3), forecasts)?.condition).toBe('sunny');
+  });
+
+  it('never borrows a nearer hour from a neighbouring day', async () => {
+    // 19:00 on the 18th is one hour from the event by clock time and would win
+    // outright if the day were not part of the key comparison; 06:00 on the
+    // event's own day is twelve hours away and is the correct answer.
+    const forecasts = await process([hourly(6, 'sunny'), hourly(19, 'rainy', 18)], 'hourly');
+
+    expect(WeatherUtils.findForecastForEvent(timedEvent(18), forecasts)?.condition).toBe('sunny');
+  });
+});
+
+describe('daily forecast lookup', () => {
+  it('returns the entry for the requested local day', async () => {
+    const forecasts = await process(
+      [
+        {
+          datetime: new Date(2026, 5, 17, 12, 0, 0).toISOString(),
+          condition: 'sunny',
+          temperature: 10,
+        },
+        {
+          datetime: new Date(2026, 5, 18, 12, 0, 0).toISOString(),
+          condition: 'rainy',
+          temperature: 10,
+        },
+      ],
+      'daily',
+    );
+
+    expect(WeatherUtils.findDailyForecast(new Date(2026, 5, 17), forecasts)?.condition).toBe(
+      'sunny',
+    );
+    expect(WeatherUtils.findDailyForecast(new Date(2026, 5, 19), forecasts)).toBeUndefined();
+  });
+
+  it('serves all-day events from the daily forecast', async () => {
+    const forecasts = await process(
+      [
+        {
+          datetime: new Date(2026, 5, 17, 12, 0, 0).toISOString(),
+          condition: 'snowy',
+          temperature: 10,
+        },
+      ],
+      'daily',
+    );
+
+    const allDay = {
+      start: { date: '2026-06-17' },
+      end: { date: '2026-06-18' },
+    } as Types.CalendarEventData;
+
+    expect(WeatherUtils.findForecastForEvent(allDay, {}, forecasts)?.condition).toBe('snowy');
+  });
+
+  it('only lets a timed event fall back to the daily forecast when asked to', async () => {
+    const daily = await process(
+      [
+        {
+          datetime: new Date(2026, 5, 17, 12, 0, 0).toISOString(),
+          condition: 'cloudy',
+          temperature: 10,
+        },
+      ],
+      'daily',
+    );
+
+    expect(WeatherUtils.findForecastForEvent(timedEvent(9), {}, daily)).toBeUndefined();
+    expect(WeatherUtils.findForecastForEvent(timedEvent(9), {}, daily, true)?.condition).toBe(
+      'cloudy',
+    );
+  });
+});
+
+describe('forecast processing', () => {
+  it('rounds the numeric fields rather than truncating them', async () => {
+    const forecasts = await process(
+      [
+        {
+          datetime: new Date(2026, 5, 17, 12, 0, 0).toISOString(),
+          condition: 'sunny',
+          temperature: 21.6,
+          templow: 8.5,
+          uv_index: 4.6,
+        },
+      ],
+      'hourly',
+    );
+
+    const entry = Object.values(forecasts)[0];
+    expect(entry.temperature).toBe(22);
+    expect(entry.templow).toBe(9);
+    expect(entry.uv_index).toBe(5);
+  });
+
+  it('skips entries with no timestamp instead of keying them as invalid', async () => {
+    const forecasts = await process(
+      [{ condition: 'sunny', temperature: 10 }, hourly(12, 'rainy')],
+      'hourly',
+    );
+
+    expect(Object.keys(forecasts)).toEqual(['2026-06-17_12']);
+  });
+});

--- a/tests/weather-hourly-key.dst.test.ts
+++ b/tests/weather-hourly-key.dst.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Hourly forecast keys are built from the local hour.
+ *
+ * `processForecastData` keys each hourly entry `YYYY-MM-DD_H`, and
+ * `findForecastForEvent` looks it up with the event's local hour. Both sides
+ * have to agree on which clock they read, and the whole unit suite runs pinned
+ * to UTC, where `getHours` and `getUTCHours` are the same function. Swapping one
+ * for the other survived every UTC assertion.
+ *
+ * Under a real zone the two differ by the offset, so every hourly lookup would
+ * miss its exact match and quietly settle for whichever neighbouring hour the
+ * nearest-hour walk happened to land on — a forecast for the wrong time of day
+ * rendered with no error.
+ *
+ * The date half of the key is asserted alongside the hour as the control: it is
+ * local in both implementations, so a passing date with a failing hour proves
+ * the entry was processed rather than dropped.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import * as Types from '../src/config/types';
+import * as WeatherUtils from '../src/utils/weather';
+
+describe(`hourly forecast keys under ${process.env.TZ}`, () => {
+  it('is not running under UTC', () => {
+    expect(process.env.TZ).toBeDefined();
+    expect(process.env.TZ).not.toBe('UTC');
+  });
+
+  it('keys and matches on the local hour, not the UTC hour', async () => {
+    let handler: ((message: { forecast: Array<Types.WeatherForecast> }) => void) | undefined;
+
+    const hass = {
+      connection: {
+        subscribeMessage: async (
+          callback: (message: { forecast: Array<Types.WeatherForecast> }) => void,
+        ) => {
+          handler = callback;
+          return () => undefined;
+        },
+      },
+    } as unknown as Types.Hass;
+
+    const config = { weather: { entity: 'weather.home' } } as unknown as Types.Config;
+
+    let forecasts: Record<string, Types.WeatherData> = {};
+    await WeatherUtils.subscribeToWeatherForecast(hass, config, 'hourly', (received) => {
+      forecasts = received;
+    });
+
+    // 14:00 local on a summer date, so every zone in the matrix carries a
+    // non-zero offset and the local and UTC hours cannot coincide.
+    handler?.({
+      forecast: [
+        {
+          datetime: new Date(2026, 5, 17, 14, 0, 0).toISOString(),
+          condition: 'sunny',
+          temperature: 10,
+        },
+      ] as Array<Types.WeatherForecast>,
+    });
+
+    expect(Object.keys(forecasts)).toEqual(['2026-06-17_14']);
+    expect(Object.values(forecasts)[0].hour).toBe(14);
+
+    const event = {
+      start: { dateTime: new Date(2026, 5, 17, 14, 0, 0).toISOString() },
+      end: { dateTime: new Date(2026, 5, 17, 15, 0, 0).toISOString() },
+    } as Types.CalendarEventData;
+
+    expect(WeatherUtils.findForecastForEvent(event, forecasts)?.condition).toBe('sunny');
+  });
+});


### PR DESCRIPTION
test: cover the per-event weather forecast matching algorithm

Every event row that shows weather gets it from findForecastForEvent. When
the hourly forecast has no entry for the event's own hour, that function walks
the day's forecasts and picks the nearest one. That walk had no direct test
coverage of any kind: no test in the suite called findForecastForEvent or
findDailyForecast, and the rendering snapshots that reach them only ever
supplied a forecast for the exact hour, so the fallback path never ran.

A fifteen-mutation sweep of src/utils/weather.ts killed two mutants and left
thirteen alive. Eleven were genuine coverage gaps, all of them silent in
production — a broken match returns the daily forecast or nothing at all
rather than throwing, so the row simply shows the wrong weather or none:

  - seeding the distance at 0 instead of 24 disables the nearest-hour
    fallback outright, so any event without an exact hourly match loses its
    forecast
  - reading index 0 instead of 1 out of the YYYY-MM-DD_H key parses the year,
    which is never below the distance seed, disabling the fallback the same way
  - dropping Math.abs makes the distance signed, so the earliest hour of the
    day always wins regardless of how far it is from the event
  - loosening the strict comparison flips every equal-distance tie to the
    later hour
  - dropping the day prefix from the key comparison lets an event borrow a
    nearer hour from a neighbouring day
  - requiring the matched hour to be greater than zero discards midnight,
    the one hour a truthiness check cannot represent
  - reading UTC hours instead of local hours when building the key, which the
    UTC-pinned unit suite structurally cannot observe
  - truncating instead of rounding temperature, templow and uv_index

tests/weather-forecast-matching.test.ts covers the ten that UTC can see, and
tests/weather-hourly-key.dst.test.ts covers the local-hour keying under the
three real zones the DST projects run. Each assertion was falsified by
re-applying its own mutation; all thirteen now fail.

The two remaining survivors are redundancies rather than gaps and were
deliberately left untested. The Array.isArray guard inside processForecastData
is unreachable because its only caller already checks Array.isArray on the
same value before calling it. The !event.start.dateTime condition in the
all-day branch is unreachable because no construction in src/ sets both date
and dateTime on an event start, and Home Assistant sends one or the other.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6c7714fb-9c18-4995-9aaa-129fa9eb7a53
