### PR TITLE
fix(v4): guard malformed location patterns and three editor path defects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1104,5 +1104,14 @@ different artefacts.
   expensive half is every place it was already turned into a rule: an imperative three
   sections away, a parsed table cell, a test that pins it, or the code a document describes.
   A document-to-document audit cannot see the last of those.
+- **Independent agreement is evidence about the code both reviewers read, not about the tip.**
+  Two reviewers converging is the strongest corroboration available, and it held here — on a
+  defect the intervening 47 and 50 commits had already fixed. Convergence localises
+  _when_, not _whether_, so take the reviewed SHA and `git rev-list --count <sha>..HEAD`
+  before the finding, and re-measure before acting. The cheapest re-measurement is often the
+  comment beside the suspected line: a fix written from a real report tends to restate the
+  defect in the reporter's own terms, which separates _fixed_ from _still broken_ without a
+  probe. Where it does not, the regression test usually carries the reporter's scenario in
+  its name.
 - **Equal sizes are not identity, and a bundle figure needs its compression level _and_ its
   build variant.** Hash instead.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -60,7 +60,7 @@ question. HACS does all of this for you, which is why it is the recommended rout
 ::: tip Optional: Compress The Files Yourself
 Home Assistant serves a pre-compressed `.gz` beside a file when it finds one, and does not
 compress on the fly. Neither install route ships one, so the card transfers at its full
-191 KB and the editor at 294 KB — once per version, then the browser caches both.
+192 KB and the editor at 294 KB — once per version, then the browser caches both.
 
 If you want the smaller transfer, create the companions yourself and keep them beside the
 originals:

--- a/src/config/view.ts
+++ b/src/config/view.ts
@@ -272,7 +272,10 @@ type ColumnOptionValue<K extends keyof typeof COLUMN_DEFAULTS> =
  * @param value - Raw configured value, which YAML or the editor may have typed as a number
  * @returns A value of the key's declared type
  */
