### PR TITLE
fix(v4): ask the grammar whether a start_date is week-relative, and close three mutation gaps

### DIFF
--- a/docs/development/backlog.md
+++ b/docs/development/backlog.md
@@ -163,6 +163,29 @@ A cheap version does not exist, which is why it was not added late. It has to pa
 allowlist for chrome classes that are emitted but deliberately undocumented — precisely the
 shape that yields false positives. **Build it when a false positive costs a re-run.**
 
-**The compact-mode event limit is not pinned.** The `totalEventsShown >= maxEvents` boundary
-inside `groupEventsByDay` in `src/utils/events.ts` survives mutation — flipping the comparison
-leaves the suite green. A coverage gap over correct code, not a defect.
+**The compact-mode event limit cannot be pinned, and does not need to be.** The
+`totalEventsShown >= maxEvents` boundary inside `groupEventsByDay` in `src/utils/events.ts`
+survives mutation, and this was previously filed here as a coverage gap. It is not one: it is
+an **equivalent mutant**. `totalEventsShown` is incremented by `slice(0, remainingEvents)`, so
+it can reach `maxEvents` and never exceed it — which makes `>` false exactly where `>=` is
+true. Flipping it only stops the loop breaking early; the remaining days then compute
+`remainingEvents === 0`, push nothing, and the output is byte-identical. The `>=` is a real
+early exit, worth keeping, with no observable consequence. Measured over a 1,279-row
+differential (5 event layouts × 8 budgets × `show_empty_days` × `compact_events_complete_days`
+× 4 `compact_days_to_show` × `isExpanded`): **0 differing rows**, against 281 and 42 for two
+controls in the same block. `totalEventsShown < maxEvents`, `eventsToShow > 0`,
+`remainingEvents > 0` and the break condition's empty-day exemption are equivalent for the
+same reason. No test can close these; do not write one.
+
+The same differential did find two mutants that were real, and they are now closed by
+`tests/compact-single-event-days.test.ts`. The block tests
+`day.events.length === 1 && day.events[0]._isEmptyDay` at three sites, and **the second
+operand is dead today** — placeholders are created after this block, so `_isEmptyDay` is never
+true here, and replacing either operand with `false` at any site changes nothing. That leaves
+the first operand exposed: relaxing either `&&` to `||` makes every _single-event_ day take the
+placeholder path, which stops the budget applying at all in the default branch and drops those
+days entirely in the complete-days branch. Both survived the full suite. The new file pins the
+property that outlives the ordering — a day with one real event counts against
+`compact_events_to_show` like any other — which is precisely the assertion that would fail if
+placeholder creation were ever moved ahead of this block, the change the comment there
+contemplates.

--- a/docs/development/backlog.md
+++ b/docs/development/backlog.md
@@ -125,7 +125,17 @@ counterpart in `normalizeColumnValue` and document the range, or drop it.**
 `computeRGBA` in `src/utils/helpers.ts` returns `rgba(var(--calendar-color-rgb, 3, 169, 244),
 …)`, and `--calendar-color-rgb` has exactly one occurrence in `src/` — that line itself. No
 stylesheet or inline style ever sets it, so the fallback light blue always wins and a themed
-`var(--primary-color)` input never reaches the rendered colour.
+`var(--primary-color)` input never reaches the rendered colour. Re-confirmed at the v4 tip,
+and the line does ship in `dist/calendar-card-pro.js`.
+
+**It is not reachable on default config, which is what bounds the severity.** Two opt-ins are
+both required. `accent_color` defaults to `#03a9f4`, a hex, so the `var(` branch is not taken;
+and `event_background_opacity` defaults to `0`, on which `getEntityAccentColorWithOpacity`
+returns before calling `convertToRGBA` at all. A user has to set a `var()` colour _and_ raise
+the opacity, and no page documents `var()` as a value for that option — the `var()` usages in
+`theming.md` are all card-mod CSS, which is a different surface. Note also that the hard-coded
+fallback `3, 169, 244` **is** `#03a9f4`, so the symptom is not a wrong-looking card but a
+themed colour silently collapsing to the default accent.
 
 Resolving the colour eagerly is the wrong fix, and was declined for that reason. The branch
 returns a live CSS expression precisely so the value stays reactive to a theme switch, and
@@ -140,18 +150,49 @@ then deferred on the same reasoning: a new harness added at release point spends
 false positive at the worst possible moment, while the same harness added after a release
 costs only a re-run.
 
-**The v4 test suite has not been mutation-tested.** 95 test files were added on this branch,
-and nothing has systematically checked them for assertions that pass whether or not the
-behaviour under test exists. The risk is demonstrated rather than theoretical: a zero-length
-probe during review reported "no throw" for the month and week separators, but only because
-its fixture rendered a single day, so `prevDay &&` short-circuited before `isZeroLength` ran,
-and a second fixture crossed no month boundary. Two of eight crash combinations were invisible
-to a probe that read as correct.
+**The v4 test suite has now been partly mutation-tested, and the results are uneven.** 95 test
+files were added on this branch. The sweeps below used type-safe operator swaps only, so a
+surviving mutant means the suite could not see a change that compiled — not that the source is
+wrong. Where a survivor was traced, it is classified; where it was not, it is listed as
+untriaged rather than as a defect.
 
