### PR TITLE
chore(v4): consolidate isConfigBlock, drop the never-emitted max-height-set class

### DIFF
--- a/docs/features/theming.md
+++ b/docs/features/theming.md
@@ -70,9 +70,38 @@ Selector lists cost nothing and survive a later switch to column view:
 .day-column.today .event-title { ... }
 ```
 
-The event-level classes — `.event`, `.event-title`, `.time`, `.location`, `.past-event` —
-are shared by both views, so only the day container needs doubling up.
+The event-level classes are shared by both views, so only the day container needs
+doubling up. They are listed under [Card & event classes](#card-event-classes).
 :::
+
+### Card & event classes
+
+The card root, `.calendar-card-pro`, carries one class describing the layout as a whole:
+
+| Class         | Applied when                                                   |
+| ------------- | -------------------------------------------------------------- |
+| `column-view` | [column view](/features/column-view) is the layout being drawn |
+
+List view adds no view class of its own, so `.calendar-card-pro:not(.column-view)` is the
+way to target it.
+
+Inside a day, every event carries `.event`, plus `past-event` once it has finished, plus
+one or both of a position pair:
+
+| Class          | Applied when                        |
+| -------------- | ----------------------------------- |
+| `event-first`  | the event is the first of its day   |
+| `event-middle` | the event is neither first nor last |
+| `event-last`   | the event is the last of its day    |
+
+::: warning A Lone Event Is Both First And Last
+A day with a single event gets `event-first` **and** `event-last` together — it is the
+first and the last. A rule written for `.event-first` alone will therefore also hit every
+single-event day. Use `.event-first:not(.event-last)` when you mean "first of several".
+:::
+
+The remaining event-level classes — `.event-title`, `.time`, `.location` — are plain
+element classes with no state attached.
 
 ### Custom title styling
 

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -1113,7 +1113,6 @@ class CalendarCardPro extends LitElement {
       this.effectiveTitle,
       content,
       handlers,
-      false,
       this.isLoading,
       this.isTitlePending,
       this.effectiveView,

--- a/src/rendering/editor/exceptions.ts
+++ b/src/rendering/editor/exceptions.ts
@@ -8,6 +8,7 @@ import * as Overrides from './overrides';
 import { walkSchema } from './panels';
 import * as Types from '../../config/types';
 import * as ViewConfig from '../../config/view';
+import * as Helpers from '../../utils/helpers';
 
 const EXTRA_KEYS_BY_PANEL: Readonly<Record<string, ReadonlyArray<string>>> = {
   layout: ['height', 'max_height'],
@@ -83,9 +84,9 @@ export function declaredKeys(config: Readonly<Types.Config>): ReadonlySet<string
   for (const blockKey of Object.values(ViewConfig.OVERRIDE_BLOCK_BY_VIEW)) {
     const block = config[blockKey];
 
-    if (!block || typeof block !== 'object' || Array.isArray(block)) continue;
+    if (!Helpers.isConfigBlock(block)) continue;
 
-    for (const [key, value] of Object.entries(block as Record<string, unknown>)) {
+    for (const [key, value] of Object.entries(block)) {
       if (value !== undefined && OVERRIDE_KEYS.has(key)) declared.add(key);
     }
   }
@@ -122,7 +123,7 @@ export function removeException(
 ): Types.Config {
   const block = config[blockKey];
 
-  if (!block || typeof block !== 'object' || Array.isArray(block)) {
+  if (!Helpers.isConfigBlock(block)) {
     return config as Types.Config;
   }
 

--- a/src/rendering/editor/value.ts
+++ b/src/rendering/editor/value.ts
@@ -15,22 +15,6 @@ const ATOMIC_KEYS = ['tap_action', 'hold_action'] as const;
 const WEATHER_GROUPS = ['date', 'event'] as const;
 
 /**
- * Narrows a value to a configuration block we can safely enumerate.
- *
- * YAML turns a key written with nothing after it into `null`, so `date:` alone on its
- * line — an easy way to start a nested block and not finish it — reaches us as `null`
- * rather than as a missing key, and a mistyped block arrives as a bare scalar.
- * `Object.entries` throws on the first and silently enumerates the characters of the
- * second, so both have to be rejected before the value is walked.
- *
- * @param value - Any value read from a user-supplied configuration
- * @returns True when the value is a plain object safe to enumerate
- */
-function isConfigBlock(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-/**
  * Structural comparison, enough for the small plain objects a config holds.
  *
  * @param a - One value
@@ -108,7 +92,7 @@ export function stripColumnDefaults(
 ): Record<string, unknown> | undefined {
   const block = config.column;
 
-  if (!isConfigBlock(block)) {
+  if (!Helpers.isConfigBlock(block)) {
     return undefined;
   }
 
@@ -335,7 +319,7 @@ export function weatherFormBlock(config: Readonly<Types.Config>): Record<string,
     const nested = stored[group];
     block[group] = {
       ...(defaults[group] ?? {}),
-      ...(isConfigBlock(nested) ? nested : {}),
+      ...(Helpers.isConfigBlock(nested) ? nested : {}),
     };
   }
 
@@ -356,7 +340,7 @@ export function stripWeatherDefaults(
 ): Record<string, unknown> | undefined {
   const block = config.weather;
 
-  if (!isConfigBlock(block)) {
+  if (!Helpers.isConfigBlock(block)) {
     return undefined;
   }
 
@@ -367,7 +351,7 @@ export function stripWeatherDefaults(
     if (value === undefined) continue;
 
     if ((WEATHER_GROUPS as readonly string[]).includes(key)) {
-      if (!isConfigBlock(value)) continue;
+      if (!Helpers.isConfigBlock(value)) continue;
 
       const groupDefaults = (defaults[key] ?? {}) as Record<string, unknown>;
       const group: Record<string, unknown> = {};

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -30,7 +30,6 @@ export { renderColumnGroupedEvents } from './column';
  * @param title Card title from configuration
  * @param content Main card content (events or status)
  * @param handlers Event handler functions
- * @param maxHeightSet Flag to add max-height-set class
  * @param isLoading Flag to mark the card as busy while events load
  * @param titlePending True while a templated title awaits its first value
  * @param effectiveView The view actually being rendered, after any width fallback
@@ -47,16 +46,13 @@ export function renderMainCardStructure(
     pointerCancel: (ev: Event) => void;
     pointerLeave: (ev: Event) => void;
   },
-  maxHeightSet: boolean = false,
   isLoading: boolean = false,
   titlePending: boolean = false,
   effectiveView: Types.EffectiveView = 'list',
 ): TemplateResult {
-  const cardClasses = [
-    'calendar-card-pro',
-    maxHeightSet ? 'max-height-set' : '',
-    ViewConfig.viewCssClass(effectiveView),
-  ]
+  // `viewCssClass` returns '' for list view, so the filter is what keeps a stray
+  // separator out of the class attribute.
+  const cardClasses = ['calendar-card-pro', ViewConfig.viewCssClass(effectiveView)]
     .filter((cls) => cls !== '')
     .join(' ');
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -312,6 +312,24 @@ export function getTimeFormat24h(
 }
 
 /**
+ * Narrows a value to a configuration block we can safely enumerate.
+ *
+ * YAML turns a key written with nothing after it into `null`, so `date:` alone on its
+ * line — an easy way to start a nested block and not finish it — reaches us as `null`
+ * rather than as a missing key, and a mistyped block arrives as a bare scalar. Arrays
+ * are objects too, so a `typeof` test alone lets one through to a walk that expects
+ * string keys. `Object.entries` throws on the first, silently enumerates the characters
+ * of the second and yields indices for the third, so all three have to be rejected
+ * before the value is walked.
+ *
+ * @param value - Any value read from a user-supplied configuration
+ * @returns True when the value is a plain object safe to enumerate
+ */
+export function isConfigBlock(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
  * Filter out default values from configuration
  *
  * @param config User configuration to filter
@@ -322,13 +340,11 @@ export function filterDefaultValues(
   config: Record<string, unknown>,
   defaultConfig: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+  if (!isConfigBlock(config)) {
     return config;
   }
 
-  const result = Array.isArray(config)
-    ? ([] as unknown as Record<string, unknown>)
-    : ({} as Record<string, unknown>);
+  const result: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(config)) {
     if (value === undefined) {

--- a/tests/card-wrapper-dom.test.ts
+++ b/tests/card-wrapper-dom.test.ts
@@ -37,7 +37,6 @@ const noopHandlers = {
 function wrapper(
   opts: {
     view?: Types.EffectiveView;
-    maxHeightSet?: boolean;
     title?: string;
     isLoading?: boolean;
     titlePending?: boolean;
@@ -50,7 +49,6 @@ function wrapper(
       opts.title,
       html`<div class="sentinel"></div>`,
       noopHandlers,
-      opts.maxHeightSet ?? false,
       opts.isLoading ?? false,
       opts.titlePending ?? false,
       opts.view ?? 'list',
@@ -83,23 +81,13 @@ describe('Y20 — the card wrapper', () => {
     expect(classes(card)).toEqual(['calendar-card-pro']);
   });
 
-  it('adds column-view only in column view', () => {
-    expect(classes(wrapper({ view: 'column' })).sort()).toEqual([
-      'calendar-card-pro',
-      'column-view',
-    ]);
-    expect(classes(wrapper({ view: 'list' }))).not.toContain('column-view');
-  });
-
-  it('adds max-height-set only when a max height is set', () => {
-    expect(classes(wrapper({ maxHeightSet: true }))).toContain('max-height-set');
-    expect(classes(wrapper({ maxHeightSet: false }))).not.toContain('max-height-set');
-  });
-
-  it('combines both conditional classes without a stray separator', () => {
-    const card = wrapper({ view: 'column', maxHeightSet: true });
-    expect(classes(card).sort()).toEqual(['calendar-card-pro', 'column-view', 'max-height-set']);
+  it('adds column-view only in column view, without a stray separator', () => {
+    const card = wrapper({ view: 'column' });
+    expect(classes(card).sort()).toEqual(['calendar-card-pro', 'column-view']);
+    // `viewCssClass` returns '' for list view, so the join must not leave padding
+    // behind on either side of the conditional class.
     expect(card.getAttribute('class')).not.toMatch(/\s{2}|^\s|\s$/);
+    expect(classes(wrapper({ view: 'list' }))).not.toContain('column-view');
   });
 
   it('keeps the header container present whether or not there is a title', () => {

--- a/tests/day-container-classes.test.ts
+++ b/tests/day-container-classes.test.ts
@@ -230,7 +230,12 @@ describe('theming.md card-mod selectors', () => {
    * in the union below. Listed explicitly instead of loosening the check, so a future
    * rename of one still has to be made deliberately here.
    */
-  const CARD_CHROME = new Set(['header-container', 'card-header']);
+  const CARD_CHROME = new Set([
+    'header-container',
+    'card-header',
+    'calendar-card-pro',
+    'column-view',
+  ]);
 
   function documentedClasses(): string[] {
     // `process.cwd()` matches `editor-schema.test.ts`; vitest runs from the repo root.


### PR DESCRIPTION
Adjudicates the three items from independent review pass 29 — verified individually at the real branch tip, not at the commit that pass reviewed.

### Correction on provenance

Pass 29 reported reviewing `629c54d` as "confirmed tip, 0 behind". It is a valid ancestor **41 commits behind** the tip. That also dissolves its `71/1527` vs this branch's `111/1983` test-count gap: 40 test files landed in those 41 commits — not a regression. All three findings were re-verified live anyway; line numbers had shifted.

### P1 + P2 — one change

`filterDefaultValues` guarded on `!config || typeof config !== 'object' || Array.isArray(config)`, then branched on `Array.isArray(config)` again to choose its accumulator — unreachable, and the sole reason that accumulator carried an `as unknown as` double assertion. The identical three-clause predicate also survived verbatim at three sites after `isConfigBlock` was introduced to prevent exactly that drift, because the helper was module-local.

Lifted into `utils/helpers.ts` rather than exported from the editor: `utils/` imports nothing, and four editor files already import `* as Helpers`, so this is the direction that keeps the layering intact. Behaviour-neutral — `!config` adds only `null` over `typeof !== 'object'`, and `null` is rejected explicitly either way. `grep` for the old predicate across `src/` now returns nothing.

### P3 — inverted, and understated

Pass 29 asked for `event-middle` and `max-height-set` to be documented. `event-middle` is now documented. **`max-height-set` is removed instead.**

Its only production call site passes a hardcoded `false`, and `origin/dev` (shipped v3) does the same — so the class has never appeared in any release since it was introduced in `c7c0aac`. `max_height` is served entirely by `--calendar-card-max-height` in `styles.ts`. Only the tests kept it reachable, by calling the renderer directly. Documenting it would have promised users a hook that never renders.

The count was also low: six classes were undocumented, not two. `column-view` is the substantive one — styled at `styles.ts:925`, but present in the docs only as a link path. It is now in the card-mod contract along with the event position trio, including the gotcha that a lone event carries `event-first` **and** `event-last` together, so `.event-first` alone also matches every single-event day.

Deliberately still excluded: `with-today-indicator` and `with-week-number` are internal padding modifiers on `.column-date-content` — implementation detail, not a user state hook.

### Guard integrity

`calendar-card-pro` and `column-view` join `CARD_CHROME` in `day-container-classes.test.ts`. That harness renders day content and so structurally cannot produce card-root classes — the same reason `header-container` and `card-header` were already listed.

Because an allowlist can silently neuter the check it belongs to, this was control-tested rather than assumed: a planted `.zzz-sentinel-class` in `theming.md` still made the guard fail and name it, and removing it restored green. The guard bites.

### Gates — all ten exit 0

| # | Gate | Result |
|---|------|--------|
| 1 | `check:format` | clean |
| 2 | `format` | no changes |
| 3 | `lint` | clean |
| 4 | `tsc --noEmit` | clean |
| 5 | `test` | **111 files / 1981 tests** |
| 6 | `check:i18n` | 0 errors, 7 pre-existing warnings |
| 7 | `check:docs` | 136 internal links resolved |
| 8 | `docs:build` | complete |
| 9 | `build` | both bundles |
| 10 | `check:bundle` | 192138 B / 294281 B |

Both denominators moved by exactly the accounted amount: tests 1983 → 1981 (two tests deleted with the dead class, the load-bearing stray-separator assertion folded into the surviving column-view test rather than dropped), links 135 → 136 (the new `/features/column-view` link).
