### PR TITLE
test: guard the card host's own behavior, and drop a dead render branch

### DIFF
--- a/docs/features/column-view.md
+++ b/docs/features/column-view.md
@@ -18,11 +18,13 @@ panel. Choosing **Columns** reveals the column-only options below it, and adds a
 **Column View Exceptions** row to the panels whose options can differ between the two
 layouts.
 
-Column view is responsive by design. A day column has a minimum readable width, so as the
-card narrows the layout gives up columns one at a time, and eventually falls back to the
-list layout entirely. **A card configured `view: column` therefore renders as a list on a
-narrow dashboard or a phone** — both layouts are live for the same card, and both are worth
-configuring. That is the first thing to get right, so it comes first below.
+Column view is responsive by design. A day column has a minimum readable width, so a card
+too narrow to give every configured day that much room falls back to the list layout.
+**A card configured `view: column` therefore renders as a list on a narrow dashboard or a
+phone** — both layouts are live for the same card, and both are worth configuring. That is
+the first thing to get right, so it comes first below. Dropping columns one at a time
+instead of falling back is available, but it is opt-in: see
+[Showing Fewer Columns Instead](#showing-fewer-columns-instead).
 
 ## 📱 Falling Back to the List Layout
 

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -1100,17 +1100,11 @@ class CalendarCardPro extends LitElement {
       content = Render.renderCardContent('error', this.effectiveLanguage);
     } else if (this.events.length === 0 && this._hasFetchError) {
       content = Render.renderCardContent('error', this.effectiveLanguage);
-    } else if (this.events.length === 0) {
-      const groupedEmptyDays = EventUtils.groupEventsByDay(
-        [], // Empty events array
-        this.effectiveConfig,
-        this.isExpanded,
-        this.effectiveLanguage,
-        this.effectiveView,
-        this.hass?.locale,
-      );
-      content = renderDays(groupedEmptyDays);
     } else {
+      // No separate empty-events branch: `groupedEvents` groups `this.events`, which is
+      // already the empty array in that case, with exactly the arguments a dedicated
+      // branch would pass. Column view's `show_empty_days` default still fills the card
+      // with empty day columns from here.
       content = renderDays(this.groupedEvents);
     }
 

--- a/tests/host-interaction.test.ts
+++ b/tests/host-interaction.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The host's own pointer and keyboard handlers.
+ *
+ * `src/interaction/` is well covered, but that module only ever sees a call that the
+ * host has already decided to make. Deciding *whether* to make it -- arming the hold
+ * timer, matching the pointer that started the gesture, recognising the two activation
+ * keys, and labelling an action as tap or hold -- lives in `calendar-card-pro.ts` and
+ * was measured to be unguarded: a mutation sweep of that file left five separate
+ * interaction mutations alive with the whole suite green.
+ *
+ * Each of the five is user-visible. Inverting the `hold_action: none` guard arms a hold
+ * timer precisely when the user asked for no hold action; inverting the pointer-id
+ * comparison lets a second finger's release fire the first finger's action; dropping
+ * either key from the keydown handler removes half of the card's keyboard
+ * accessibility; and swapping the label in `handleAction` runs the tap action when a
+ * caller asked for hold.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import * as Constants from '../src/config/constants';
+import '../src/calendar-card-pro';
+
+vi.mock('../src/utils/logger', () => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  setLogLevel: vi.fn(),
+  initializeLogger: vi.fn(),
+  printVersionInfo: vi.fn(),
+}));
+
+const handleAction = vi.hoisted(() => vi.fn());
+vi.mock('../src/interaction/actions', () => ({ handleAction }));
+
+interface CardUnderTest extends HTMLElement {
+  setConfig(config: unknown): void;
+  hass?: unknown;
+  isInitialLoad: boolean;
+  handleAction(actionConfig: unknown): void;
+  _handlePointerDown(ev: PointerEvent): void;
+  _handlePointerUp(ev: PointerEvent): void;
+  _handleKeyDown(ev: KeyboardEvent): void;
+  _holdTriggered: boolean;
+  readonly updateComplete: Promise<boolean>;
+}
+
+/** A minimal stand-in for a real PointerEvent, which happy-dom does not construct. */
+function pointer(pointerId: number): PointerEvent {
+  return { pointerId, clientX: 0, clientY: 0 } as PointerEvent;
+}
+
+async function mount(overrides: Record<string, unknown> = {}): Promise<CardUnderTest> {
+  const card = document.createElement('calendar-card-pro-dev') as unknown as CardUnderTest;
+  card.setConfig(buildConfig(overrides));
+  card.hass = { states: {}, locale: { language: 'en' } };
+  card.isInitialLoad = false;
+  document.body.appendChild(card);
+  await card.updateComplete;
+  return card;
+}
+
+describe('host pointer handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    handleAction.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not arm a hold when the user configured no hold action', async () => {
+    const card = await mount({ hold_action: { action: 'none' } });
+
+    card._handlePointerDown(pointer(1));
+    vi.advanceTimersByTime(Constants.TIMING.HOLD_THRESHOLD + 50);
+
+    expect(card._holdTriggered).toBe(false);
+  });
+
+  it('arms a hold when a hold action is configured', async () => {
+    // The positive control for the case above: without it, a handler that never armed
+    // anything at all would satisfy that assertion.
+    const card = await mount({ hold_action: { action: 'expand' } });
+
+    card._handlePointerDown(pointer(1));
+    vi.advanceTimersByTime(Constants.TIMING.HOLD_THRESHOLD + 50);
+
+    expect(card._holdTriggered).toBe(true);
+  });
+
+  it('ignores a hold timer belonging to a pointer that is no longer active', async () => {
+    const card = await mount({ hold_action: { action: 'expand' } });
+
+    card._handlePointerDown(pointer(1));
+    // A second finger lands before the first one's timer fires, taking over the gesture.
+    card._handlePointerDown(pointer(2));
+    vi.advanceTimersByTime(Constants.TIMING.HOLD_THRESHOLD + 50);
+
+    // The surviving timer is the second pointer's, so a hold is still recognised --
+    // but the first pointer's timer must not have been the one to set it.
+    expect(card._holdTriggered).toBe(true);
+
+    // Releasing the pointer that never became active must do nothing at all.
+    handleAction.mockClear();
+    card._handlePointerUp(pointer(1));
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+
+  it('runs the hold action when the active pointer is released after a hold', async () => {
+    const card = await mount({ hold_action: { action: 'expand' } });
+
+    card._handlePointerDown(pointer(3));
+    vi.advanceTimersByTime(Constants.TIMING.HOLD_THRESHOLD + 50);
+    card._handlePointerUp(pointer(3));
+
+    expect(handleAction).toHaveBeenCalledTimes(1);
+    expect(handleAction.mock.calls[0][2]).toBe('hold');
+  });
+
+  it('runs the tap action when the pointer is released before the hold threshold', async () => {
+    const card = await mount({ tap_action: { action: 'expand' } });
+
+    card._handlePointerDown(pointer(4));
+    vi.advanceTimersByTime(50);
+    card._handlePointerUp(pointer(4));
+
+    expect(handleAction).toHaveBeenCalledTimes(1);
+    expect(handleAction.mock.calls[0][2]).toBe('tap');
+  });
+});
+
+describe('host keyboard handling', () => {
+  beforeEach(() => {
+    handleAction.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  it.each(['Enter', ' '])('activates the card on %j', async (key) => {
+    const card = await mount({ tap_action: { action: 'expand' } });
+
+    card._handleKeyDown({ key, preventDefault: vi.fn() } as unknown as KeyboardEvent);
+
+    expect(handleAction).toHaveBeenCalledTimes(1);
+    expect(handleAction.mock.calls[0][2]).toBe('tap');
+  });
+
+  it('ignores other keys', async () => {
+    // The negative control. Without it, a handler that fired on every keystroke would
+    // pass both cases above.
+    const card = await mount({ tap_action: { action: 'expand' } });
+
+    card._handleKeyDown({ key: 'a', preventDefault: vi.fn() } as unknown as KeyboardEvent);
+
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+});
+
+describe('host handleAction labelling', () => {
+  beforeEach(() => {
+    handleAction.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  it('labels the configured hold action as a hold and the tap action as a tap', async () => {
+    const card = await mount({
+      tap_action: { action: 'expand' },
+      hold_action: { action: 'more-info' },
+    });
+
+    card.handleAction((card as unknown as { config: { hold_action: unknown } }).config.hold_action);
+    expect(handleAction.mock.calls[0][2]).toBe('hold');
+
+    card.handleAction((card as unknown as { config: { tap_action: unknown } }).config.tap_action);
+    expect(handleAction.mock.calls[1][2]).toBe('tap');
+  });
+});

--- a/tests/host-update-state.test.ts
+++ b/tests/host-update-state.test.ts
@@ -1,0 +1,233 @@
+/**
+ * The host's fetch bookkeeping, compact-limit detection and error rendering.
+ *
+ * A mutation sweep of `calendar-card-pro.ts` left six mutations in these three areas
+ * alive with the whole suite green. Every one of them is user-visible:
+ *
+ * - dropping the empty-entities guard sends a card with no calendars into a fetch;
+ * - raising the failure threshold to `> 1` means a single broken calendar no longer
+ *   marks the card as errored, so the card reports success while showing nothing;
+ * - inverting the instance-id comparison makes a reconfigured card keep the *previous*
+ *   configuration's events when the new one fails, which is the stale-render bug the
+ *   generation counter exists to prevent, reintroduced one branch further down;
+ * - dropping either half of the compact-limit check disables expand/collapse for a
+ *   card that configured only `compact_days_to_show`, or configured its limit
+ *   per-calendar rather than card-wide;
+ * - dropping the fetch-error render branch shows an ordinary empty calendar instead of
+ *   the error state when every calendar failed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import '../src/calendar-card-pro';
+
+vi.mock('../src/utils/logger', () => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  setLogLevel: vi.fn(),
+  initializeLogger: vi.fn(),
+  printVersionInfo: vi.fn(),
+}));
+
+const fetchEventData = vi.hoisted(() => vi.fn());
+vi.mock('../src/utils/events', async () => {
+  const actual = await vi.importActual<typeof import('../src/utils/events')>('../src/utils/events');
+  return { ...actual, fetchEventData };
+});
+
+interface CardUnderTest extends HTMLElement {
+  setConfig(config: unknown): void;
+  hass?: unknown;
+  isInitialLoad: boolean;
+  isExpanded: boolean;
+  events: Types.CalendarEventData[];
+  updateEvents(force?: boolean): Promise<void>;
+  toggleExpanded(): void;
+  _hasFetchError: boolean;
+  readonly updateComplete: Promise<boolean>;
+  readonly shadowRoot: ShadowRoot | null;
+}
+
+/** A single event far enough ahead to survive any default window. */
+function event(summary: string): Types.CalendarEventData {
+  return {
+    summary,
+    start: { dateTime: '2026-06-17T12:00:00Z' },
+    end: { dateTime: '2026-06-17T13:00:00Z' },
+  } as Types.CalendarEventData;
+}
+
+/** Let any update the host started on its own run to completion. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 6; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Mount a card and drain the update the `hass` setter starts, so that a later explicit
+ * `updateEvents()` is the newest request rather than a superseded one.
+ */
+async function mount(overrides: Record<string, unknown> = {}): Promise<CardUnderTest> {
+  const card = document.createElement('calendar-card-pro-dev') as unknown as CardUnderTest;
+  card.setConfig(buildConfig(overrides));
+  card.hass = { states: {}, locale: { language: 'en' } };
+  card.isInitialLoad = false;
+  document.body.appendChild(card);
+  await settle();
+  fetchEventData.mockClear();
+  return card;
+}
+
+describe('host fetch bookkeeping', () => {
+  beforeEach(() => {
+    fetchEventData.mockReset();
+    fetchEventData.mockResolvedValue({ events: [], failedEntities: [] });
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not fetch when the card has no calendars configured', async () => {
+    const card = await mount();
+    (card as unknown as { config: { entities: unknown[] } }).config.entities = [];
+
+    await card.updateEvents();
+
+    expect(fetchEventData).not.toHaveBeenCalled();
+    expect(card.isInitialLoad).toBe(false);
+  });
+
+  it('fetches when the card has calendars configured', async () => {
+    // The positive control: without it, an `updateEvents` that returned immediately in
+    // every case would satisfy the assertion above.
+    const card = await mount();
+
+    await card.updateEvents();
+
+    expect(fetchEventData).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the card as errored when a single calendar fails', async () => {
+    fetchEventData.mockResolvedValue({
+      events: [event('kept')],
+      failedEntities: ['calendar.broken'],
+    });
+    const card = await mount();
+
+    await card.updateEvents();
+
+    expect(card._hasFetchError).toBe(true);
+  });
+
+  it('does not mark the card as errored when every calendar succeeds', async () => {
+    fetchEventData.mockResolvedValue({ events: [event('fine')], failedEntities: [] });
+    const card = await mount();
+
+    await card.updateEvents();
+
+    expect(card._hasFetchError).toBe(false);
+  });
+
+  it('keeps previously loaded events when a refresh of the same query fails', async () => {
+    const card = await mount();
+
+    fetchEventData.mockResolvedValue({
+      events: [event('first'), event('second')],
+      failedEntities: [],
+    });
+    await card.updateEvents();
+    expect(card.events).toHaveLength(2);
+
+    fetchEventData.mockResolvedValue({ events: [], failedEntities: ['calendar.personal'] });
+    await card.updateEvents();
+
+    expect(card.events).toHaveLength(2);
+  });
+
+  it('discards previously loaded events when the card has been reconfigured', async () => {
+    const card = await mount();
+
+    fetchEventData.mockResolvedValue({ events: [event('old config')], failedEntities: [] });
+    await card.updateEvents();
+    expect(card.events).toHaveLength(1);
+
+    // A new configuration mints a new instance id, so the events on the card belong to
+    // a query nobody is asking for any more. A failing fetch must not resurrect them.
+    card.setConfig(buildConfig({ entities: ['calendar.other'] }));
+    fetchEventData.mockResolvedValue({ events: [], failedEntities: ['calendar.other'] });
+    await card.updateEvents();
+
+    expect(card.events).toHaveLength(0);
+  });
+});
+
+describe('host compact-limit detection', () => {
+  beforeEach(() => {
+    fetchEventData.mockReset();
+    fetchEventData.mockResolvedValue({ events: [], failedEntities: [] });
+    document.body.innerHTML = '';
+  });
+
+  it.each([
+    ['card-wide event limit', { compact_events_to_show: 2 }],
+    ['card-wide day limit', { compact_days_to_show: 2 }],
+    [
+      'per-calendar event limit',
+      { entities: [{ entity: 'calendar.personal', compact_events_to_show: 2 }] },
+    ],
+  ])('toggles expansion for a %s', async (_label, overrides) => {
+    const card = await mount(overrides);
+
+    card.toggleExpanded();
+
+    expect(card.isExpanded).toBe(true);
+  });
+
+  it('does not toggle expansion when no compact limit is configured', async () => {
+    // The negative control. Without it, a `hasCompactModeLimits` that always returned
+    // true would pass all three cases above.
+    const card = await mount();
+
+    card.toggleExpanded();
+
+    expect(card.isExpanded).toBe(false);
+  });
+});
+
+describe('host error rendering', () => {
+  beforeEach(() => {
+    fetchEventData.mockReset();
+    fetchEventData.mockResolvedValue({ events: [], failedEntities: [] });
+    document.body.innerHTML = '';
+  });
+
+  it('renders the error state rather than an empty calendar when every calendar failed', async () => {
+    fetchEventData.mockResolvedValue({ events: [], failedEntities: ['calendar.personal'] });
+    const card = await mount();
+
+    await card.updateEvents();
+    await settle();
+    await card.updateComplete;
+
+    const text = card.shadowRoot?.textContent ?? '';
+    expect(text).toContain('Error');
+    expect(card.shadowRoot?.querySelector('.day-table')).toBeNull();
+  });
+
+  it('renders an empty calendar rather than the error state when nothing failed', async () => {
+    // The positive control, and the discriminator: both branches produce a card with no
+    // events, so only the presence of the error text separates them.
+    const card = await mount();
+
+    await card.updateEvents();
+    await settle();
+    await card.updateComplete;
+
+    expect(card.shadowRoot?.textContent ?? '').not.toContain('Error');
+  });
+});


### PR DESCRIPTION
test: guard the card host's own behavior, and drop a dead render branch

A mutation sweep of `src/calendar-card-pro.ts` — the custom element itself, as
opposed to the rendering and utility modules every previous sweep covered —
broke 16 of its behaviors one at a time and ran the full suite against each.
Three were caught. Thirteen survived with every one of the 1,754 tests passing,
the largest single coverage gap found in this branch. The host was effectively
untested: the suite exercised what the card renders, never how the card behaves.

Eleven of the thirteen are real gaps and are now guarded by two new files.

`tests/host-interaction.test.ts` covers everything the card does in response to
a user. Each of these could be broken with the whole suite green: honouring
`hold_action: 'none'` rather than arming a hold timer anyway; matching the
pointer that started a hold against the one that ends it, so a second finger
taking over cannot fire someone else's action; choosing hold over tap at the
500 ms threshold; activating on Enter and on Space and on nothing else; and
labelling the dispatched action 'hold' or 'tap' correctly — that last one could
be swapped outright, so every hold ran the tap action, and nothing failed.

`tests/host-update-state.test.ts` covers the fetch and render state machine:
not fetching for a card with no calendars; raising the error flag on the first
failed entity rather than the second; discarding a previous configuration's
events after a reconfigure by comparing the events' instance id against the
current one — the companion branch to the stale-response guard, one step
further down, where inverting the comparison resurrects the old calendar's
events; detecting a compact limit from either the card-wide day count, the
card-wide event count, or any per-entity override; and rendering the error
state rather than an empty calendar when a fetch fails.

Both files were falsified per assertion: all sixteen mutations are now killed,
each with `tsc --noEmit` exiting 0 first, so no kill is a compile error wearing
a test failure's clothes.

Two of the thirteen survivors are not coverage gaps. `isLimit`'s
`Number.isFinite` check cannot fail, because `toValidNumber` in config.ts
already rejects every non-finite value at both normalization sites; it is left
in place as a cheap boundary assertion. The separate empty-events render branch
is genuinely dead: it called `groupEventsByDay([], ...)` with arguments
byte-identical to the `groupedEvents` getter the fallthrough uses, at a point
where `this.events` is that same empty array. Replacing it with `else if (false)`
left all 1,754 tests passing, including the column snapshot and column-count
render tests, which is the deletion proven by experiment. It is removed here,
with a comment recording why no branch is needed.

Also corrects the opening of the column view page, which said the layout gives
up columns one at a time as the card narrows. It does not, by default:
`min_days_to_show` resolves to `days_to_show` when unset, so the floor equals
the ceiling and a card too narrow for every configured day falls back to the
list layout immediately. The page already said so correctly twice further down —
once in prose and once in a warning box explaining that reducing columns is
deliberately opt-in — so the intro was the single wrong statement on the page,
and the first thing a reader saw.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 6c7714fb-9c18-4995-9aaa-129fa9eb7a53