-The known-risky places have already been swept by hand and came back connected: all seven
-`FETCH_TIME_KEYS` fail `npm test` when dropped, the `COLUMN_OVERRIDE_KEYS` and `fitColumns`
-epsilon probes were both null, and an off-default hypothesis dissolved under measurement at
-109 keys with none lacking a test reference. **What remains is breadth.**
+| File                       | Sites | Killed | Survived | Reading                                      |
+| -------------------------- | ----: | -----: | -------: | -------------------------------------------- |
+| `src/config/view.ts`       |    52 |     49 |        3 | all three unreachable or equivalent          |
+| `src/calendar-card-pro.ts` |  28\* |     17 |       10 | **weakest of the three; see the list below** |
+| `src/utils/events.ts`      |   131 |     81 |       50 | largely defensive guards; partly untriaged   |
+
+\* A curated subset of the host element's operator sites, not all of them. Two more — the
+`updated()` guard at the `hass`-just-arrived test, and the weather-config comparison beside it
+— **cannot be swept at all**: relaxing either makes `updated()` call `updateEvents()`, which
+sets reactive properties and re-enters `updated()`, so the mutant loops forever and hangs the
+runner rather than failing it. Any harness aimed at this file needs a per-mutant timeout.
+
+The three `view.ts` survivors resolve cleanly and need nothing: `unit <= 0` in `fitColumns` is
+unreachable because `normalizeColumnValue` floors numeric column options at `> 0`, the
+`measuredWidthPx <= 0` guard is the same shape, and the hysteresis half-band's `- 1` is
+absorbed by the clamp. The `fitColumns` epsilon is documented in place as unkillable.
+
+The host element's ten survivors are worth closing next cycle, and they cluster:
+
+- **The suite is English-only end to end.** `this._language || 'en'` in `effectiveLanguage`,
+  and both halves of the language-recompute condition in `updated()`, all survive — every
+  fixture resolves to `en`, so a getter hard-wired to English is indistinguishable from a
+  correct one. This is the largest of the ten and the cheapest to fix: one host-level test in a
+  non-English language.
+- **Title-template state.** `isTitlePending` returns `isTemplate(title) && renderedTitle ===
+undefined`; relaxing it to `||` marks a plain string title as pending and nothing notices.
+- **Interaction edge.** The tap branch's `!this._holdTriggered` guard survives, because
+  `hold_action` defaults to `{ action: 'none' }` and is therefore always truthy, so the hold
+  branch always wins first. It becomes reachable only when a user writes a bare `hold_action:`
+  in YAML — the shallow-merge hazard recorded above — and a hold would then also fire the tap
+  action.
+- **Untriaged:** the refresh-interval fallback, the weather-subscription guard, the
+  initial-load retry cleanup, the `isLimit` numeric test, and the empty-state branch in
+  `render`.
+
+**What remains is breadth**, and specifically `src/rendering/` — `leaves.ts`, `render.ts`,
+`column.ts`, `presentation.ts` and `styles.ts` have not been mutation-tested at all.
 
 **No gate cross-checks documented CSS classes against emitted ones.** `theming.md` lists the
 classes the card exposes, the renderers emit them, and nothing compares the two sets. The

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -6,7 +6,7 @@
 import * as FormatUtils from './format';
 import * as Helpers from './helpers';
 import * as Logger from './logger';
-import { parseStartDateExpression } from './start-date';
+import { isWeekRelative, parseStartDateExpression } from './start-date';
 import * as Constants from '../config/constants';
 import * as Types from '../config/types';
 import * as ViewConfig from '../config/view';
@@ -1363,12 +1363,17 @@ export function getBaseCacheKey(
 
   const startDatePart = normalizedStartDate ? `_${normalizedStartDate}` : '';
 
-  const weekRelative = /^(start_of_week|end_of_week|mon|tue|wed|thu|fri|sat|sun)/i.test(
-    normalizedStartDate,
-  );
+  // Asked of the grammar rather than restated here. A regex over the raw value drifted
+  // both ways: it matched `end_of_week`, which is not an anchor, and missed anything
+  // carrying whitespace, because `getTimeWindow` trims before parsing and this did not —
+  // so a quoted `" start_of_week"` was keyed as absolute while its window moved.
+  //
   // Explicitly against `undefined`, not truthiness: Sunday resolves to 0, so a truthy
   // test would drop it from the key and collide a Sunday-start week with "no weekday".
-  const firstDayPart = weekRelative && firstDayOfWeek !== undefined ? `_fdw${firstDayOfWeek}` : '';
+  const firstDayPart =
+    isWeekRelative(normalizedStartDate) && firstDayOfWeek !== undefined
+      ? `_fdw${firstDayOfWeek}`
+      : '';
 
   return `${Constants.CACHE.EVENT_CACHE_KEY_PREFIX}${instanceId}_${entityIds}_${daysToShow}${startDatePart}${firstDayPart}${Constants.VERSION.CURRENT}`;
 }

