### PR TITLE
docs: record why the fitColumns epsilon is unkillable by test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1104,5 +1104,14 @@ different artefacts.
   expensive half is every place it was already turned into a rule: an imperative three
   sections away, a parsed table cell, a test that pins it, or the code a document describes.
   A document-to-document audit cannot see the last of those.
+- **Independent agreement is evidence about the code both reviewers read, not about the tip.**
+  Two reviewers converging is the strongest corroboration available, and it held here — on a
+  defect the intervening 47 and 50 commits had already fixed. Convergence localises
+  _when_, not _whether_, so take the reviewed SHA and `git rev-list --count <sha>..HEAD`
+  before the finding, and re-measure before acting. The cheapest re-measurement is often the
+  comment beside the suspected line: a fix written from a real report tends to restate the
+  defect in the reporter's own terms, which separates _fixed_ from _still broken_ without a
+  probe. Where it does not, the regression test usually carries the reporter's scenario in
+  its name.
 - **Equal sizes are not identity, and a bundle figure needs its compression level _and_ its
   build variant.** Hash instead.

--- a/src/config/view.ts
+++ b/src/config/view.ts
@@ -901,7 +901,14 @@ export interface ColumnFit {
 }
 
 // Closed-form inverse of `computeColumnThresholdPxFor`; the epsilon protects exact
-// boundaries from floating-point underflow.
+// boundaries from floating-point underflow. Removing it is invisible through
+// `resolveColumnFit`, the only caller: an underflowed count stops matching
+// `previousColumns`, so the hysteresis re-fit recomputes from a shifted width and
+// lands back on the same number — measured at 0 divergent over 481,915 widths derived
+// from exact column boundaries, against a control mutating this same expression that
+// diverged on 41,307. No test can kill the epsilon because there is nothing to
+// observe, so keep it on the arithmetic's own merits: a caller added without that
+// re-fit would drop a column at an exact boundary.
 function fitColumns(config: Types.Config, widthPx: number): number {
   const gutter = columnGutterPx(config);
   const unit = resolveColumnOption(config, 'min_day_width') + gutter;


### PR DESCRIPTION
Comment-only. Closes out the one actionable item from two late independent review passes.

## Why

Both passes flagged `+ 1e-9` in `fitColumns` as a **surviving mutation**: removing it passes all 1941 tests, and it provably changes the arithmetic at exact column boundaries (`274.08 / 81.04` floors to 3 with it, 2 without). Each then spent a large differential sweep discovering that the survival is *structural*, not a coverage gap.

`resolveColumnFit` is the only caller. When the underflowed count stops matching `previousColumns`, the hysteresis re-fit recomputes from a shifted width and lands back on the same number — so there is nothing to observe and no test can kill it.

## Measurement at tip

481,915 widths derived from exact column boundaries, fractional units, every previous-layout state including `null`:

| arm | divergent |
|---|---|
| epsilon removed | **0** / 481,915 |
| control: same expression → `+ 0.5` | **41,307** / 481,915 |

The control deliberately mutates *the expression under test*. A control that changes a constant elsewhere (`COLUMN_CARD_PADDING_PX 32→33`) returns 0 divergent too, because the re-fit absorbs it — which is what made one pass suspect a broken harness and reach for a `return 999` sledgehammer.

## Effect

No behaviour change; bundle byte-identical (191896 B / 294305 B). The next reviewer who spots the surviving mutation reads the comment instead of running the sweep a third time.
