### PR TITLE
docs(agents): qualify independent-agreement rule with an ancestry check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1104,5 +1104,14 @@ different artefacts.
   expensive half is every place it was already turned into a rule: an imperative three
   sections away, a parsed table cell, a test that pins it, or the code a document describes.
   A document-to-document audit cannot see the last of those.
+- **Independent agreement is evidence about the code both reviewers read, not about the tip.**
+  Two reviewers converging is the strongest corroboration available, and it held here — on a
+  defect the intervening 47 and 50 commits had already fixed. Convergence localises
+  _when_, not _whether_, so take the reviewed SHA and `git rev-list --count <sha>..HEAD`
+  before the finding, and re-measure before acting. The cheapest re-measurement is often the
+  comment beside the suspected line: a fix written from a real report tends to restate the
+  defect in the reporter's own terms, which separates _fixed_ from _still broken_ without a
+  probe. Where it does not, the regression test usually carries the reporter's scenario in
+  its name.
 - **Equal sizes are not identity, and a bundle figure needs its compression level _and_ its
   build variant.** Hash instead.


### PR DESCRIPTION
Closes the v4 review by recording the one lesson this round produced that the `Verification` section did not already cover.

## Why

That section's table already says, of a probe that is *"correct, correctly configured, honestly reported — and measuring the wrong thing"*, that the falsifier is to **have someone derive it a second way; two independent derivations agreeing is worth more than either being careful.**

Two review passes then did exactly that, independently, on the same `updateEvents()` stale-overwrite race — from SHAs **47 and 50 commits behind the tip**. Ordinarily that is the strongest corroboration available. Here the intervening commits had already fixed *and pinned* the defect.

The rule was not wrong. It was underspecified: agreement is evidence about **the code both reviewers read**, which is not necessarily the code in front of you.

## What the verification actually found

All seven findings from the two passes are resolved at tip `0421a54`:

| Finding | State |
| --- | --- |
| stale response overwrites newer config | `calendar-card-pro.ts:929-935` generation ticket; `isSuperseded()` at 971-974 / 985-988 |
| three initiating paths on initial load | fixed; pinned by `concurrent-fetch-single-flight.test.ts:71` |
| no-hass 1.5 s retry stays armed | retry cleared at `:937-943` once `safeHass` appears |
| malformed event crashes grouping | `keepWellFormedEvents` (`events.ts:180-184`) runs at `:245`, before dedup |
| concurrent consumers double-fetch | `inFlightRawFetches` (`events.ts:32`) |
| weather entity switch retains forecast | cleared at `:574` |
| weather-i18n drops later callbacks | `inFlight` is now `Map<string, Array<() => void>>`, notifying every waiter at `:236` |

One further finding — partial calendar failure rendering indistinguishably from success — was adjudicated a release-time product decision by the reporting pass itself, and is unchanged.

Verified by running the six relevant test files: **53 tests pass**. The runtime log `Discarding a superseded event response` appears in that output, so the guard is provably live rather than merely present in source.

## The two cheap re-measurements, which is the transferable part

Neither required writing a probe:

1. **The comment beside the suspected line.** `:567-572` explains why `weatherForecasts` is cleared on entity change *and not on other weather edits* — which is the reporting pass's own opposite-direction control, encoded in the guard's condition. A fix written from the defect arm alone would have cleared on any weather config change and shipped a flicker.
2. **The regression test's name.** `concurrent-fetch-single-flight.test.ts:71` is titled `fetches once when hass and config are both assigned before connection` — the reporter's defect arm verbatim — with `:88` preserving its control.

## Notes

- No line-number citations in the added text; the section warns that those rot, and its own falsifier had already rotted that way.
- The `47 and 50` figures are a record of a past event, in the same register as the existing `8 of the 10 releases from v3.0.1 through v3.4.0` — not a live assertion that must stay true.

## Verification

- `npx prettier --write AGENTS.md` — unchanged, already conformant
- `npm run check:format` — exit 0
- `npm run check:docs` — exit 0; **93 defaults / 93 rows / 119 fields / 22 pages / 135 links / 9 CI gates / v4.0.0**, all identical to the pre-change baseline

Docs-only, +9 / −0.