--- a/src/utils/start-date.ts
+++ b/src/utils/start-date.ts
@@ -70,6 +70,38 @@ function tokenize(input: string): string[] {
 }
 
 /**
+ * Whether an expression resolves differently for different first weekdays.
+ *
+ * Exactly one thing in this grammar consults `firstDayOfWeek`: the `start_of_week`
+ * anchor. Every weekday anchor lands on the next `monday`, `sat`, … from today, and every
+ * operator adds days, weeks or a weekday offset — none of which move when the week starts
+ * somewhere else.
+ *
+ * This lives here, beside the grammar it describes, because the event cache key needs the
+ * same answer and re-implementing it drifted in both directions at once. The copy was a
+ * regex over the raw config value, and it matched `end_of_week` — never an anchor here —
+ * while failing on any value carrying whitespace, because `getTimeWindow` trims before
+ * parsing and the regex did not. That second half was the live defect: a padded
+ * `" start_of_week"` resolved to a week-relative window but was keyed as though it were
+ * absolute, so a Sunday-start and a Monday-start profile shared one cache entry while
+ * asking Home Assistant for different days.
+ *
+ * Reusing `tokenize` and the normalization step rather than restating them is the point —
+ * a future anchor or operator that reads `firstDayOfWeek` has to be added a few lines
+ * below, where this predicate is visible, and `tests/start-date-week-relative.test.ts`
+ * reconciles the two by measuring whether the resolved date actually moves.
+ *
+ * @param input - Raw `start_date` config value, trimmed or not
+ * @returns `true` when the resolved date depends on the first day of the week
+ */
+export function isWeekRelative(input: string): boolean {
+  const normalized = String(input).replace(/\s+/g, '').toLowerCase();
+  if (normalized === '') return false;
+
+  return tokenize(normalized)[0] === ANCHOR_START_OF_WEEK;
+}
+
+/**
  * Parse a start date expression such as `start_of_week+7`, `today+sat` or `monday-1w`.
  *
  * @param input - Raw `start_date` config value

--- a/tests/compact-single-event-days.test.ts
+++ b/tests/compact-single-event-days.test.ts
@@ -1,0 +1,110 @@
+/**
+ * A day holding one real event is not an empty day.
+ *
+ * The compact block tests `day.events.length === 1 && day.events[0]._isEmptyDay` in three
+ * places to exempt placeholder days from the event budget. Both halves matter, and only
+ * one of them is load-bearing today: placeholders are created *after* this block runs, so
+ * `_isEmptyDay` is never true here and the conjunction is always false. Measured, not
+ * assumed — replacing either operand with `false` at any of the three sites changes
+ * nothing across a 1,279-config differential.
+ *
+ * What that leaves exposed is the first operand standing alone. Relaxing either `&&` to
+ * `||` makes *every single-event day* take the placeholder path: in the default branch
+ * they are pushed without being counted, so the budget stops applying entirely, and in the
+ * complete-days branch they are skipped, so they never enter `daysStarted` and vanish. The
+ * full suite saw neither.
+ *
+ * This is not a test of dead code. It pins the property that survives whatever happens to
+ * the ordering — a day with one real event counts against `compact_events_to_show` like
+ * any other — which is exactly the assertion that would fail if placeholder creation were
+ * ever moved ahead of this block and the exemption started matching real days.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as EventUtils from '../src/utils/events';
+
+/** One event on each of three consecutive days, so every day holds exactly one. */
+const ONE_PER_DAY: Types.CalendarEventData[] = ['18', '19', '20'].map((day) => ({
+  start: { dateTime: `2026-06-${day}T09:00:00.000Z` },
+  end: { dateTime: `2026-06-${day}T10:00:00.000Z` },
+  summary: `day-${day}`,
+  _entityId: 'calendar.personal',
+}));
+
+/** Days carrying at least one real event, and the summaries shown, in order. */
+function shown(overrides: Partial<Types.Config>): { days: number; summaries: string[] } {
+  const config = buildConfig({
+    days_to_show: 7,
+    start_date: '2026-06-17',
+    compact_events_to_show: 2,
+    ...overrides,
+  });
+
+  const grouped = EventUtils.groupEventsByDay(ONE_PER_DAY, config, false, 'en', 'list');
+  const real = grouped
+    .map((day) => day.events.filter((event) => !event._isEmptyDay))
+    .filter((events) => events.length > 0);
+
+  return {
+    days: real.length,
+    summaries: real.flatMap((events) => events.map((event) => event.summary ?? '?')),
+  };
+}
+
+describe('compact_events_to_show counts single-event days', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stops at the budget rather than exempting them', () => {
+    // Relaxing the empty-day test at the passthrough site pushes each single-event day
+    // without counting it, so all three days render and the budget stops meaning anything.
+    expect(shown({ compact_events_complete_days: false })).toEqual({
+      days: 2,
+      summaries: ['day-18', 'day-19'],
+    });
+  });
+
+  it('keeps them when whole days are requested', () => {
+    // The complete-days branch reaches the same answer by a different route, and the
+    // matching relaxation there drops every single-event day instead of exempting it —
+    // the opposite failure, invisible to the assertion above.
+    expect(shown({ compact_events_complete_days: true })).toEqual({
+      days: 2,
+      summaries: ['day-18', 'day-19'],
+    });
+  });
+
+  it('shows all three once the budget is raised', () => {
+    // The control. Both assertions above are satisfied by a card that simply renders two
+    // days whatever it is asked for; this is what makes the number a budget.
+    expect(shown({ compact_events_to_show: 3 })).toEqual({
+      days: 3,
+      summaries: ['day-18', 'day-19', 'day-20'],
+    });
+  });
+
+  it('is not applied at all when the card is expanded', () => {
+    // The second control: compact limits are the collapsed-state behavior, so a fixture
+    // that produced two days regardless of `isExpanded` would not be exercising them.
+    const config = buildConfig({
+      days_to_show: 7,
+      start_date: '2026-06-17',
+      compact_events_to_show: 2,
+    });
+    const grouped = EventUtils.groupEventsByDay(ONE_PER_DAY, config, true, 'en', 'list');
+    const real = grouped
+      .map((day) => day.events.filter((event) => !event._isEmptyDay))
+      .filter((events) => events.length > 0);
+
+    expect(real).toHaveLength(3);
+  });
+});

