### PR TITLE
docs(agents): require a denominator on passing controls, not just nulls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1072,8 +1072,13 @@ different artefacts.
 
 **Rules that follow from those.**
 
-- **A null must prove it can be non-zero.** Print a denominator; plant a real violation and
-  confirm it is caught _before_ mutating. A mutation that changes no observable behaviour is
+- **A null must prove it can be non-zero — and so must a passing control.** Print the
+  denominator _beside_ the verdict, not as a separate step: `CONTROL x -> old:true new:true`
+  cannot expose a corpus defect, whereas the same line carrying the size of what it looked
+  at makes a short count something you catch by reading rather than by luck. Compare
+  `ls src/rendering/editor/*.ts` with `find src/rendering/editor -name '*.ts'` for a live
+  flat glob that silently drops most of a nested tree. Plant a real violation and confirm
+  it is caught _before_ mutating. A mutation that changes no observable behaviour is
   evidence about the corpus, not the code.
 - **`grep` exits 1 on no match — read the status, not the count.** `grep -c` saturates at 1
   after flattening; use `grep -o … | wc -l`.


### PR DESCRIPTION
Adopts a methodological refinement contributed by a sibling review session, after verifying the gap is real rather than a rephrasing of what AGENTS.md already says.

## The gap

`AGENTS.md:1075` read **"A null must prove it can be non-zero. Print a denominator."** That scopes the obligation to _nulls_. A control that reports a **passing verdict** is not a null, so a reader following the document exactly would not print a denominator for it — and that is precisely where two probes in this review lost their corpus.

Row 3 of the table above it (_"a probe can be correct, correctly configured, honestly reported — and measuring the wrong thing"_) does name the failure class, but prescribes _"have someone derive it a second way"_ — a second derivation. The cheaper mechanical remedy was missing.

## The two instances, both from this review

| Probe | Printed | Actual corpus | How it was caught |
| --- | --- | --- | --- |
| `days_to_show` override control | `CONTROL days_to_show -> old:true new:true` | 12 files looked at, tree holds 27 | unrelated memory of `synthetic.ts:119` contradicting it |
| `COLUMN_OVERRIDE_KEYS` block validity | `54 / 54 / 54` — all three controls passed | regex silently returned the same array twice; real answer 54 + 6 = 60 | three identical integers looked wrong |

Neither was caught by reading. Both would have been caught in one glance by a size printed beside the verdict.

## The trap is live in this repo, measured

```
ls  src/rendering/editor/*.ts          -> 15 files
find src/rendering/editor -name '*.ts' -> 27 files
DIFFER by 12
```

A flat glob over `src/rendering/editor/` silently drops **12 of 27** files — exactly the short count the first probe reported.

## Why the citation is a command pair and not a number

#507 (merged two commits ago) de-numeralised two falsifiers in this same section because _"an absolute total is the same rot-prone citation as a line number"_ — the test count had drifted 1237 → 1941. Writing "15 of 27" here would reintroduce that rot the moment a file is added to the editor tree. The command pair falsifies itself on every run and degrades gracefully: if it becomes 16 vs 28, the point still stands.

## Gates

Docs-only change to a file no code imports; `tsc`, `build` and the test suite cannot observe it. The load-bearing gates:

| Gate | Result |
| --- | --- |
| `npm run format` (prettier) | exit 0 — `proseWrap: preserve`, wrap left intact |
| `npm run lint` | exit 0 |
| `npm run check:docs` | exit 0 — this is the gate that reads AGENTS.md (relative links + duplicated sentences) |

Line widths 84–92, inside the file's existing band. Node 22.23.2, matching CI.
