### PR TITLE
fix(check-docs): read gates written as YAML block scalars

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1637,13 +1637,36 @@ function checkGateLists() {
       .replace(/\s+/g, ' ');
 
   const workflow = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8');
-  const gates = workflow
-    .split('\n')
-    .map((line) => line.match(/^\s*run:\s*((?:npm|npx)\s.+)$/))
-    .filter(Boolean)
-    .map((match) => normalize(match[1]))
+  const lines = workflow.split('\n');
+  const found = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const inline = lines[index].match(/^\s*run:\s*((?:npm|npx)\s.+)$/);
+    if (inline) {
+      found.push(normalize(inline[1]));
+      continue;
+    }
+    // A step written as a YAML block scalar keeps its commands on the following
+    // lines, so matching only `run: <command>` cannot see them: a gate added as
+    // `run: |` stayed invisible here while the three lists stayed silently short.
+    // Read the block's own lines, but only where the command opens one — the
+    // pinning step is a shell script whose `npx npm@10.9.2 install` sits inside an
+    // echoed error string, and lifting that would demand contributors run it.
+    const opener = lines[index].match(/^(\s*)run:\s*[|>][-+]?\d*\s*$/);
+    if (!opener) continue;
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const line = lines[cursor];
+      if (line.trim() === '') continue;
+      if (line.match(/^\s*/)[0].length <= opener[1].length) break;
+      const command = line.match(/^\s*((?:npm|npx)\s.+)$/);
+      if (command) found.push(normalize(command[1]));
+    }
+  }
+  const gates = found
     // Installing dependencies is not a gate a contributor reruns as a check.
-    .filter((command) => command !== 'npm ci');
+    .filter((command) => command !== 'npm ci')
+    // One command named twice is still one gate, so the count stays the number of
+    // distinct commands a contributor has to run.
+    .filter((command, position, all) => all.indexOf(command) === position);
   assertFound(gates, 'npm gate commands', join(ROOT, '.github/workflows/ci.yml'));
 
   // Each file states the list once, in the only fenced block that reaches check:bundle.


### PR DESCRIPTION
## What

`checkGateLists` in `scripts/check-docs.mjs` reconciles the npm gate list in `AGENTS.md`, `CONTRIBUTING.md` and `docs/contributing.md` against `.github/workflows/ci.yml`. It extracted gates with a regex requiring the command on the **same line** as `run:`, so a step written as a YAML block scalar was invisible to it:

```yaml
- name: Some gate
  run: |
    npm run check:something   # ← never seen
```

The workflow runs the gate, the three lists omit it, and `check:docs` passes.

## Measurement

Falsifier plus an opposite-direction control, denominator reported beside the verdict:

| arm | before | after |
|---|---|---|
| baseline (9 real gates) | 9 · exit 0 | **9 · exit 0** |
| new gate as `run: \|` block scalar | **9 · exit 0 — blind** | **10 · exit 1**, 3 errors |
| same gate written inline | 10 · exit 1 | 10 · exit 1 |

The control fired in both directions: the instrument can see a new gate, and the identical gate written as a block scalar was silent before this change.

## The false-positive trap this had to avoid

The baseline staying at **9** is the load-bearing assertion, not a formality. `ci.yml` already contains a block scalar — the version-pinning step at L53 — and its error message echoes:

```
npx npm@10.9.2 install --package-lock-only
```

A naive *"any npm/npx inside the block"* parse lifts that string into the gate list, pushes the count to 10, and demands every contributor add it to three docs files. Anchoring on a **bare command at the start of a line** excludes it: no line in that block begins with `npm`/`npx`.

## Honest scope

This is **gate-hardening, not a bug fix**. No gate is currently written as a block scalar, so no list is short today and nothing user-facing changes. The silent path is narrow — *a brand-new gate authored as a block scalar and not added to the three lists* — but a checker that cannot detect the drift it advertises is defective in its own terms.

Two things this is **not**:

- **`assertFound` is not implicated.** It guards an empty result; the result was never empty (9 ≠ 0) and it passed correctly in both arms. The hole was in the extraction regex.
- **An expected-minimum argument to `assertFound` would not have caught it.** A floor of 9 still passes when 9 are seen and 10 exist.

The reverse direction — gates *consolidated* into one block, leaving the lists with extra entries — was already caught by the existing "extra entries fail too" check.

## Provenance

`checkGateLists` is absent from `origin/dev`; introduced by `e46ecdb` (#452). v4-only, in scope for this review.

## Verification

All ten gates green at this tip, every number matching the `6d65cf8` baseline: **109 files / 1941 tests**, 35 languages / 198 editor fields / 0 errors, 93 defaults / 93 rows / **9 CI gates**, bundle `191896 B` / `294305 B`, zero prettier drift. `ci.yml` restored byte-identical after probing.

No test covers `scripts/check-docs.mjs`, so the three-arm falsifier above is the verification rather than a committed test.
