### PR TITLE
docs(ci): a GitHub outage fails validate-hacs the same way a bad branch name does

### DIFF
--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -24,12 +24,19 @@ name: HACS Validation
 # "Repository structure for <branch> is not compliant" on a pull request touching only `src/`,
 # `tests/` and `docs/development/`, none of which HACS reads.
 #
-# The two are told apart by repetition, not by reading the message: the branch-name bug is
-# deterministic and fails every run on that branch, while an outage does not. So **re-run the
-# job once before believing it**, and check https://www.githubstatus.com — a green re-run on an
-# unchanged commit is the whole diagnosis. Renaming a branch is the expensive wrong move here,
-# because it appears to work: the new run passes, and the rename gets the credit that belonged
-# to the retry.
+# **Settle it by running this workflow against `main`**, not by re-running the failed job:
+#
+#     gh workflow run hacs-validate.yml --ref main
+#
+# `main` is the ref HACS actually ships from, so it cannot be structurally non-compliant. If it
+# reports the same thing, the problem is not your branch. During that incident it did — "…for
+# refs/heads/main is not compliant" — which settled the question in one run.
+#
+# Retrying is the obvious move and it is not good enough: at a 50% error rate two consecutive
+# failures are a one-in-four coincidence, and this job failed **three times running** on one
+# unchanged commit that afternoon before the `main` control was tried. So "it failed twice, it
+# must be real" is worth nothing here. Renaming a branch is the expensive wrong move, because it
+# appears to work — the next run passes on its own and the rename takes the credit.
 on:
   pull_request:
     branches:

--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -16,6 +16,20 @@ name: HACS Validation
 # fetch then 404s and both content checks report generic "invalid hacs.json" / "no images in
 # Readme" errors while the six metadata checks pass. Rename the branch — see AGENTS.md,
 # "Branch model".
+#
+# A GitHub incident produces the same shape, and that is the trap: those two content checks
+# are the only ones that need a network fetch, so anything degrading raw.githubusercontent.com
+# fails exactly what the branch-name bug fails. On 2026-08-17 — "archive downloads and raw
+# repository content downloads … approximate 50% error rate" — this workflow reported
+# "Repository structure for <branch> is not compliant" on a pull request touching only `src/`,
+# `tests/` and `docs/development/`, none of which HACS reads.
+#
+# The two are told apart by repetition, not by reading the message: the branch-name bug is
+# deterministic and fails every run on that branch, while an outage does not. So **re-run the
+# job once before believing it**, and check https://www.githubstatus.com — a green re-run on an
+# unchanged commit is the whole diagnosis. Renaming a branch is the expensive wrong move here,
+# because it appears to work: the new run passes, and the rename gets the credit that belonged
+# to the retry.
 on:
   pull_request:
     branches:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,16 +396,28 @@ Both files were byte-identical to `main` throughout. Ten hypotheses were falsifi
 the branch name was suspected; the fix is to rename it and re-open the PR. Only reachable
 since v4 added the `pull_request` trigger below.
 