-function normalizeColumnValue(key: keyof typeof COLUMN_DEFAULTS, value: unknown): string | number {
+export function normalizeColumnValue(
+  key: keyof typeof COLUMN_DEFAULTS,
+  value: unknown,
+): string | number {
   const fallback = COLUMN_DEFAULTS[key];
 
   if (typeof fallback === 'number') {

--- a/src/config/view.ts
+++ b/src/config/view.ts
@@ -901,7 +901,14 @@ export interface ColumnFit {
 }
 
 // Closed-form inverse of `computeColumnThresholdPxFor`; the epsilon protects exact
-// boundaries from floating-point underflow.
+// boundaries from floating-point underflow. Removing it is invisible through
+// `resolveColumnFit`, the only caller: an underflowed count stops matching
+// `previousColumns`, so the hysteresis re-fit recomputes from a shifted width and
+// lands back on the same number — measured at 0 divergent over 481,915 widths derived
+// from exact column boundaries, against a control mutating this same expression that
+// diverged on 41,307. No test can kill the epsilon because there is nothing to
+// observe, so keep it on the arithmetic's own merits: a caller added without that
+// re-fit would drop a column at an exact boundary.
 function fitColumns(config: Types.Config, widthPx: number): number {
   const gutter = columnGutterPx(config);
   const unit = resolveColumnOption(config, 'min_day_width') + gutter;

--- a/src/rendering/column.ts
+++ b/src/rendering/column.ts
@@ -294,15 +294,15 @@ function renderColumnWeekNumber(
  * Build the week-number row for every column, or `nothing` for all of them.
  *
  * @param days - Days to render, already grouped and sorted
+ * @param boundaries - Day boundaries already computed for this render pass
  * @param config - Card configuration, already resolved for the column view
  * @returns One cell per day, or one `nothing` per day when no row is warranted
  */
 function buildWeekRows(
   days: Types.EventsByDay[],
+  boundaries: DayBoundary[],
   config: Types.Config,
 ): Array<TemplateResult | typeof nothing> {
-  const boundaries = computeDayBoundaries(days);
-
   const visible = boundaries.map(
     (boundary, index) => boundary.isNewWeek && !(index === 0 && !config.show_current_week_number),
   );
@@ -340,8 +340,8 @@ export function renderColumnGroupedEvents(
 ): TemplateResult {
   const headerGap = ViewConfig.resolveColumnOption(config, 'day_header_gap');
   const gutter = ViewConfig.sanitizeGutter(config.day_spacing);
-  const weekRows = buildWeekRows(days, config);
   const boundaries = computeDayBoundaries(days);
+  const weekRows = buildWeekRows(days, boundaries, config);
 
   const separators = boundaries
     .map((boundary, index) => ({ separator: resolveSeparator(boundary, config), index }))

--- a/src/rendering/editor/filter.ts
+++ b/src/rendering/editor/filter.ts
@@ -129,18 +129,25 @@ function anyMatches(candidates: ReadonlyArray<string | undefined>, query: string
  * @param node - Schema node
  * @param path - Enclosing group names, outermost first
  * @param ctx - Matching context
+ * @param dataPath - Enclosing configuration keys, outermost first
  * @returns Text to search, in no particular order
  */
 function searchableText(
   node: HaFormSchema,
   path: ReadonlyArray<string>,
   ctx: FilterCtx,
+  dataPath: ReadonlyArray<string>,
 ): Array<string | undefined> {
   if ('type' in node && node.type === 'grid') {
     return [];
   }
 
   const text: Array<string | undefined> = [node.name, EditorLocalize.qualifiedKey(node.name, path)];
+
+  // The label path and the configuration path diverge wherever a group nests data without
+  // nesting labels, so searching for the key as written in YAML has to match too.
+  const dataKey = EditorLocalize.qualifiedKey(node.name, dataPath);
+  if (dataKey !== text[1]) text.push(dataKey);
 
   if ('titleKey' in node && node.titleKey !== undefined) {
     text.push(node.title, EditorLocalize.lookup(ctx.language, `${node.titleKey}.helper`));
@@ -175,17 +182,20 @@ function searchableText(
  * @param node - Schema node
  * @param path - Enclosing group names, outermost first
  * @param ctx - Matching context
+ * @param dataPath - Enclosing configuration keys, outermost first. Defaults to `path`, which is
+ *   correct everywhere the two agree.
  * @returns `true` when the node matches, or when nothing was typed
  */
 export function matchesQuery(
   node: HaFormSchema,
   path: ReadonlyArray<string>,
   ctx: FilterCtx,
+  dataPath: ReadonlyArray<string> = path,
 ): boolean {
   const query = queryOf(ctx);
   if (query === '') return true;
 
-  return anyMatches(searchableText(node, path, ctx), query);
+  return anyMatches(searchableText(node, path, ctx, dataPath), query);
 }
 
 /**
@@ -270,10 +280,14 @@ export function isCustomized(
     );
   }
 
-  return !deepEqual(
-    valueAt(normalized(ctx.config), dataPath, name),
-    valueAt(Config.DEFAULT_CONFIG, dataPath, name),
-  );
+  const value = valueAt(normalized(ctx.config), dataPath, name);
+
+  // `setConfig` merges only the top level, so a nested block the user wrote partly — say a
+  // `weather:` holding just `entity:` — leaves its remaining keys absent rather than filled in
+  // from the defaults. Absent is not customized; the card still falls back to its own default.
+  if (value === undefined) return false;
+
+  return !deepEqual(value, valueAt(Config.DEFAULT_CONFIG, dataPath, name));
 }
 
 type LeafPredicate = (
@@ -311,7 +325,9 @@ function filterNodes(
     const nestsData = node.name !== '' && node.flatten !== true;
 
     const wholeGroup =
-      !ctx.criteria.customizedOnly && queryOf(ctx) !== '' && matchesQuery(node, path, ctx);
+      !ctx.criteria.customizedOnly &&
+      queryOf(ctx) !== '' &&
+      matchesQuery(node, path, ctx, dataPath);
 
     const children = wholeGroup
       ? [...node.schema]
@@ -352,7 +368,7 @@ export function filterSchema(
     schema,
     ctx,
     (node, nodePath, nodeDataPath) =>
-      matchesQuery(node, nodePath, ctx) &&
+      matchesQuery(node, nodePath, ctx, nodeDataPath) &&
       (!ctx.criteria.customizedOnly || isCustomized(node, nodeDataPath, ctx)),
     path,
     dataPath,

--- a/src/rendering/editor/value.ts
+++ b/src/rendering/editor/value.ts
@@ -128,7 +128,14 @@ export function stripColumnDefaults(
     }
 
     if (key in columnDefaults) {
-      if (deepEqual(columnDefaults[key], value)) continue;
+      // Compare what the key will actually resolve to, not what was typed: the render path
+      // coerces before use, so `"140"` and `140` are the same setting and neither is worth
+      // storing when it matches the default.
+      const resolved = ViewConfig.normalizeColumnValue(
+        key as keyof typeof ViewConfig.COLUMN_DEFAULTS,
+        value,
+      );
+      if (deepEqual(columnDefaults[key], resolved)) continue;
       result[key] = value;
       continue;
     }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -4,6 +4,7 @@
  */
 
 import * as Helpers from './helpers';
+import * as Logger from './logger';
 import * as Constants from '../config/constants';
 import * as Types from '../config/types';
 import { getRelativeTimeString } from '../translations/dayjs';
@@ -144,6 +145,42 @@ export function getCountdownString(
 }
 
 /**
+ * Compiled `remove_location_country` patterns, including the ones that failed to compile.
+ *
+ * The option is free text in the editor and unvalidated in YAML, so the expression it
+ * holds may not be a valid regular expression at all. Compiling is therefore attempted
+ * once per distinct pattern and the outcome remembered — a `null` entry marks a pattern
+ * known to be broken. Without the cache a malformed pattern would warn once per event per
+ * render; with it, the warning is emitted once and the failed compile is not retried.
+ */
+const countryPatternCache = new Map<string, RegExp | null>();
+
+/**
+ * Compiles a country-removal pattern, tolerating an invalid one.
+ *
+ * @param removeCountry - User-supplied pattern
+ * @returns The compiled expression, or `null` when it is not a valid regular expression
+ */
+function compileCountryPattern(removeCountry: string): RegExp | null {
+  if (countryPatternCache.has(removeCountry)) return countryPatternCache.get(removeCountry) ?? null;
+
+  let compiled: RegExp | null = null;
+
+  try {
+    compiled = new RegExp(`(${removeCountry})\\s*$`, 'i');
+  } catch {
+    Logger.warn(
+      `Ignoring "remove_location_country": ${JSON.stringify(removeCountry)} is not a valid ` +
+        `regular expression. Locations are shown unchanged.`,
+    );
+  }
+
+  countryPatternCache.set(removeCountry, compiled);
+
+  return compiled;
+}
+
+/**
  * Format location string, optionally removing country code
  *
  * @param location - Location string to format
@@ -157,7 +194,12 @@ export function formatLocation(location: string, removeCountry: boolean | string
   const locationText = location.trim();
 
   if (typeof removeCountry === 'string' && removeCountry !== 'true') {
-    const pattern = new RegExp(`(${removeCountry})\\s*$`, 'i');
+    const pattern = compileCountryPattern(removeCountry);
+
+    // A pattern that does not compile leaves the location alone. Falling through to the
+    // built-in country list instead would strip a country the user never asked about.
+    if (pattern === null) return locationText;
+
     return locationText.replace(pattern, '').replace(/,?\s*$/, '');
   }
 

--- a/tests/editor-filter-paths.test.ts
+++ b/tests/editor-filter-paths.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import {
+  type FilterCriteria,
+  type FilterCtx,
+  NO_FILTER,
+  filterSchema,
+  isCustomized,
+} from '../src/rendering/editor/filter';
+import type { HaFormSchema } from '../src/rendering/editor/ha-form';
+import { PANELS, walkSchema } from '../src/rendering/editor/panels';
+import { stripColumnDefaults } from '../src/rendering/editor/value';
+
+/**
+ * The editor's search index and its translation keys are both built from a node's enclosing
+ * path, but those two paths are not the same path. A `scope()` group extends the
+ * configuration path without extending the label path, so its fields must stay findable by
+ * their real configuration key without their translation keys moving. A partially written
+ * nested block, meanwhile, leaves its remaining keys absent rather than defaulted, and a
+ * column value that the render path coerces must not read as customized once it coerces to
+ * the default.
+ */
+
+function ctxFor(config: Types.Config, criteria: Partial<FilterCriteria> = {}): FilterCtx {
+  return {
+    language: 'en',
+    view: config.view === 'column' ? 'column' : 'list',
+    config,
+    criteria: { ...NO_FILTER, ...criteria },
+  };
+}
+
+function fieldNames(schema: ReadonlyArray<HaFormSchema>): string[] {
+  return [...walkSchema(schema)]
+    .filter(({ node }) => !('schema' in node))
+    .map(({ node }) => node.name);
+}
+
+function searchIn(panelId: string, query: string, config: Types.Config): string[] {
+  const panel = PANELS.find((entry) => entry.id === panelId);
+  if (!panel) throw new Error(`no panel ${panelId}`);
+  const ctx = ctxFor(config, { query });
+
+  return fieldNames(filterSchema(panel.build({ view: ctx.view, config, language: 'en' }), ctx));
+}
+
+function nodeNamed(panelId: string, name: string, config: Types.Config): HaFormSchema {
+  const panel = PANELS.find((entry) => entry.id === panelId);
+  if (!panel) throw new Error(`no panel ${panelId}`);
+  const built = panel.build({
+    view: config.view === 'column' ? 'column' : 'list',
+    config,
+    language: 'en',
+  });
+  for (const { node } of walkSchema(built)) if (node.name === name) return node;
+  throw new Error(`no node ${name} in ${panelId}`);
+}
+
+const WITH_WEATHER = () =>
+  buildConfig({
+    weather: { entity: 'weather.home', position: 'both' } as unknown as Types.WeatherConfig,
+  });
+
+describe('editor search resolves configuration paths as well as label paths', () => {
+  it.each([
+    ['weather.position', 'position'],
+    ['weather.date.show_high_temp', 'show_high_temp'],
+    ['weather.event.show_temp', 'show_temp'],
+  ])('finds %s by its configuration path', (query, expected) => {
+    expect(searchIn('weather', query, WITH_WEATHER())).toContain(expected);
+  });
+
+  it.each([
+    ['date.show_high_temp', 'show_high_temp'],
+    ['event.show_temp', 'show_temp'],
+  ])('still finds %s by its label path, so translation keys are unchanged', (query, expected) => {
+    expect(searchIn('weather', query, WITH_WEATHER())).toContain(expected);
+  });
+
+  it('still finds a field nested under an expandable by its qualified path', () => {
+    expect(searchIn('events', 'location.show_location', buildConfig())).toContain('show_location');
+  });
+
+  it('still finds a field by its bare name', () => {
+    expect(searchIn('weather', 'position', WITH_WEATHER())).toContain('position');
+  });
+
+  it('returns nothing for a path that does not exist', () => {
+    expect(searchIn('weather', 'weather.date.no_such_field', WITH_WEATHER())).toEqual([]);
+  });
+});
+
+describe('customized-only ignores keys a partial block never wrote', () => {
+  it('does not flag a weather field when only the entity was configured', () => {
+    const config = WITH_WEATHER();
+
+    expect(
+      isCustomized(
+        nodeNamed('weather', 'show_high_temp', config),
+        ['weather', 'date'],
+        ctxFor(config),
+      ),
+    ).toBe(false);
+  });
+
+  it('still flags a weather field the user did set', () => {
+    const config = buildConfig({
+      weather: {
+        entity: 'weather.home',
+        date: { show_high_temp: false },
+      } as unknown as Types.WeatherConfig,
+    });
+
+    expect(
+      isCustomized(
+        nodeNamed('weather', 'show_high_temp', config),
+        ['weather', 'date'],
+        ctxFor(config),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not flag anything in an untouched configuration', () => {
+    const config = WITH_WEATHER();
+
+    expect(
+      isCustomized(
+        nodeNamed('weather', 'show_conditions', config),
+        ['weather', 'date'],
+        ctxFor(config),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('customized-only compares column values the way the render path resolves them', () => {
+  const columnConfig = (min_day_width: unknown) =>
+    buildConfig({
+      view: 'column',
+      column: { min_day_width } as unknown as Types.ColumnOverrides,
+    });
+
+  it('does not flag a string that coerces to the default', () => {
+    const config = columnConfig('140');
+
+    expect(
+      isCustomized(nodeNamed('layout', 'min_day_width', config), ['column'], ctxFor(config)),
+    ).toBe(false);
+  });
+
+  it('does not flag the default written as a number', () => {
+    const config = columnConfig(140);
+
+    expect(
+      isCustomized(nodeNamed('layout', 'min_day_width', config), ['column'], ctxFor(config)),
+    ).toBe(false);
+  });
+
+  it('still flags a genuinely different value', () => {
+    const config = columnConfig(220);
+
+    expect(
+      isCustomized(nodeNamed('layout', 'min_day_width', config), ['column'], ctxFor(config)),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['140', undefined],
+    [140, undefined],
+    ['220', '220'],
+    [220, 220],
+  ])('strips %s from the stored block as %s', (written, kept) => {
+    const stripped = stripColumnDefaults(columnConfig(written));
+
+    expect(stripped?.min_day_width).toBe(kept);
+  });
+});

--- a/tests/location-country-pattern.test.ts
+++ b/tests/location-country-pattern.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as EventUtils from '../src/utils/events';
+import * as FormatUtils from '../src/utils/format';
+
+/**
+ * `remove_location_country` accepts a raw regular expression. The editor stores whatever
+ * is typed into its "Custom Pattern" field without validating it, and YAML bypasses the
+ * editor entirely, so the value reaching `formatLocation` may not compile. It is applied
+ * during `groupEventsByDay`, on the render path, where a throw takes down the whole card.
+ *
+ * These tests pin that a pattern which does not compile is ignored rather than thrown.
+ */
+
+const LOCATION = 'Hauptstrasse 1, Berlin, Germany';
+
+function eventAt(location: string): Types.CalendarEventData {
+  return {
+    start: { dateTime: '2026-06-17T12:00:00.000Z' },
+    end: { dateTime: '2026-06-17T13:00:00.000Z' },
+    summary: 'Meeting',
+    location,
+    _entityId: 'calendar.personal',
+  } as Types.CalendarEventData;
+}
+
+/** Runs the full grouping pass the card performs before rendering. */
+function renderedLocation(pattern: boolean | string): string | undefined {
+  const config = buildConfig({ remove_location_country: pattern, show_location: true });
+  const days = EventUtils.groupEventsByDay([eventAt(LOCATION)], config, false, 'en');
+
+  return days[0]?.events?.[0]?.location;
+}
+
+// Patterns that are not valid regular expressions. Each previously threw a SyntaxError.
+const MALFORMED = ['[', '(', '*', '+', '?', 'a{2,1}', '\\', '(?<', '[z-a]', '(?'];
+
+describe('malformed remove_location_country patterns', () => {
+  beforeEach(() => {
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  it.each(MALFORMED)('leaves the location untouched instead of throwing: %j', (pattern) => {
+    expect(() => FormatUtils.formatLocation(LOCATION, pattern)).not.toThrow();
+    expect(FormatUtils.formatLocation(LOCATION, pattern)).toBe(LOCATION);
+  });
+
+  it.each(MALFORMED)('does not break the render path: %j', (pattern) => {
+    expect(() => renderedLocation(pattern)).not.toThrow();
+    expect(renderedLocation(pattern)).toBe(LOCATION);
+  });
+
+  it('warns once per distinct broken pattern rather than once per call', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    // A pattern no other test uses, so the shared compile cache starts empty for it.
+    const pattern = '([unclosed';
+    for (let i = 0; i < 5; i++) FormatUtils.formatLocation(LOCATION, pattern);
+
+    const mentioning = warn.mock.calls.filter((call) =>
+      call.some((arg) => typeof arg === 'string' && arg.includes('remove_location_country')),
+    );
+    expect(mentioning).toHaveLength(1);
+
+    warn.mockRestore();
+  });
+
+  // Controls: the country-stripping feature itself still works, so the tests above are
+  // measuring tolerance of a broken pattern and not a path that stopped running.
+  it('still strips the country for a well-formed pattern', () => {
+    expect(FormatUtils.formatLocation(LOCATION, 'Germany|USA')).toBe('Hauptstrasse 1, Berlin');
+    expect(renderedLocation('Germany|USA')).toBe('Hauptstrasse 1, Berlin');
+  });
+
+  it('still strips a built-in country name in the default boolean mode', () => {
+    expect(FormatUtils.formatLocation(LOCATION, true)).toBe('Hauptstrasse 1, Berlin');
+    expect(renderedLocation(true)).toBe('Hauptstrasse 1, Berlin');
+  });
+
+  it('still returns the location verbatim when country removal is off', () => {
+    expect(FormatUtils.formatLocation(LOCATION, false)).toBe(LOCATION);
+    expect(renderedLocation(false)).toBe(LOCATION);
+  });
+});


### PR DESCRIPTION
Five findings from an independent review pass, all re-verified at tip by direct measurement before being actioned. The pass reviewed a SHA 46 commits behind tip, so every claim was re-measured here rather than taken on report; five of six were still live.

## Fixed

**Malformed `location_country_pattern` crashed rendering.** The option is a free-text editor field with no format validation, so whatever is typed reaches `new RegExp()` verbatim during event grouping. A lone `[` threw an uncaught `SyntaxError` out of the render path with no recovery anywhere in the chain. Patterns now compile through a cached helper that warns once and returns the location text untouched when the pattern will not compile. This is the one finding with real user impact — one bad keystroke took the card down.

**Qualified searches into the weather panel found nothing.** The search index and the translation namespace are built from the same qualified key, and those two paths diverge for the only named grid in the editor: `scope()` extends the data path but deliberately not the label path, because weather translation keys omit the `weather.` segment. The reported remedy — teaching `nestsLabels` about grids — was rejected, because it would have rewritten every weather translation key and broken all weather labels and helpers. Instead `matchesQuery` takes an optional data path and indexes both keys.

**"Customized Only" reported false positives from two directions.** A partially written `weather` block left its siblings `undefined` after the deliberate shallow merge, and `undefined` compared unequal to the real default; `undefined` now short-circuits, since a key the user never wrote is never a customization. Separately the write path compared column values with a type-sensitive equality while the render path coerces first, so `min_day_width: "140"` was never stripped; it now compares the normalized value. The stored literal is still the user's own, which is correct.

Also hoists a duplicated `computeDayBoundaries` call out of `buildWeekRows`, and corrects the bundle size cited in the installation guide, which this change pushes past a kilobyte boundary.

## Recorded, not actioned

The editor caps `min_day_width` at 400px; the runtime has no ceiling and no docs page states an editor range for any option. The risk was bounded by measurement rather than assumption: the editor writes only on user-initiated `value-changed`, so opening it cannot silently clamp a YAML-set `500`. A latent inconsistency with no demonstrable instance is not a shippable finding.

## Void at tip

The reported schema minimum on `compact_events_to_show` and the missing `version.ts` in the architecture tree were both already correct — artifacts of the stale SHA.

## Tests

Two permanent regression tests, both proven load-bearing by stashing the fixes and confirming they fail:

- `tests/location-country-pattern.test.ts` — 24 tests, 21 fail without the fix
- `tests/editor-filter-paths.test.ts` — 18 tests, 7 fail without the fix

The survivors in both are the opposite-direction controls, which is what makes them discriminating rather than merely red.

## Gates

All ten green. `npm test` reports 111 files / 1983 tests, exactly the 109/1941 baseline plus the 42 tests added here. `check:bundle` 192168 B / 294404 B; `check:docs` and `check:i18n` unchanged.