--- a/tests/first-day-of-week-fetch.test.ts
+++ b/tests/first-day-of-week-fetch.test.ts
@@ -78,6 +78,29 @@ describe('first_day_of_week is treated as the fetch-affecting option it is', () 
     expect(keyFor(0, '2026-06-17')).toBe(keyFor(1, '2026-06-17'));
   });
 
+  it('keeps the weekday in the key when the start date is padded', () => {
+    // `getTimeWindow` trims before parsing, so a quoted `" start_of_week"` resolves
+    // week-relatively and asks Home Assistant for a different set of days per profile.
+    // The key was built from the *untrimmed* value against a regex anchored at `^`, so
+    // the leading space made it look absolute and dropped the weekday — handing a
+    // Sunday-start and a Monday-start profile the same entry for different windows.
+    //
+    // Whitespace normalization now lives with the grammar in `isWeekRelative`, which is
+    // the only thing that knows `start_of_week` is the sole weekday-dependent anchor.
+    expect(keyFor(0, ' start_of_week')).not.toBe(keyFor(1, ' start_of_week'));
+    expect(keyFor(0, 'start_of_week ')).not.toBe(keyFor(1, 'start_of_week '));
+  });
+
+  it('drops the weekday for a weekday anchor, which does not depend on it', () => {
+    // The other half of asking the grammar rather than a regex. `monday` means "the next
+    // Monday from today" and lands on the same date whatever the week starts on, so the
+    // old alternation — which matched every weekday prefix — was splitting one entry
+    // into seven. Over-matching is only ever wasted fetches, which is why it survived,
+    // but it is still wrong and the same lookup now answers both directions.
+    expect(keyFor(0, 'monday')).toBe(keyFor(1, 'monday'));
+    expect(keyFor(0, 'sat+3')).toBe(keyFor(1, 'sat+3'));
+  });
+
   it('resolves system to a different weekday per profile', () => {
     // Why the key takes the resolved value rather than the raw setting: this is one
     // config string, and it is not an identity. Both halves of the composition are

--- a/tests/interaction-actions.test.ts
+++ b/tests/interaction-actions.test.ts
@@ -1,0 +1,228 @@
+/**
+ * `handleAction` had no test of its own, and coverage read as 0% for the whole module.
+ *
+ * Not a gap in the fixtures: the one file that exercises tap and hold —
+ * `tests/host-interaction.test.ts` — does `vi.mock('../src/interaction/actions')`, because
+ * what it is pinning is the *host's* pointer handling and it wants to assert which label
+ * reached the handler. That is the right call there, and its consequence is that the real
+ * dispatch has never run in a test. Nothing verified that the card emits `hass-action` at
+ * all, that the event crosses a shadow boundary, or that the entity Home Assistant needs
+ * for `more-info` is the one attached.
+ *
+ * So this file imports the module directly and asserts what leaves the element, rather
+ * than that the module was called.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as Config from '../src/config/config';
+import type * as Types from '../src/config/types';
+import { handleAction } from '../src/interaction/actions';
+
+/** A config differing from the default only in the fields named. */
+function config(overrides: Partial<Types.Config>): Types.Config {
+  return {
+    ...Config.DEFAULT_CONFIG,
+    entities: ['calendar.personal'],
+    ...overrides,
+  } as Types.Config;
+}
+
+/** Captured `hass-action` events, and the node they were dispatched from. */
+function listeningNode(): { node: HTMLElement; events: Event[] } {
+  const node = document.createElement('div');
+  const events: Event[] = [];
+
+  node.addEventListener('hass-action', (event) => events.push(event));
+  document.body.appendChild(node);
+
+  return { node, events };
+}
+
+/** The `detail` Home Assistant reads off the event. */
+function detailOf(event: Event): { config: { entity?: string }; action: string } {
+  return (event as unknown as { detail: { config: { entity?: string }; action: string } }).detail;
+}
+
+describe('handleAction delegates to Home Assistant', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('dispatches hass-action for a tap', () => {
+    const { node, events } = listeningNode();
+
+    handleAction(node, config({ tap_action: { action: 'more-info' } }), 'tap');
+
+    expect(events).toHaveLength(1);
+    expect(detailOf(events[0]).action).toBe('tap');
+  });
+
+  it('dispatches hass-action for a hold', () => {
+    const { node, events } = listeningNode();
+
+    handleAction(node, config({ hold_action: { action: 'more-info' } }), 'hold');
+
+    expect(events).toHaveLength(1);
+    expect(detailOf(events[0]).action).toBe('hold');
+  });
+
+  it('reads the label rather than defaulting to tap', () => {
+    // The two assertions above pass individually even if the label is hard-coded, since
+    // each only ever sees its own. Both actions are configured here and only the label
+    // varies, so a fixed value fails one of the two.
+    const both = config({
+      tap_action: { action: 'more-info' },
+      hold_action: { action: 'navigate', navigation_path: '/lovelace/0' },
+    });
+    const { node, events } = listeningNode();
+
+    handleAction(node, both, 'tap');
+    handleAction(node, both, 'hold');
+
+    expect(events.map((event) => detailOf(event).action)).toEqual(['tap', 'hold']);
+  });
+
+  it('crosses the shadow boundary', () => {
+    // The card dispatches from inside its own shadow root, so an event that does not
+    // compose never reaches the Home Assistant handler listening further up. Both flags
+    // are load-bearing and neither is observable from the assertions above.
+    const { node, events } = listeningNode();
+
+    handleAction(node, config({ tap_action: { action: 'more-info' } }), 'tap');
+
+    expect(events[0].bubbles).toBe(true);
+    expect(events[0].composed).toBe(true);
+  });
+
+  it('hands over both action configs, since Home Assistant chooses by label', () => {
+    const both = config({
+      tap_action: { action: 'more-info' },
+      hold_action: { action: 'navigate', navigation_path: '/lovelace/0' },
+    });
+    const { node, events } = listeningNode();
+
+    handleAction(node, both, 'hold');
+
+    expect(detailOf(events[0]).config).toMatchObject({
+      tap_action: { action: 'more-info' },
+      hold_action: { action: 'navigate', navigation_path: '/lovelace/0' },
+    });
+  });
+});
+
+describe('handleAction resolves the entity more-info needs', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('takes the first entity when it is a plain string', () => {
+    const { node, events } = listeningNode();
+
+    handleAction(
+      node,
+      config({
+        entities: ['calendar.first', 'calendar.second'],
+        tap_action: { action: 'more-info' },
+      }),
+      'tap',
+    );
+
+    expect(detailOf(events[0]).config.entity).toBe('calendar.first');
+  });
+
+  it('takes the first entity when it is an object', () => {
+    const { node, events } = listeningNode();
+
+    handleAction(
+      node,
+      config({
+        entities: [{ entity: 'calendar.configured', color: '#fff' }, 'calendar.second'],
+        tap_action: { action: 'more-info' },
+      }),
+      'tap',
+    );
+
+    expect(detailOf(events[0]).config.entity).toBe('calendar.configured');
+  });
+
+  it('still dispatches with no entity when none is configured', () => {
+    // `more-info` needs an entity, but a card with an empty `entities` list is a
+    // configuration the editor can produce mid-edit. Swallowing the action here would
+    // make the card silently unresponsive rather than letting Home Assistant report it.
+    const { node, events } = listeningNode();
+
+    handleAction(node, config({ entities: [], tap_action: { action: 'more-info' } }), 'tap');
+
+    expect(events).toHaveLength(1);
+    expect(detailOf(events[0]).config.entity).toBeUndefined();
+  });
+});
+
+describe('handleAction keeps expand to itself', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('runs the callback and dispatches nothing', () => {
+    // `expand` is the card's own action and has no Home Assistant equivalent, so
+    // delegating it would reach a handler that does not know the name.
+    const expand = vi.fn();
+    const { node, events } = listeningNode();
+
+    handleAction(node, config({ tap_action: { action: 'expand' } }), 'tap', expand);
+
+    expect(expand).toHaveBeenCalledTimes(1);
+    expect(events).toHaveLength(0);
+  });
+
+  it('does not delegate when no callback was supplied', () => {
+    const { node, events } = listeningNode();
+
+    handleAction(node, config({ tap_action: { action: 'expand' } }), 'tap');
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('does not run the callback for any other action', () => {
+    // The control for the pair above: the callback is passed on every real call site in
+    // `calendar-card-pro.ts`, so it has to be the action that selects it, not its presence.
+    const expand = vi.fn();
+    const { node, events } = listeningNode();
+
+    handleAction(node, config({ tap_action: { action: 'more-info' } }), 'tap', expand);
+
+    expect(expand).not.toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+  });
+});
+
+describe('handleAction with nothing configured', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('does nothing when the action for that label is absent', () => {
+    // `tap_action` and `hold_action` are required by the type, but the config arriving at
+    // `setConfig` is untyped YAML and a user can write `hold_action:` with no body.
+    const missing = { ...config({}), hold_action: undefined } as unknown as Types.Config;
+    const expand = vi.fn();
+    const { node, events } = listeningNode();
+
+    handleAction(node, missing, 'hold', expand);
+
+    expect(events).toHaveLength(0);
+    expect(expand).not.toHaveBeenCalled();
+  });
+
+  it('still acts on the label that is present', () => {
+    // The control: the early return must be selected by the missing half, not by the
+    // config being unusual.
+    const missing = { ...config({ tap_action: { action: 'more-info' } }), hold_action: undefined };
+    const { node, events } = listeningNode();
+
+    handleAction(node, missing as unknown as Types.Config, 'tap');
+
+    expect(events).toHaveLength(1);
+  });
+});

