### PR TITLE
docs(v4): record the shallow-merge cause behind two fixed defects

### DIFF
--- a/docs/development/backlog.md
+++ b/docs/development/backlog.md
@@ -78,6 +78,35 @@ reviewed column layout was the wrong way round on the eve of a release; it is th
 round once the release is out. **Scope the selector to list view, or re-verify column
 view's weather spacing alongside the change.**
 
+**`setConfig` merges only the top level.** It builds the effective configuration as
+`{ ...DEFAULT_CONFIG, ...config }`, so a nested block the user writes partly replaces the
+default block wholesale instead of being filled in key by key. A `weather:` holding just
+`entity:` therefore arrives with `position`, `date` and `event` all `undefined`, even
+though `position` is published with a default of `date` in the reference and the two
+sub-blocks carry defaults of their own in `DEFAULT_CONFIG`.
+
+This produced two defects in v4 review, and both were fixed at the symptom rather than at
+the cause. `isCustomized` in `src/rendering/editor/filter.ts` now returns early when the
+value it reads is `undefined`, so the editor's Customized Only filter stops flagging keys
+the user never wrote, and `resolveWeatherPosition` in `src/utils/weather.ts` centralises
+the `position` default that the subscribe and render halves had been resolving
+differently — one paying for a forecast stream the other then declined to draw. Both are
+covered by tests that fail if the fix is removed.
+
+The cause is still there, so a third reader of a nested default can repeat it. What bounds
+the risk is that the exposed surface is almost entirely `weather`: `DEFAULT_CONFIG` has
+four nested entries, and `tap_action` and `hold_action` each default to a single key while
+`entities` defaults to `[]` and is written in full, so none of them can lose a key to a
+partial write the way `weather` can.
+
+A deep merge is the real fix and was deliberately not attempted on a release candidate.
+It changes `setConfig` semantics for every consumer at once, and `hasConfigChanged`,
+`isCustomized` and `toStoredConfig` are all built around the current shape —
+`toStoredConfig` in particular strips defaults back out on the write path, so filling them
+in on the read path has to be matched there or the card starts writing ninety defaults
+into the user's YAML. **Do it early in a cycle, with the write path changed in the same
+commit, not as a late fix.**
+
 **`visible:` conditions in the editor.** Home Assistant's `ha-form` can hide a row through
 a `visible:` condition rather than through the memoised schema recomputation the editor does
 today. Worth adopting only with a stated minimum HA version, since a version that does not


### PR DESCRIPTION
## Why

Two findings from the v4 review turned out to share a single cause, and both were fixed at the symptom:

- **Customized Only** flagged weather keys the user never wrote (fixed in #514)
- **`weather.position`** resolved differently in the subscribe and render halves, so the card paid for a forecast stream it then declined to draw (fixed in #516)

The cause — `setConfig` merging only the top level — is deliberately untouched for v4. That decision was sound, but its rationale lived only in review notes. This records it, which is the difference between a deliberate deferral and an unexplained one.

## What it adds

One entry under **After v4** in `docs/development/backlog.md`, covering:

- the mechanism, and why a partly-written `weather:` block loses `position`, `date` and `event`
- the two defects it already produced, and that both are covered by tests that fail if the fix is removed
- **the bound that makes it tractable** — of the four nested entries in `DEFAULT_CONFIG`, `tap_action` and `hold_action` default to a single key each and `entities` defaults to `[]` and is written in full, so `weather` is effectively the entire exposed surface
- why a deep merge was not attempted on a release candidate: `toStoredConfig` strips defaults back out on the write path, so filling them in on the read path has to be matched there in the same commit or the card starts writing ninety defaults into the user's YAML

## Verification

Claims are anchored on **symbols, not line numbers**. `backlog.md` is excluded from `check:docs`, so line citations here are unvalidated and would rot silently — the same failure mode as the two stale comments corrected in #516.

Each factual claim was checked against the source before writing, and one was tightened after checking: the reference publishes a default for `weather → position` but shows `-` for the `date` and `event` objects, so the entry now says exactly that instead of claiming defaults are documented for all three.

While confirming the first defect was genuinely closed, I also measured that the repo's own protection is real — removing the guard drops `tests/editor-filter-paths.test.ts` from 18 passed to 2 failed | 16 passed, so the fix cannot be silently reverted.

## Gates

Docs-only change to an unpublished file; the four gates that can see it all pass.

| Gate | Result |
|---|---|
| `npm run format` | clean |
| `npm run check:format` | pass |
| `npm run check:docs` | pass |
| `npm run docs:build` | pass |
