### PR TITLE
fix(v4): render weather when position is left at its default

### DIFF
--- a/docs/development/backlog.md
+++ b/docs/development/backlog.md
@@ -37,8 +37,11 @@ contributor to ask.
 
 ## After v4
 
-**Grid view.** The `grid` name is reserved in the view vocabulary; nothing is built.
-Feasibility was assessed and the architecture generalises, with named changes. Attribution
+**Grid view.** Nothing is built, and the `grid` name is not reserved anywhere either —
+`EffectiveView` in `src/config/types.ts` is `'list' | 'column'`, so adding it starts with
+widening that union. (The `'grid'` occurrences in `src/rendering/editor/` are Home
+Assistant form-layout node types and have nothing to do with views.) Feasibility was
+assessed and the architecture generalises, with named changes. Attribution
 runs through [issue #339](https://github.com/alexpfau/calendar-card-pro/issues/339), from
 @lenaxia — that issue is the durable record and the thing to credit. Do not expect to
 recover code from a branch: both the contributor branch and the adapted review branch have

--- a/docs/features/theming.md
+++ b/docs/features/theming.md
@@ -70,9 +70,38 @@ Selector lists cost nothing and survive a later switch to column view:
 .day-column.today .event-title { ... }
 ```
 
-The event-level classes — `.event`, `.event-title`, `.time`, `.location`, `.past-event` —
-are shared by both views, so only the day container needs doubling up.
+The event-level classes are shared by both views, so only the day container needs
+doubling up. They are listed under [Card & event classes](#card-event-classes).
 :::
+
+### Card & event classes
+
+The card root, `.calendar-card-pro`, carries one class describing the layout as a whole:
+
+| Class         | Applied when                                                   |
+| ------------- | -------------------------------------------------------------- |
+| `column-view` | [column view](/features/column-view) is the layout being drawn |
+
+List view adds no view class of its own, so `.calendar-card-pro:not(.column-view)` is the
+way to target it.
+
+Inside a day, every event carries `.event`, plus `past-event` once it has finished, plus
+one or both of a position pair:
+
+| Class          | Applied when                        |
+| -------------- | ----------------------------------- |
+| `event-first`  | the event is the first of its day   |
+| `event-middle` | the event is neither first nor last |
+| `event-last`   | the event is the last of its day    |
+
+::: warning A Lone Event Is Both First And Last
+A day with a single event gets `event-first` **and** `event-last` together — it is the
+first and the last. A rule written for `.event-first` alone will therefore also hit every
+single-event day. Use `.event-first:not(.event-last)` when you mean "first of several".
+:::
+
+The remaining event-level classes — `.event-title`, `.time`, `.location` — are plain
+element classes with no state attached.
 
 ### Custom title styling
 

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -1113,7 +1113,6 @@ class CalendarCardPro extends LitElement {
       this.effectiveTitle,
       content,
       handlers,
-      false,
       this.isLoading,
       this.isTitlePending,
       this.effectiveView,

--- a/src/config/view.ts
+++ b/src/config/view.ts
@@ -811,9 +811,12 @@ export function resolveMinDaysFallback(config: Types.Config): Types.ColumnMinDay
  * - **`effectiveView`** is what is rendered after the width fallback.
  *
  * Everything downstream — option resolution, grouping, compaction, rendering — takes
- * the resolved effective view. Nothing reads `config.view` directly, because below the
+ * the resolved effective view, and none of it reads `config.view`, because below the
  * threshold that value still says `column` while the card renders a list, and every
- * per-view resolution would then resolve for the wrong view.
+ * per-view resolution would then resolve for the wrong view. The three sites that do
+ * read it all want the *requested* view by definition: the `requestedView` getter, the
+ * `resolveColumnFit` call that consumes it as input, and the editor, which must show
+ * the user what they configured rather than what the current width happens to render.
  *
  * The fallback this function models is **wholesale**: below the threshold it answers
  * list view, never column view with fewer columns. That is a property of *this

--- a/src/rendering/editor/exceptions.ts
+++ b/src/rendering/editor/exceptions.ts
@@ -8,6 +8,7 @@ import * as Overrides from './overrides';
 import { walkSchema } from './panels';
 import * as Types from '../../config/types';
 import * as ViewConfig from '../../config/view';
+import * as Helpers from '../../utils/helpers';
 
 const EXTRA_KEYS_BY_PANEL: Readonly<Record<string, ReadonlyArray<string>>> = {
   layout: ['height', 'max_height'],
@@ -83,9 +84,9 @@ export function declaredKeys(config: Readonly<Types.Config>): ReadonlySet<string
   for (const blockKey of Object.values(ViewConfig.OVERRIDE_BLOCK_BY_VIEW)) {
     const block = config[blockKey];
 
-    if (!block || typeof block !== 'object' || Array.isArray(block)) continue;
+    if (!Helpers.isConfigBlock(block)) continue;
 
-    for (const [key, value] of Object.entries(block as Record<string, unknown>)) {
+    for (const [key, value] of Object.entries(block)) {
       if (value !== undefined && OVERRIDE_KEYS.has(key)) declared.add(key);
     }
   }
@@ -122,7 +123,7 @@ export function removeException(
 ): Types.Config {
   const block = config[blockKey];
 
-  if (!block || typeof block !== 'object' || Array.isArray(block)) {
+  if (!Helpers.isConfigBlock(block)) {
     return config as Types.Config;
   }
 

--- a/src/rendering/editor/value.ts
+++ b/src/rendering/editor/value.ts
@@ -15,22 +15,6 @@ const ATOMIC_KEYS = ['tap_action', 'hold_action'] as const;
 const WEATHER_GROUPS = ['date', 'event'] as const;
 
 /**
- * Narrows a value to a configuration block we can safely enumerate.
- *
- * YAML turns a key written with nothing after it into `null`, so `date:` alone on its
- * line — an easy way to start a nested block and not finish it — reaches us as `null`
- * rather than as a missing key, and a mistyped block arrives as a bare scalar.
- * `Object.entries` throws on the first and silently enumerates the characters of the
- * second, so both have to be rejected before the value is walked.
- *
- * @param value - Any value read from a user-supplied configuration
- * @returns True when the value is a plain object safe to enumerate
- */
-function isConfigBlock(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-/**
  * Structural comparison, enough for the small plain objects a config holds.
  *
  * @param a - One value
@@ -108,7 +92,7 @@ export function stripColumnDefaults(
 ): Record<string, unknown> | undefined {
   const block = config.column;
 
-  if (!isConfigBlock(block)) {
+  if (!Helpers.isConfigBlock(block)) {
     return undefined;
   }
 
@@ -335,7 +319,7 @@ export function weatherFormBlock(config: Readonly<Types.Config>): Record<string,
     const nested = stored[group];
     block[group] = {
       ...(defaults[group] ?? {}),
-      ...(isConfigBlock(nested) ? nested : {}),
+      ...(Helpers.isConfigBlock(nested) ? nested : {}),
     };
   }
 
@@ -356,7 +340,7 @@ export function stripWeatherDefaults(
 ): Record<string, unknown> | undefined {
   const block = config.weather;
 
-  if (!isConfigBlock(block)) {
+  if (!Helpers.isConfigBlock(block)) {
     return undefined;
   }
 
@@ -367,7 +351,7 @@ export function stripWeatherDefaults(
     if (value === undefined) continue;
 
     if ((WEATHER_GROUPS as readonly string[]).includes(key)) {
-      if (!isConfigBlock(value)) continue;
+      if (!Helpers.isConfigBlock(value)) continue;
 
       const groupDefaults = (defaults[key] ?? {}) as Record<string, unknown>;
       const group: Record<string, unknown> = {};

--- a/src/rendering/leaves.ts
+++ b/src/rendering/leaves.ts
@@ -31,9 +31,8 @@ export function renderDateWeather(
   config: Types.Config,
   weatherForecasts?: Types.WeatherForecasts,
 ): TemplateResult | typeof nothing {
-  const showDateWeather =
-    (config.weather?.position === 'date' || config.weather?.position === 'both') &&
-    config.weather?.entity;
+  const position = Weather.resolveWeatherPosition(config.weather);
+  const showDateWeather = (position === 'date' || position === 'both') && config.weather?.entity;
 
   if (!showDateWeather || !weatherForecasts?.daily) {
     return nothing;
@@ -293,10 +292,8 @@ function renderEventTitle(
  * Whether the card is configured to show a weather badge on individual events.
  */
 function hasEventWeather(config: Types.Config): boolean {
-  return !!(
-    config.weather?.entity &&
-    (config.weather.position === 'event' || config.weather.position === 'both')
-  );
+  const position = Weather.resolveWeatherPosition(config.weather);
+  return !!(config.weather?.entity && (position === 'event' || position === 'both'));
 }
 
 /**

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -30,7 +30,6 @@ export { renderColumnGroupedEvents } from './column';
  * @param title Card title from configuration
  * @param content Main card content (events or status)
  * @param handlers Event handler functions
- * @param maxHeightSet Flag to add max-height-set class
  * @param isLoading Flag to mark the card as busy while events load
  * @param titlePending True while a templated title awaits its first value
  * @param effectiveView The view actually being rendered, after any width fallback
@@ -47,16 +46,13 @@ export function renderMainCardStructure(
     pointerCancel: (ev: Event) => void;
     pointerLeave: (ev: Event) => void;
   },
-  maxHeightSet: boolean = false,
   isLoading: boolean = false,
   titlePending: boolean = false,
   effectiveView: Types.EffectiveView = 'list',
 ): TemplateResult {
-  const cardClasses = [
-    'calendar-card-pro',
-    maxHeightSet ? 'max-height-set' : '',
-    ViewConfig.viewCssClass(effectiveView),
-  ]
+  // `viewCssClass` returns '' for list view, so the filter is what keeps a stray
+  // separator out of the class attribute.
+  const cardClasses = ['calendar-card-pro', ViewConfig.viewCssClass(effectiveView)]
     .filter((cls) => cls !== '')
     .join(' ');
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -312,6 +312,24 @@ export function getTimeFormat24h(
 }
 
 /**
+ * Narrows a value to a configuration block we can safely enumerate.
+ *
+ * YAML turns a key written with nothing after it into `null`, so `date:` alone on its
+ * line — an easy way to start a nested block and not finish it — reaches us as `null`
+ * rather than as a missing key, and a mistyped block arrives as a bare scalar. Arrays
+ * are objects too, so a `typeof` test alone lets one through to a walk that expects
+ * string keys. `Object.entries` throws on the first, silently enumerates the characters
+ * of the second and yields indices for the third, so all three have to be rejected
+ * before the value is walked.
+ *
+ * @param value - Any value read from a user-supplied configuration
+ * @returns True when the value is a plain object safe to enumerate
+ */
+export function isConfigBlock(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
  * Filter out default values from configuration
  *
  * @param config User configuration to filter
@@ -322,13 +340,11 @@ export function filterDefaultValues(
   config: Record<string, unknown>,
   defaultConfig: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+  if (!isConfigBlock(config)) {
     return config;
   }
 
-  const result = Array.isArray(config)
-    ? ([] as unknown as Record<string, unknown>)
-    : ({} as Record<string, unknown>);
+  const result: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(config)) {
     if (value === undefined) {

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -13,6 +13,31 @@ import * as Types from '../config/types';
 //-----------------------------------------------------------------------------
 
 /**
+ * Resolve the effective weather position, applying the documented `date` default.
+ *
+ * `setConfig` merges with `{ ...DEFAULT_CONFIG, ...config }` — a *shallow* spread — so a
+ * user `weather:` block replaces the default block wholesale and `position` arrives
+ * `undefined` unless it was spelled out. Every consumer must therefore resolve the
+ * default itself, and reading `weather.position` raw is exactly how the subscribe and
+ * render halves drifted apart: the card subscribed to the daily forecast and then drew
+ * nothing.
+ *
+ * This resolves a *missing* value only; it deliberately does not validate. Config
+ * arrives from YAML unvalidated, so `position` can hold something outside its declared
+ * union at runtime, and `getRequiredForecastTypes` pins that case to subscribing to
+ * everything rather than dropping it. Clamping an unknown value to `date` here would
+ * quietly break that.
+ *
+ * @param weatherConfig Weather configuration options, if any
+ * @returns The position every consumer should act on
+ */
+export function resolveWeatherPosition(
+  weatherConfig?: Types.WeatherConfig,
+): NonNullable<Types.WeatherConfig['position']> {
+  return weatherConfig?.position || 'date';
+}
+
+/**
  * Determine which forecast types (daily, hourly) are required based on configuration
  *
  * @param weatherConfig Weather configuration options
@@ -25,7 +50,7 @@ export function getRequiredForecastTypes(
     return [];
   }
 
-  const position = weatherConfig.position || 'date';
+  const position = resolveWeatherPosition(weatherConfig);
 
   // 'none' renders nothing anywhere, so subscribing to a forecast would pay the
   // cost of a stream nobody reads. Without this arm it falls through to the

--- a/tests/card-wrapper-dom.test.ts
+++ b/tests/card-wrapper-dom.test.ts
@@ -37,7 +37,6 @@ const noopHandlers = {
 function wrapper(
   opts: {
     view?: Types.EffectiveView;
-    maxHeightSet?: boolean;
     title?: string;
     isLoading?: boolean;
     titlePending?: boolean;
@@ -50,7 +49,6 @@ function wrapper(
       opts.title,
       html`<div class="sentinel"></div>`,
       noopHandlers,
-      opts.maxHeightSet ?? false,
       opts.isLoading ?? false,
       opts.titlePending ?? false,
       opts.view ?? 'list',
@@ -83,23 +81,13 @@ describe('Y20 — the card wrapper', () => {
     expect(classes(card)).toEqual(['calendar-card-pro']);
   });
 
-  it('adds column-view only in column view', () => {
-    expect(classes(wrapper({ view: 'column' })).sort()).toEqual([
-      'calendar-card-pro',
-      'column-view',
-    ]);
-    expect(classes(wrapper({ view: 'list' }))).not.toContain('column-view');
-  });
-
-  it('adds max-height-set only when a max height is set', () => {
-    expect(classes(wrapper({ maxHeightSet: true }))).toContain('max-height-set');
-    expect(classes(wrapper({ maxHeightSet: false }))).not.toContain('max-height-set');
-  });
-
-  it('combines both conditional classes without a stray separator', () => {
-    const card = wrapper({ view: 'column', maxHeightSet: true });
-    expect(classes(card).sort()).toEqual(['calendar-card-pro', 'column-view', 'max-height-set']);
+  it('adds column-view only in column view, without a stray separator', () => {
+    const card = wrapper({ view: 'column' });
+    expect(classes(card).sort()).toEqual(['calendar-card-pro', 'column-view']);
+    // `viewCssClass` returns '' for list view, so the join must not leave padding
+    // behind on either side of the conditional class.
     expect(card.getAttribute('class')).not.toMatch(/\s{2}|^\s|\s$/);
+    expect(classes(wrapper({ view: 'list' }))).not.toContain('column-view');
   });
 
   it('keeps the header container present whether or not there is a title', () => {

--- a/tests/day-container-classes.test.ts
+++ b/tests/day-container-classes.test.ts
@@ -230,7 +230,12 @@ describe('theming.md card-mod selectors', () => {
    * in the union below. Listed explicitly instead of loosening the check, so a future
    * rename of one still has to be made deliberately here.
    */
-  const CARD_CHROME = new Set(['header-container', 'card-header']);
+  const CARD_CHROME = new Set([
+    'header-container',
+    'card-header',
+    'calendar-card-pro',
+    'column-view',
+  ]);
 
   function documentedClasses(): string[] {
     // `process.cwd()` matches `editor-schema.test.ts`; vitest runs from the repo root.

--- a/tests/weather-position.test.ts
+++ b/tests/weather-position.test.ts
@@ -16,6 +16,7 @@ import { render as litRender } from 'lit';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EVENTS, FROZEN_NOW, WEATHER, buildConfig } from './fixtures';
+import * as Config from '../src/config/config';
 import * as Types from '../src/config/types';
 import * as Column from '../src/rendering/column';
 import * as Render from '../src/rendering/render';
@@ -175,5 +176,85 @@ describe('weather position `none` renders no badge', () => {
     expect(column.querySelectorAll('.event-weather').length).toBe(0);
     expect(list.querySelectorAll('.weather').length).toBe(0);
     expect(list.querySelectorAll('.event-weather').length).toBe(0);
+  });
+});
+
+/**
+ * The same contract once more, but reached the way a real dashboard reaches it.
+ *
+ * `setConfig` merges with `{ ...DEFAULT_CONFIG, ...config }` — a *shallow* spread — so a
+ * user block of `weather: { entity: … }` replaces the default `weather` block wholesale
+ * and arrives with `position` undefined. Both suites above assign `config.weather`
+ * directly with the position spelled out, so neither can see that: they never exercise
+ * the merge, and the omitted case is the one every user who does not spell the option
+ * out lands on.
+ *
+ * The two halves disagreed exactly there. `getRequiredForecastTypes` resolved the
+ * documented `date` default and subscribed to the daily stream, while the render gates
+ * compared `position` raw, matched neither `'date'` nor `'both'`, and drew nothing — the
+ * card paid for a forecast it could not display. The subscribe half was already pinned
+ * above, which is why this suite stayed green while the render half was broken.
+ *
+ * Asserting *equivalence with an explicit `'date'`* rather than a bare "renders
+ * something" is what keeps this honest: a gate defaulting to the wrong position, and a
+ * gate widened to render for every value, each fail one of the two tests below.
+ */
+describe('weather position omitted from a user config', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Renders both views through the same shallow merge `setConfig` performs. */
+  function merged(weather: Record<string, unknown>): {
+    column: HTMLElement;
+    list: HTMLElement;
+    config: Types.Config;
+  } {
+    const userYaml = { ...buildConfig({ split_multiday_events: true }), weather };
+    const config = { ...Config.DEFAULT_CONFIG, ...userYaml } as Types.Config;
+
+    const view = (v: 'column' | 'list'): HTMLElement => {
+      const days = EventUtils.groupEventsByDay(EVENTS, config, false, 'en', v);
+      const container = document.createElement('div');
+      litRender(
+        v === 'column'
+          ? Column.renderColumnGroupedEvents(days, config, 'en', WEATHER, null)
+          : Render.renderGroupedEvents(days, config, 'en', WEATHER, null),
+        container,
+      );
+      return container;
+    };
+
+    return { column: view('column'), list: view('list'), config };
+  }
+
+  it('renders exactly what an explicit `date` renders', () => {
+    const omitted = merged({ entity: ENTITY });
+    const explicit = merged({ entity: ENTITY, position: 'date' });
+
+    // Positive control: the explicit config must actually draw something, or two zeroes
+    // would satisfy the equivalence below and prove nothing at all.
+    expect(explicit.column.querySelectorAll('.weather').length).toBeGreaterThan(0);
+
+    for (const view of ['column', 'list'] as const) {
+      for (const badge of ['.weather', '.event-weather'] as const) {
+        expect(omitted[view].querySelectorAll(badge).length).toBe(
+          explicit[view].querySelectorAll(badge).length,
+        );
+      }
+    }
+  });
+
+  it('draws the daily forecast it subscribed to', () => {
+    const { config, column, list } = merged({ entity: ENTITY });
+
+    expect(WeatherUtils.getRequiredForecastTypes(config.weather)).toContain('daily');
+    expect(column.querySelectorAll('.weather').length).toBeGreaterThan(0);
+    expect(list.querySelectorAll('.weather').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Clears all three findings from independent review pass 30, each verified live at the tip before acting.

## The defect

A `weather:` block that omits `position` subscribed to the daily forecast and then rendered nothing.

`setConfig` merges `{ ...DEFAULT_CONFIG, ...config }` — a **shallow** spread — so a user block replaces `DEFAULT_CONFIG.weather` wholesale and `position` arrives `undefined`. The two halves then disagreed:

| Site | Read | Result |
|---|---|---|
| `utils/weather.ts` (subscribe) | `position \|\| 'date'` | asks HA for the daily forecast |
| `leaves.ts` `renderDateWeather` | raw `=== 'date'` | `undefined` matches nothing → renders nothing |
| `leaves.ts` `hasEventWeather` | raw `=== 'event'` | same |

So `weather: { entity: weather.home }` — the minimal config both docs pages imply works — paid for a stream nobody drew. `docs/reference/configuration.md:200` and `docs/features/weather.md:43` both publish `date` as the default.

**Pre-existing in shipped v3.** `origin/dev` has the identical shallow merge, the identical non-defaulting render guards and the identical defaulting subscribe. Not a column-view regression.

## The fix

One exported `resolveWeatherPosition()` in `utils/weather.ts`, called from the subscribe path and both render gates — the same drift shape as the `isConfigBlock` consolidation, fixed the same way.

It resolves a *missing* value only and deliberately does not validate. Config arrives from YAML unvalidated, so `position` can hold something outside its declared union at runtime, and `getRequiredForecastTypes` pins that case to subscribing to everything rather than dropping it; clamping to `date` here would quietly break `forecastsFor('bogus')`.

Two sites deliberately left alone:

- `calendar-card-pro.ts:565` compares raw previous-vs-current for change detection. Comparing raw is the conservative side — worst case is one redundant re-subscribe.
- `schemas/weather.ts:113` already does `?? 'date'`. Importing `utils/weather` there would pull `FormatUtils`, `Logger` and `WeatherI18n` into the 294 KB editor bundle that `check:bundle` pins.

### Why not the structural deep-merge

Deep-merging `weather` in `setConfig` would fix the whole class and would also subsume pass 28's finding #4 (`isCustomized` false-positives on a partial `weather` block). Rejected for this release: it changes `setConfig` semantics broadly and interacts with `hasConfigChanged`, `isCustomized` and `toStoredConfig`, whose default-stripping machinery is built around the current shape. Too much blast radius this close to v4.0.0. Pass 28 #4 stays open, with that rationale recorded.

## Proof

A controlled probe against unmodified source, then promoted to a permanent regression test in `tests/weather-position.test.ts` — the suite whose own docblock states the invariant that was being violated, and which already pinned the subscribe half.

| Stage | Result |
|---|---|
| Probe, pre-fix | `1 failed \| 3 passed` — target `expected 0 to be greater than 0` |
| Probe, post-fix | `4 passed` |
| Permanent tests, post-fix | `12 passed` |
| Permanent tests, `src/` stashed | **`2 failed \| 10 passed`** |

That last row is the one that matters: both new tests fail without the source fix and nothing pre-existing breaks, so they are load-bearing rather than decorative.

The test asserts *equivalence with an explicit `date`* rather than "renders something", so a gate defaulting to the wrong position and a gate widened to render for every value each fail one of the two. It carries an inline positive control so two zeroes cannot satisfy it vacuously.

## Two comments falsified by one grep

- `docs/development/backlog.md:40` claimed the `grid` name is reserved in the view vocabulary. It is not — `EffectiveView` is `'list' | 'column'`, and all six `'grid'` hits in `src/` are HA form-layout node types. Unpublished path, so no gate sees it.
- `src/config/view.ts:814` claimed nothing reads `config.view` directly. Three sites do, and all three are legitimate: the `requestedView` getter whose job is exposing the raw value, the `resolveColumnFit` call that consumes it as input, and the editor, which must show what the user configured rather than what the current width renders. The intent was right; the absolute wording sends the next reader hunting a bug that isn't there.

## Gates

All ten exit 0, in the mandated order.

`npm test` → **111 files / 1983 tests**, against a baseline of 111 / 1981. The +2 is exactly the two new regression tests; no file count change, since they were appended to an existing suite.

`check:bundle` → `calendar-card-pro.js (192112 B), editor.js (294281 B)`.

`check:docs` → consistent, 136 internal links resolved.