--- a/tests/multiday-middle-segments.test.ts
+++ b/tests/multiday-middle-segments.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The middle days of a split multi-day event.
+ *
+ * `splitMultiDayEvent` has two branches. The all-day branch is covered; the timed branch
+ * emits a first segment, a *run of whole-day middle segments*, and a last segment — and
+ * that middle loop only executes when the event spans three or more calendar days. Every
+ * fixture in the suite spanned two, so the loop never ran: mutating the `+ 1` that derives
+ * each middle segment's exclusive end date to `+ 2` left the whole suite green.
+ *
+ * The option is off by default, which is the second half of why this was invisible. A
+ * suite assembled from `DEFAULT_CONFIG` never splits anything, so `split_multiday_events`
+ * has to be turned on deliberately here.
+ *
+ * The assertions read the segments straight off the day buckets `groupEventsByDay`
+ * returns, because the boundary being pinned is the segment's own `start`/`end` rather
+ * than which bucket it landed in — a middle segment given a two-day span still sorts into
+ * the same day, so a count of days carrying the event cannot see the difference.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as EventUtils from '../src/utils/events';
+
+/** Four calendar days: one first segment, two middle segments, one last segment. */
+const SPANNING_EVENT: Types.CalendarEventData = {
+  start: { dateTime: '2026-06-18T09:00:00.000Z' },
+  end: { dateTime: '2026-06-21T14:00:00.000Z' },
+  summary: 'Conference',
+  _entityId: 'calendar.personal',
+};
+
+/** The segments carried by each day, in day order. */
+function segmentsByDay(event: Types.CalendarEventData): Types.CalendarEventData[] {
+  const config = buildConfig({ split_multiday_events: true, days_to_show: 7 });
+
+  return EventUtils.groupEventsByDay([event], config, true, 'en')
+    .flatMap((day) => day.events)
+    .filter((candidate) => candidate.summary === 'Conference');
+}
+
+describe('a timed event spanning four days', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('splits into one segment per day it touches', () => {
+    // The denominator for everything below: three segments would mean no middle loop ran
+    // and the assertions on middle days would be vacuously satisfied by an empty list.
+    expect(segmentsByDay(SPANNING_EVENT)).toHaveLength(4);
+  });
+
+  it('gives each middle day a segment covering exactly that day', () => {
+    // The `+ 1` under test. A middle segment is written in the all-day shape, where `end`
+    // is exclusive, so one whole day is `start` and the following date — not two.
+    const [, secondDay, thirdDay] = segmentsByDay(SPANNING_EVENT);
+
+    expect(secondDay.start).toEqual({ date: '2026-06-19' });
+    expect(secondDay.end).toEqual({ date: '2026-06-20' });
+    expect(thirdDay.start).toEqual({ date: '2026-06-20' });
+    expect(thirdDay.end).toEqual({ date: '2026-06-21' });
+  });
+
+  it('leaves no gap or overlap between consecutive segments', () => {
+    // Derived a second way, so the dates above are not merely restating the
+    // implementation: each middle segment must end exactly where the next one starts.
+    const [, secondDay, thirdDay, lastDay] = segmentsByDay(SPANNING_EVENT);
+
+    expect(secondDay.end?.date).toBe(thirdDay.start?.date);
+    expect(thirdDay.end?.date).toBe(
+      new Date('2026-06-21T00:00:00.000Z').toISOString().slice(0, 10),
+    );
+    expect(lastDay.start?.dateTime).toBeDefined();
+  });
+
+  it('keeps the real times on the first and last days', () => {
+    // The middle days are whole days; the outer two are not, and truncating them to whole
+    // days would be a different way to make the middle assertions pass.
+    const segments = segmentsByDay(SPANNING_EVENT);
+    const first = segments[0];
+    const last = segments[3];
+
+    expect(first.start?.dateTime).toBe(new Date('2026-06-18T09:00:00.000Z').toISOString());
+    expect(new Date(first.end!.dateTime!).toISOString()).toBe('2026-06-18T23:59:59.999Z');
+    expect(new Date(last.start!.dateTime!).toISOString()).toBe('2026-06-21T00:00:00.000Z');
+    expect(new Date(last.end!.dateTime!).toISOString()).toBe('2026-06-21T14:00:00.000Z');
+  });
+
+  it('marks every segment as one', () => {
+    // `_isMultiDaySegment` is what the renderers read to decide a segment is part of a
+    // longer event rather than a standalone entry.
+    expect(segmentsByDay(SPANNING_EVENT).every((segment) => segment._isMultiDaySegment)).toBe(true);
+  });
+
+  it('does not split at all when the option is off', () => {
+    // The control for the whole file. `split_multiday_events` defaults to `false`, so
+    // every assertion above depends on it being switched on — without this, a change that
+    // made splitting unconditional would look identical from here.
+    const config = buildConfig({ days_to_show: 7 });
+    const carried = EventUtils.groupEventsByDay([SPANNING_EVENT], config, true, 'en')
+      .flatMap((day) => day.events)
+      .filter((candidate) => candidate.summary === 'Conference');
+
+    expect(carried.every((candidate) => !candidate._isMultiDaySegment)).toBe(true);
+  });
+});

