### PR TITLE
fix(ci): align i18n placeholder gate with runtime; de-numeralise AGENTS.md falsifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,8 @@ exact spaces a fix had just removed and turned five tests red. Locate them with
 the three moved the last time someone edited a comment above them. If you find one and
 wonder whether it is still needed, it is — delete it, **run `npm run format`**, then
 `npm test`. The format step is the whole experiment: without it the directive's removal
-changes nothing and all 1237 tests pass, which reads as "safe to delete" and is not.
+changes nothing and the whole suite still passes, which reads as "safe to delete" and
+is not.
 
 **Never resolve a snapshot failure with `vitest -u`.** It launders the change past review,
 and the gate's entire value is that it is the one artefact the person doing the refactor
@@ -1052,10 +1053,12 @@ falsifier: _"delete a `prettier-ignore` in `leaves.ts`, run `npm run format`, th
 **A falsifier is itself a claim, and it can rot in two ways.** This one did both. It
 cited `leaves.ts:122`, a line that has since become three lines none of which is 122 —
 so write the `grep` that finds the site, not the number. And it omitted the `format`
-step, so anyone who ran it exactly as written saw 1237 tests pass and would reasonably
-have concluded the directive was dead. **Re-run your own falsifiers before quoting them**;
-a falsifier that no longer falsifies is worse than none, because it launders an untested
-claim as a verified one.
+step, so anyone who ran it exactly as written saw the whole suite pass and would
+reasonably have concluded the directive was dead. Note that neither sentence quotes a
+test count: an absolute total is the same rot-prone citation as a line number, and this
+one had already drifted by several hundred before anyone reading it noticed.
+**Re-run your own falsifiers before quoting them**; a falsifier that no longer falsifies
+is worse than none, because it launders an untested claim as a verified one.
 
 **Four ways a check passes while proving nothing.** Each was found here, twice, against
 different artefacts.

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -840,7 +840,15 @@ const structuralGlyphs = (text) =>
     (ch) => ch.codePointAt(0) > 127 && !/[\p{L}\p{M}]/u.test(ch) && !/["'“”‘’„«»]/u.test(ch),
   );
 
-const placeholders = (text) => (text.match(/\{[a-z_]+\}/g) ?? []).sort();
+/**
+ * Placeholders the runtime will substitute.
+ *
+ * Must mirror `interpolate()` in `src/rendering/editor/strings.ts`, which matches
+ * `/\{(\w+)\}/g`. A narrower pattern here exempts any placeholder carrying an uppercase
+ * letter or a digit from validation entirely — `{maxCount}` dropped from a translation
+ * passed this check silently until the two were reconciled.
+ */
+const placeholders = (text) => (text.match(/\{\w+\}/g) ?? []).sort();
 
 /**
  * Structural integrity, orthography and terminology, per language.


### PR DESCRIPTION
Two ungated inconsistencies found in the final reconciliation of the independent v4 review. Both are branch-only — neither shipped in a tagged release, so no release note.

## 1. `check:i18n` validated a narrower placeholder set than the runtime substitutes

`scripts/check-i18n.mjs` matched editor placeholders with `/\{[a-z_]+\}/g`, while `interpolate()` in `src/rendering/editor/strings.ts` substitutes `/\{(\w+)\}/g`.

A placeholder carrying an uppercase letter or a digit was therefore **interpolated at runtime but invisible to the gate** — dropping `{maxCount}` from a translation would render the literal text `{maxCount}` to the user and still pass CI.

Proven in both directions before changing anything, by planting into the English `EDITOR_STRINGS` value for `day_spacing`:

| Run | Plant | Regex | Exit | Verdict |
|---|---|---|---|---|
| control | lowercase `{count}` | old | **1** | gate works at all |
| test A | camelCase `{maxCount}` | old | **0** | **gap reproduced** |
| test A | camelCase `{maxCount}` | new | **1** | fix bites — 9 errors, same shape as control |
| test B | pristine source | new | **0** | summary byte-identical to baseline |

Test B matters as much as the others: `35 languages, 198 editor fields — 0 error(s), 7 warning(s)` is unchanged, so the wider pattern adds no noise.

Widening to `\w` **cannot produce false positives by construction** — `\w` is exactly what the runtime interpolates, so anything newly flagged is genuinely substituted.

The current corpus has no instance (all six placeholders are lowercase; card-side translations contain none at all). That is the normal state for a *prospective* gate, not a reason to leave it narrower than the thing it validates — the standing "no instance = null" rule governs latent weakness in shipped product code, not a check that disagrees with its own target. A JSDoc block now records the coupling so the pattern is not narrowed again.

## 2. AGENTS.md quoted a test count short by 704

Two falsifiers said "1237 tests"; the suite is **1941** (109 files).

Both sit inside the passage warning that a drifted falsifier *"launders an untested claim as a verified one"* — and whose own rule, three lines above the second occurrence, is *"write the `grep` that finds the site, not the number."*

So the count is **removed rather than bumped**. An absolute total is the same rot-prone citation as a line number, and this one had already drifted `1237 → 1316 → 1324 → 1941` over the course of this review; bumping it guarantees re-rot on the next test added. A short note now says why no number appears.

Nothing reads these numerics: `check:docs` validates AGENTS.md relative links and duplicated sentences only, and was green with the wrong figure in place.

Deliberately left alone: the "53 assets" and "66 files" figures nearby describe *third-party* repositories as point-in-time research notes, and are correctly framed as such.

## Gates

`tsc`, `lint`, `test` (109 files / 1941 tests), `check:i18n`, `check:docs`, `build`, `check:bundle` — all exit 0.