### PR TITLE
fix: retarget three dead README links and correct the stale CSS-comment figures

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,4 +42,4 @@ This PR fixes or closes issue: fixes #
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have tested the change in my local Home Assistant instance.
-- [ ] I have followed [the translation guidelines](https://github.com/alexpfau/calendar-card-pro#adding-translations) if I'm adding or updating a translation.
+- [ ] I have followed [the translation guidelines](https://calendar-card-pro.alexpfau.com/contributing#adding-translations) if I'm adding or updating a translation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -966,9 +966,9 @@ export function getView(config: Config): View {
 
 **Comment the stylesheets as freely as the TypeScript.** A `css` tagged template's contents
 are a string literal, so no minifier looks inside one — comments there used to ship to every
-user, and 65% of the stylesheet was comment. That is fixed at build time by the
+user, and 46% of the stylesheet was comment. That is fixed at build time by the
 `strip-css-comments` plugin in `rollup.config.mjs`, which removes them from both
-`rendering/styles.ts` and `rendering/editor/styles.ts` and cost 29,264 raw / 10,879 gzip
+`rendering/styles.ts` and `rendering/editor/styles.ts` and cost 15,214 raw / 5,889 gzip
 bytes off the eager path when it landed.
 
 This is worth stating because the alternative is worse than it looks: without knowing the

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -204,7 +204,7 @@ The card deliberately never hides while you are editing the dashboard, never hid
 - **Weekday Anchors** - `saturday`, or the short form `sat`, resolves to the next Saturday, counting today if today is already Saturday
 - **Composable Offsets** - `+N` / `-N` days, `+Nw` / `-Nw` weeks and `+<weekday>` / `-<weekday>` jumps combine on any anchor: `start_of_week+7`, `today+sat+7`, `monday+1w`
 
-Parsing is case-insensitive and ignores whitespace, and existing values such as a fixed `2025-07-01`, `today+7` and `+3` behave exactly as before. The README has worked examples of every anchor and offset combination — see [Start Date Configuration](https://github.com/alexpfau/calendar-card-pro#-start-date-configuration) (#296, #276, #193)
+Parsing is case-insensitive and ignores whitespace, and existing values such as a fixed `2025-07-01`, `today+7` and `+3` behave exactly as before. The documentation has worked examples of every anchor and offset combination — see [Start Date Configuration](https://calendar-card-pro.alexpfau.com/features/start-date-offset#start-date-configuration) (#296, #276, #193)
 
 ### 🏷️ Templated Titles
 
@@ -1851,7 +1851,7 @@ A huge thank you to these contributors who made this multi-language release poss
 - **Improved localization framework**: Updated to support multiple date formatting conventions
 - **Consistent naming convention**: Language files follow standard IETF language tags
 
-Want to add your language? See the [Adding Translations](https://github.com/alexpfau/calendar-card-pro#-adding-translations) section in our README.
+Want to add your language? See the [Adding Translations](https://calendar-card-pro.alexpfau.com/contributing#adding-translations) section in the documentation.
 
 ---
 

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1475,6 +1475,7 @@ function report(counts) {
       `${counts.reachable} pages reachable from the navigation, ` +
       `${counts.themed} theme defaults documented, ` +
       `${counts.citations} line citations resolved, ` +
+      `${counts.readmeAnchors} README anchor links checked, ` +
       `release surfaces agree on v${counts.version}.\n`,
   );
 
@@ -2098,6 +2099,61 @@ function checkCitations() {
   return checked;
 }
 
+// Check 26 - no link points into our own GitHub README with a content fragment
+//
+// The README stopped being the manual in v4: it is a landing page whose sections are
+// Overview, Installation, Quick Start, What's New and Contributing, and everything it used
+// to document now lives on the docs site. Links written against the old README therefore
+// still resolve to a page — GitHub simply ignores an anchor it cannot find and drops the
+// reader at the top — so nothing is visibly broken and no check has ever looked.
+//
+// Check 16 only resolves relative links inside `docs/`, so an absolute link to our own
+// repository is outside its reach, and `.github/` metadata is not scanned at all. Three
+// links survived that way: two in the release notes and one in the pull request template.
+//
+// Rather than reimplement GitHub's heading slugger — which would have to agree with it
+// about emoji to avoid failing a release for a link that works — this bans the shape. A
+// fragment into our own README is always wrong now, because the content it named is on the
+// docs site. The bare `#readme` anchor GitHub generates for the repository landing page is
+// not a heading link and stays allowed.
+function checkReadmeFragmentLinks() {
+  const surfaces = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '.git') continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.(md|ya?ml)$/.test(entry.name)) surfaces.push(full);
+    }
+  };
+  walk(join(ROOT, '.github'));
+  walk(DOCS_DIR);
+  for (const name of ['README.md', 'CONTRIBUTING.md', 'AGENTS.md']) {
+    const full = join(ROOT, name);
+    if (existsSync(full)) surfaces.push(full);
+  }
+  assertFound(surfaces, 'documentation and metadata surfaces', ROOT);
+
+  const pattern = /https:\/\/github\.com\/alexpfau\/calendar-card-pro#([\w%-]+)/g;
+  let checked = 0;
+  for (const file of surfaces) {
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .forEach((line, i) => {
+        for (const match of line.matchAll(pattern)) {
+          checked += 1;
+          if (match[1] === 'readme') continue;
+          error(
+            `${relative(ROOT, file)}:${i + 1} links to the GitHub README anchor ` +
+              `#${match[1]}, but the README is only a landing page. Link to the ` +
+              `matching https://calendar-card-pro.alexpfau.com page instead.`,
+          );
+        }
+      });
+  }
+  return checked;
+}
+
 function main() {
   const defaults = readDefaults();
   const rows = readReferenceRows();
@@ -2128,6 +2184,7 @@ function main() {
   checkAgentsDuplication();
   checkAgentsLinks();
   const gates = checkGateLists();
+  const readmeAnchors = checkReadmeFragmentLinks();
   const version = checkReleaseVersion();
   const enums = checkEnumValues(readEnumOptions());
   const removed = checkDeprecatedTable(readDeprecatedMaps());
@@ -2150,6 +2207,7 @@ function main() {
       reachable,
       themed,
       citations,
+      readmeAnchors,
       version,
     }),
   );

--- a/tests/css-comment-strip.test.ts
+++ b/tests/css-comment-strip.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { stripComments } from '../rollup.config.mjs';
+import { cardStyles } from '../src/rendering/styles';
 
 /**
  * The build strips comments out of `css` tagged templates, because their contents are a
- * string literal that no minifier touches — 29,259 bytes raw and 10,879 gzip on the
- * eagerly-loaded card, which is 65% of the stylesheet.
+ * string literal that no minifier touches — 15,214 bytes raw and 5,889 gzip on the
+ * eagerly-loaded card, which is 46% of the stylesheet.
  *
  * That makes this function the one place in the build that edits CSS, and a bug in it
  * ships a broken stylesheet to every user with every gate still green: `stylesheet.test.ts`
@@ -71,5 +72,28 @@ describe('stripComments', () => {
   it('is idempotent', () => {
     const once = stripComments('a{color:red}/* x */\nb{color:blue}');
     expect(stripComments(once)).toBe(once);
+  });
+
+  // The figures in this file's header and in `AGENTS.md` are the reason anyone believes the
+  // plugin is worth its complexity, and until now nothing measured them. They drifted to
+  // roughly double the truth — 29,259 raw against an actual 15,214, and 65% of the sheet
+  // against an actual 46% — and disagreed with each other by five bytes, with every gate
+  // green, because a number in a comment is not checked by anything.
+  //
+  // Bands rather than exact bytes: an exact pin would fail on every edit to a CSS comment,
+  // which is precisely the thing `AGENTS.md` tells contributors to write freely. These are
+  // wide enough to survive ordinary editing and far too tight to survive the 1.9x drift
+  // that actually happened.
+  it('saves the number of bytes the documentation claims it does', () => {
+    const body = cardStyles.cssText;
+    expect(body.length).toBeGreaterThan(10_000);
+
+    const saved = body.length - stripComments(body).length;
+    const share = saved / body.length;
+
+    expect(saved).toBeGreaterThan(13_000);
+    expect(saved).toBeLessThan(18_000);
+    expect(share).toBeGreaterThan(0.4);
+    expect(share).toBeLessThan(0.55);
   });
 });


