### PR TITLE
docs(config): name the resolvers that actually coerce the column block

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -329,7 +329,11 @@ function bareNumber(value: unknown): string | undefined {
  * Descent requires a plain object on **both** sides. That excludes arrays — `entities` has
  * no per-index shipped default to descend into, so walking it could only do harm — and it
  * excludes any key the defaults do not describe, such as the `column:` block, whose own
- * keys are coerced by `resolveEffectiveConfig` against `COLUMN_DEFAULTS` instead.
+ * keys are coerced during view resolution instead. Neither kind of key the block holds
+ * reaches this walk, and the two are coerced by different resolvers against different
+ * tables: `resolveEffectiveConfig` hoists the ones that override a top-level option and
+ * coerces them against `DEFAULT_CONFIG`, while the column-only keys are coerced on read
+ * by `resolveColumnOption` against `COLUMN_DEFAULTS`.
  *
  * **Nested groups are copied, never written through.** Home Assistant hands cards a frozen
  * configuration, and `setConfig` merges it shallowly — so `config.weather` and


### PR DESCRIPTION
## What

One-sentence JSDoc correction in `src/config/config.ts`. Comment only — no code, no tests, no shipped bytes.

## The defect

The `normalizeLengthOptions` docstring claimed the `column:` block's keys are

> coerced by `resolveEffectiveConfig` against `COLUMN_DEFAULTS`

That pairing describes **zero keys**. `resolveEffectiveConfig` never references `COLUMN_DEFAULTS` — it seeds `COLUMN_DEFAULT_OVERRIDES` and coerces via `coercePixelLength`, which reads `DEFAULT_CONFIG`. The keys that *do* live in `COLUMN_DEFAULTS` are coerced somewhere else entirely.

The block holds two kinds of key, on two paths:

| kind | resolver | coerced against |
|---|---|---|
| override keys | `resolveEffectiveConfig` (hoists) → `coercePixelLength` | `DEFAULT_CONFIG` |
| column-only keys | `resolveColumnOption` → `normalizeColumnValue` → `coercePixelLengthAgainst` | `COLUMN_DEFAULTS` |

The old sentence took the **function** from the first row and the **constant** from the second.

## The tell

The same file already describes this correctly ~50 lines up, in the `coercePixelLengthAgainst` docstring:

> Those keys are absent from `DEFAULT_CONFIG` — they live in `COLUMN_DEFAULTS` — so `coercePixelLength` looks them up as `undefined` and returns every value untouched.

So `config.ts` contradicted itself: one docstring said the `DEFAULT_CONFIG` path returns these keys untouched (true), the other said they were coerced there against `COLUMN_DEFAULTS` (a path that does not exist).

## Evidence

Runtime probe against the real modules, with a control in the opposite direction and denominators reported alongside the verdict:

```
DENOMINATOR COLUMN_DEFAULTS keys=5 pxValued=2 [day_header_gap,day_header_separator_width]
DENOMINATOR COLUMN_OVERRIDE_KEYS=54 pxValued=19
DISTINCTNESS overlap(COLUMN_DEFAULTS, COLUMN_OVERRIDE_KEYS)=0

  TEST    resolveEffectiveConfig day_header_gap:             undefined
  TEST    resolveEffectiveConfig day_header_separator_width: undefined
  CONTROL resolveEffectiveConfig vertical_line_width: "12px"
  CONTROL resolveEffectiveConfig event_spacing:       "12px"
  CONTROL resolveEffectiveConfig day_spacing:         "12px"
  ALT     resolveColumnOption    day_header_gap:             "34px"
  ALT     resolveColumnOption    day_header_separator_width: "34px"

VERDICT testCoerced=0/2  controlCoerced=3/3  viaColumnOption=2/2
```

The control is load-bearing: it proves the probe **can** observe a coercion at `resolveEffectiveConfig`, so `0/2` is a real negative rather than a broken instrument. The distinctness check (`overlap=0`) confirms the two key tables are genuinely different sets, not the same array read twice. Probe was deleted after measurement.

## Provenance

Landed in `16d1f198` ("fix(config): coerce bare-number lengths inside nested groups too"). v4-only — `resolveEffectiveConfig` does not exist on `dev`, so this is a v4-introduced leftover, not pre-existing drift.

Originally surfaced by an independent sibling review pass, then re-measured here from scratch at the current tip; that pass reviewed stale commit `6261029`, so its numbers were discarded and only its conclusion carried forward.

## Impact

None at runtime. The harm is to a maintainer who greps `COLUMN_DEFAULTS` inside `resolveEffectiveConfig` on the strength of this comment and finds nothing. Nothing gates JSDoc accuracy — `check:docs` reads `AGENTS.md` and the docs site, not source comments — so this class of defect is only ever caught by reading.

## Gates

All ten re-run at this exact base (`6a8b69a` + this commit):

| gate | result |
|---|---|
| `format` / `check:format` | 0, no drift |
| `tsc --noEmit` | 0 |
| `lint` | 0 |
| `test` | **109 files / 1941 tests** ✓ baseline |
| `check:i18n` | 35 languages, 198 editor fields, 0 errors, 7 warnings ✓ |
| `check:docs` | 93 defaults / 93 rows / 119 fields / 22 pages / 135 links / 9 CI gates / v4.0.0 ✓ |
| `build` | 0 |
| `check:bundle` | `calendar-card-pro.js 191896 B`, `editor.js 294305 B` — **byte-identical** ✓ |
