### PR TITLE
docs: record why first_day_of_week is unconditionally data-changing

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -539,7 +539,17 @@ export function hasConfigChanged(
     previousEntityIds !== currentEntityIds ||
     previous.days_to_show !== current.days_to_show ||
     previous.start_date !== current.start_date ||
-    // Moves the fetch window whenever `start_date` is week-relative.
+    // Deliberately unconditional, and deliberately inconsistent with the exclusions
+    // below. `first_day_of_week` only moves the fetch window when `start_date` is
+    // week-relative; with an absolute date — or with none at all, which is the
+    // default — `getTimeWindow` returns a byte-identical window, so the refresh it
+    // triggers is waste by the very standard those exclusions set. It is kept anyway:
+    // narrowing it means re-deriving "is this start date week-relative" here, and a
+    // wrong predicate serves a stale window rather than merely re-fetching a fresh
+    // one. One avoidable request is the cheaper failure. Do not narrow this without
+    // `getBaseCacheKey` (`src/utils/events.ts`) and `generateDeterministicId`
+    // (`src/utils/helpers.ts`) in view — both were made weekday-aware to close real
+    // staleness bugs, so this is the conservative end of a settled trade-off.
     previous.first_day_of_week !== current.first_day_of_week;
 
   // `show_past_events` and `filter_duplicates` are deliberately absent. Both are


### PR DESCRIPTION
## What

Adds a rationale comment above the `first_day_of_week` term in `dataChanged`. **No behaviour change** — the built bundle is byte-identical at 191896 B, which is the whole proof.

## Why

`src/config/config.ts` rejects `show_past_events` and `filter_duplicates` from `dataChanged` with an explicit comment saying they "spent a network round-trip and a loading state to re-fetch data the cache already held". Four lines above, `first_day_of_week` is admitted unconditionally — and its one-line comment justified it *conditionally*: "moves the fetch window whenever `start_date` is week-relative".

So the file failed its own stated standard, and said so in its own comments. Three separate review passes have now landed on it independently, each re-deriving the same reasoning from scratch.

## Measurement

`getTimeWindow(daysToShow, startDate, firstDayOfWeek)` at `src/utils/events.ts:1055`, Sunday (0) vs Monday (1), system date Wed 2026-06-17:

| `start_date` | fdw=0 vs fdw=1 |
| --- | --- |
| absolute `"2026-06-17"` | **identical** — `06-17T00:00:00.000Z .. 06-24T23:59:59.999Z` |
| unset (the default) | **identical** — same window |
| `"start_of_week"` | **differs** — `06-14..06-21` vs `06-15..06-22` |

Denominator 3 kinds; 2 identical, 1 differing. The differing row is the positive control: it proves the probe genuinely reads the argument, so the two "identical" rows are a real null and not a broken harness.

This is broader than previously reported — the redundant refresh fires on the **default** config, not only on an explicitly absolute `start_date`.

## Why not fix it

Narrowing the check means re-deriving "is this start date week-relative" at this site. Get that predicate wrong and the card serves a **stale window** instead of merely re-fetching a fresh one — strictly the worse failure. `getBaseCacheKey` and `generateDeterministicId` were both deliberately made weekday-aware to close real staleness bugs; loosening the third member of that family late in the release risks re-opening them to save one request on a rare config change.

The comment names both functions so the next person to consider narrowing it knows what else moves.