--- a/tests/start-date-week-relative.test.ts
+++ b/tests/start-date-week-relative.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `isWeekRelative` must agree with what the parser actually does.
+ *
+ * The event cache key appends the resolved first weekday only for `start_date` values
+ * whose window moves with it. Getting that set wrong is silent in both directions, and
+ * asymmetric in cost: naming one option too many splits a cache entry that could have
+ * been shared, while naming one too few hands two genuinely different windows the same
+ * entry, so a Sunday-start profile renders a Monday-start week until the TTL expires.
+ *
+ * The under-matching half is not hypothetical — it shipped on this branch. The predicate
+ * used to be a regex over the raw config value in `getBaseCacheKey`, and `getTimeWindow`
+ * trims before parsing while the regex did not, so a quoted `" start_of_week"` resolved
+ * week-relatively and was keyed as if absolute.
+ *
+ * Restating the rule here would inherit whatever the implementation believes, so this
+ * derives the answer a second way instead: resolve each expression under every first
+ * weekday and see whether the date it lands on actually moves. Both directions then fail
+ * — an anchor or operator that starts reading `firstDayOfWeek` without being declared, and
+ * a value declared week-relative that resolves identically all seven ways.
+ *
+ * Swept across a full week of reference dates, because a single `now` can hide a
+ * difference: `start_of_week` and `monday` resolve to the same day when today *is* the
+ * start of a Monday week.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { isWeekRelative, parseStartDateExpression } from '../src/utils/start-date';
+
+/** Every first weekday Home Assistant can resolve to. */
+const WEEKDAYS = [0, 1, 2, 3, 4, 5, 6];
+
+/** A week of reference dates, so no single weekday's coincidences decide the answer. */
+const REFERENCE_DATES = Array.from({ length: 7 }, (_, offset) => new Date(2026, 5, 15 + offset));
+
+/** Local calendar day, so a DST transition cannot make two equal dates compare unequal. */
+function dayKey(date: Date): string {
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+}
+
+/**
+ * Whether an expression's resolved date actually moves with the first weekday.
+ *
+ * This is the independent oracle: it asks the parser rather than the predicate.
+ *
+ * @param expression - `start_date` value to resolve
+ * @returns `true` when any reference date resolves two ways across the seven weekdays
+ */
+function resolvedDateMoves(expression: string): boolean {
+  return REFERENCE_DATES.some((now) => {
+    const landings = new Set(
+      WEEKDAYS.map((firstDayOfWeek) => {
+        const parsed = parseStartDateExpression(expression, firstDayOfWeek, now);
+        return parsed.kind === 'ok' ? dayKey(parsed.date) : parsed.kind;
+      }),
+    );
+
+    return landings.size > 1;
+  });
+}
+
+/** Expressions the grammar accepts, spanning every anchor and every operator form. */
+const GRAMMAR = [
+  'today',
+  'start_of_week',
+  'monday',
+  'mon',
+  'sunday',
+  'sun',
+  'saturday',
+  'sat',
+  'wednesday',
+  'wed',
+  '+7',
+  '-3',
+  'today+7',
+  'today-1w',
+  'today+sat',
+  'today-mon',
+  'start_of_week+7',
+  'start_of_week-3',
+  'start_of_week+1w',
+  'start_of_week-1w',
+  'start_of_week+sat',
+  'monday+1w',
+  'monday-1w',
+  'sat+3',
+  'sun-2w',
+  // Whitespace and case are normalized by the parser, so the predicate must normalize
+  // them too. The padded form is the exact shape that produced the cache collision.
+  ' start_of_week',
+  'start_of_week ',
+  ' start_of_week ',
+  'START_OF_WEEK',
+  'Start_Of_Week',
+  'start_of_week + 1w',
+  ' monday ',
+  'TODAY+7',
+];
+
+describe('isWeekRelative agrees with the parser', () => {
+  it.each(GRAMMAR)('%s', (expression) => {
+    expect(isWeekRelative(expression)).toBe(resolvedDateMoves(expression));
+  });
+
+  it('finds both answers across the sample, so neither side is trivially satisfied', () => {
+    // Without this, a predicate hard-coded to `false` would pass every case above if the
+    // sample happened to contain no week-relative value, and vice versa.
+    const relative = GRAMMAR.filter((expression) => resolvedDateMoves(expression));
+    const absolute = GRAMMAR.filter((expression) => !resolvedDateMoves(expression));
+
+    expect(relative.length).toBeGreaterThan(0);
+    expect(absolute.length).toBeGreaterThan(0);
+  });
+});
+
+describe('isWeekRelative on values outside the grammar', () => {
+  // These never reach the parser's weekday handling at all, so the resolved-date oracle
+  // has nothing to say about them. They are pinned directly because the regex this
+  // replaced got one of them wrong: `end_of_week` matched it and is not an anchor here.
+  it.each(['end_of_week', '2026-06-17', '2026-06-17T09:00:00', 'nonsense', '', '   '])(
+    '%s is not week-relative',
+    (value) => {
+      expect(isWeekRelative(value)).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
Follow-up to an independent audit of the v4 release candidate, reviewed at `d813bb6` — still the tip of `feature/column-view-v4`, so drift is 0.

Five commits, deliberately separable. **Only the first touches `src/`**; the rest are tests and `docs/development/`, so they cannot move a byte in `dist/`.

## The one genuine defect

`getBaseCacheKey` decided whether a `start_date` was week-relative using its own regex over the raw config value. That copy of the grammar had drifted **both** ways:

- **Under-matched, and this was live.** `getTimeWindow` trims before parsing; the regex was anchored at `^` and did not. A quoted `" start_of_week"` therefore resolved to a week-relative window while being keyed as absolute — a Sunday-start and a Monday-start profile shared one cache entry for two different sets of days, until the TTL expired.
- **Over-matched, harmlessly.** `end_of_week` is not an anchor in this grammar and had exactly one occurrence in the repository — that alternation. Every weekday anchor is `first_day_of_week`-independent, so seven of the nine alternatives only ever split an entry that could have been shared.

`isWeekRelative` now lives in `start-date.ts` beside the grammar, reusing the same tokenizer and normalization, so whitespace and case are handled by construction rather than by a second rule that can drift. Narrowing is safe because `firstDayOfWeek` is referenced in exactly one place in that parser — the `start_of_week` anchor.

Weekday anchors consequently stop contributing `_fdw` to the key. Nothing needs migrating: the key already embeds the version, so entries turn over at the bump regardless.

**Never shipped.** `dev`'s `getBaseCacheKey` takes no `firstDayOfWeek` at all, so this is branch-local and needs no release-note entry.

## Three mutation gaps closed

Each test was shown to fail against the unfixed code *before* the fix landed.

- **`actions.ts` had no test of its own.** Its only caller mocks the whole module, so the real `hass-action` dispatch had never executed — nothing verified the card emits it, that it escapes the shadow root, or that the entity `more-info` needs is attached. Ten single-branch mutants, each killed by the new file alone.
- **Multi-day middle segments.** That loop only runs for a *timed* event spanning 3+ calendar days and no fixture had one, so the `+ 1` deriving each segment's exclusive end date could become `+ 2` with the suite green. Verified by removing the new file and watching the mutant survive again.
- **Compact mode.** See below — the interesting one.

## The backlog was wrong about the compact-mode limit

It filed `totalEventsShown >= maxEvents` as an unpinned boundary. It is not: it is an **equivalent mutant**. `totalEventsShown` is incremented by `slice(0, remainingEvents)`, so it reaches `maxEvents` and never passes it, which makes `>` false exactly where `>=` is true — flipping it only stops the loop breaking early, after which the remaining days compute a zero budget and push nothing. Identical output, measured at **0 differing rows across a 1,279-config differential** (5 event layouts × 8 budgets × `show_empty_days` × `compact_events_complete_days` × 4 `compact_days_to_show` × `isExpanded`), against 281 and 42 for two controls in the same block. No test can close it, so the entry is corrected rather than satisfied with a test that pins nothing.

The same differential *did* find two mutants that were real and that the full suite missed. All three sites test `day.events.length === 1 && day.events[0]._isEmptyDay`, and the second operand is dead today — placeholders are created after this block, and replacing either operand with `false` at any site changes nothing. That leaves the first standing alone under `||`, which makes every single-event day take the placeholder path. Both are now closed by a test pinning the property that outlives the ordering: a day holding one real event counts against `compact_events_to_show` like any other.

## Backlog corrected, not merely appended

The mutation sweep the backlog listed as outstanding is now done for two files, with numbers. `view.ts` is strongly pinned — 49 of 52, and all three survivors resolve to unreachable or equivalent code. `calendar-card-pro.ts` is the weak one: 10 of 28 curated sites survive, clustering rather than scattering, and the largest cluster is that the suite is English-only end to end. Two sites there **cannot be swept at all** — relaxing either makes `updated()` re-enter itself, so the mutant loops rather than fails and hangs the runner.

Also bounds the `--calendar-color-rgb` item, which was correct but unbounded: it needs two opt-ins and has therefore never affected a default config.

## Verification

All nine gates pass, with the Node 22 pin for `check:docs` / `check:bundle` / `docs:build`. Suite 2,198 → 2,263. Bundle 192,064 → 192,102 B — still 192 KB, so the documented figure is unchanged and `check:bundle` agrees.