### PR DESCRIPTION
fix: retarget three dead README links and correct the stale CSS-comment figures

Two unrelated leftovers from the v4 documentation restructure, both of which
survived every gate because nothing looked at the surface they live on.

Three links pointed into our own GitHub README at anchors that no longer exist.
The README stopped being the manual in v4 — it is now a landing page whose only
sections are Overview, Installation, Quick Start, What's New and Contributing —
and everything those links named moved to the documentation site. GitHub does
not report a missing anchor: it silently drops the reader at the top of the
page, so all three still resolved to something and looked fine.

  .github/PULL_REQUEST_TEMPLATE.md  #adding-translations
  docs/RELEASE_NOTES.md             #-start-date-configuration   (v4-new)
  docs/RELEASE_NOTES.md             #-adding-translations        (pre-existing)

They now point at docs/contributing.md and docs/features/start-date-offset.md,
matching the twenty-two links the release notes already send to the docs site.
Two sentences were adjusted with them, because "the README has worked examples"
and "in our README" had also stopped being true.

check:docs never saw them. Check 16 resolves relative links inside docs/ only,
so an absolute link to our own repository is out of its reach, and .github/ is
not scanned at all — the gate reported "135 internal links resolved" and exited
0 with all three broken. Check 26 closes that: it scans docs/, .github/ and the
three root markdown files, and rejects any link into our own GitHub README that
carries a content fragment. It bans the shape rather than resolving the anchor,
because reimplementing GitHub's heading slugger well enough to agree with it
about emoji would risk failing a release over a link that works. The bare
#readme anchor GitHub generates for the repository landing page stays allowed,
and the count proves that allowance is real rather than an accident of parsing.
Each of the three links was replanted individually and each failed the gate.

Separately, the byte figures for the CSS-comment stripping plugin were wrong on
both surfaces that quote them. AGENTS.md claimed 29,264 raw / 10,879 gzip and
65% of the stylesheet; the test header claimed 29,259 / 10,879 / 65%. The two
disagreeing by five bytes is what made the drift visible, but the agreement on
10,879 was not a control — both numbers are stale. Measured two independent
ways, by diffing a build with and without the plugin and by running
stripComments over the imported CSSResult, the true saving is 15,214 raw /
5,889 gzip, which is 46% of the card stylesheet. Both figures were roughly
double the truth.

They drifted because a number written in a comment is checked by nothing. The
test now measures the saving itself and pins it in bands — wide enough to
survive ordinary editing of CSS comments, which AGENTS.md actively encourages,
and far too tight to survive the 1.9x drift that actually happened. Restoring
either stale figure fails it.