-**Re-run the job before you believe any of that, because a GitHub incident wears the same
-costume.** Those two content checks are the only ones that need a network fetch, so anything
-degrading `raw.githubusercontent.com` fails exactly what the branch name fails. On 2026-08-17
-— _"archive downloads and raw repository content downloads … approximate 50% error rate"_ —
-`validate-hacs` reported _"Repository structure for `<branch>` is not compliant"_ on a pull
-request touching only `src/`, `tests/` and `docs/development/`, none of which HACS reads; a
-re-run of the same commit passed. The discriminator is repetition rather than wording: the
-branch-name bug is deterministic and fails every run, an outage is not. This matters because
-the remedy above is self-confirming under an outage — rename, re-open, watch it pass, and the
-rename takes credit that belonged to the retry.
+**Run the workflow against `main` before you believe any of that, because a GitHub incident
+wears the same costume.** Those two content checks are the only ones that need a network
+fetch, so anything degrading `raw.githubusercontent.com` fails exactly what the branch name
+fails. On 2026-08-17 — _"archive downloads and raw repository content downloads … approximate
+50% error rate"_ — `validate-hacs` reported _"Repository structure for `<branch>` is not
+compliant"_ on a pull request touching only `src/`, `tests/` and `docs/development/`, none of
+which HACS reads.
+
+```bash
+gh workflow run hacs-validate.yml --ref main
+```
+
+`main` is the ref HACS ships from, so it cannot be structurally non-compliant; if it reports
+the same thing, the problem is not your branch. During that incident it did — _"…for
+`refs/heads/main` is not compliant"_ — and one run settled what retrying had not.
+
+**Retrying is the obvious discriminator and it is not good enough.** This document said
+"re-run once" for about ten minutes, until the job failed **three times running** on one
+unchanged commit — at a 50% error rate, two consecutive failures are a one-in-four
+coincidence, so "it failed twice, it must be real" is worth nothing. That matters because the
+remedy above is self-confirming under an outage: rename, re-open, watch it pass, and the
+rename takes credit that belonged to the weather.
 
 **When several branches feed one integration branch, "merged" has to name which branch.**
 Merging the integration branch _into_ your own, or merging your work into a peer's, leaves

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,17 @@ Both files were byte-identical to `main` throughout. Ten hypotheses were falsifi
 the branch name was suspected; the fix is to rename it and re-open the PR. Only reachable
 since v4 added the `pull_request` trigger below.
 
+**Re-run the job before you believe any of that, because a GitHub incident wears the same
+costume.** Those two content checks are the only ones that need a network fetch, so anything
+degrading `raw.githubusercontent.com` fails exactly what the branch name fails. On 2026-08-17
+— _"archive downloads and raw repository content downloads … approximate 50% error rate"_ —
+`validate-hacs` reported _"Repository structure for `<branch>` is not compliant"_ on a pull
+request touching only `src/`, `tests/` and `docs/development/`, none of which HACS reads; a
+re-run of the same commit passed. The discriminator is repetition rather than wording: the
+branch-name bug is deterministic and fails every run, an outage is not. This matters because
+the remedy above is self-confirming under an outage — rename, re-open, watch it pass, and the
+rename takes credit that belonged to the retry.
+
 **When several branches feed one integration branch, "merged" has to name which branch.**
 Merging the integration branch _into_ your own, or merging your work into a peer's, leaves
 a local state indistinguishable from being integrated: `git status` is clean, local equals


### PR DESCRIPTION
The workflow already documents why a branch ending in `tags` fails this job: HACS fetches `hacs.json` and the README from `raw.githubusercontent.com`, so the two content checks fail while the six metadata checks pass. Those two are **the only checks that touch the network**, so anything degrading raw content downloads fails exactly the same pair — and the message accuses the repository either way.

That happened while merging #518, during the incident reporting *"archive downloads and raw repository content downloads … approximate 50% error rate"*. This job reported **"Repository structure for `<branch>` is not compliant"** on a pull request touching only `src/`, `tests/` and `docs/development/`, none of which HACS reads.

The discriminator added here is:

```bash
gh workflow run hacs-validate.yml --ref main
```

`main` is the ref HACS ships from and cannot be structurally non-compliant, so if it reports the same thing the problem is not your branch.

**Confirmed on this PR, in both directions.** During the outage, `main` failed with *"Repository structure for `refs/heads/main` is not compliant"*. After mitigation, with no change to `main`, the same dispatch passed — and this PR's own `validate-hacs`, which had failed on both of its commits, passed on a re-run with no code change.

**Retrying is the obvious discriminator and it is not good enough.** The note said "re-run once" until this job failed **three times running** on one unchanged commit; at a 50% error rate two consecutive failures are a one-in-four coincidence. That matters because the documented remedy is self-confirming under an outage: rename the branch, re-open, watch it pass, and the rename takes credit that belonged to the weather.

Touches `.github/workflows/hacs-validate.yml` (beside the `tags` paragraph it would be confused with) and the matching passage in `AGENTS.md` § Branch model, whose stated fix — *"rename it and re-open the PR"* — is the advice that misfires.

No code change; 9/9 gates pass.
