### PR TITLE
test(host): cover effectiveLanguage, and withdraw two of its sibling findings

### DIFF
--- a/docs/development/backlog.md
+++ b/docs/development/backlog.md
@@ -173,13 +173,25 @@ unreachable because `normalizeColumnValue` floors numeric column options at `> 0
 `measuredWidthPx <= 0` guard is the same shape, and the hysteresis half-band's `- 1` is
 absorbed by the clamp. The `fitColumns` epsilon is documented in place as unkillable.
 
-The host element's ten survivors are worth closing next cycle, and they cluster:
+The host element's ten survivors cluster, and the first cluster turned out to be smaller than
+it looked:
 
-- **The suite is English-only end to end.** `this._language || 'en'` in `effectiveLanguage`,
-  and both halves of the language-recompute condition in `updated()`, all survive — every
-  fixture resolves to `en`, so a getter hard-wired to English is indistinguishable from a
-  correct one. This is the largest of the ten and the cheapest to fix: one host-level test in a
-  non-English language.
+- **~~The suite is English-only end to end.~~ Closed, and the original claim was wrong.**
+  `tests/host-language.test.ts` now covers `effectiveLanguage` — which no test read, while
+  `host-updated-wiring.test.ts` covered only the private `_language` field that every consumer
+  reaches _through_ that getter. So the `|| 'en'` arm was free: relaxing it to `&&` returns
+  `'en'` for every configured language and `''` when none is set, and the suite stayed green.
+  That one is real and is now killed by 7 of the new file's 9 tests.
+
+  The claim that this "closes three of the ten" was **over-stated and is withdrawn**. Both
+  halves of the language-recompute condition in `updated()` are **equivalent mutants**, not
+  coverage gaps: relaxing either `&&` to `||` only makes the condition true more often, and
+  recomputing the language is idempotent, so the resolved value never differs. Measured across
+  a 74-row lifecycle differential — 5 Home Assistant locales × 5 configured languages × 3
+  follow-up config edits, capturing `_language` and `effectiveLanguage` after each of three
+  lifecycle steps — at **0 differing rows each**, against 68 for the `effectiveLanguage`
+  mutant and 63 for a control. No test can close them; do not write one.
+
 - **Title-template state.** `isTitlePending` returns `isTemplate(title) && renderedTitle ===
 undefined`; relaxing it to `||` marks a plain string title as pending and nothing notices.
 - **Interaction edge.** The tap branch's `!this._holdTriggered` guard survives, because
@@ -190,6 +202,10 @@ undefined`; relaxing it to `||` marks a plain string title as pending and nothin
 - **Untriaged:** the refresh-interval fallback, the weather-subscription guard, the
   initial-load retry cleanup, the `isLimit` numeric test, and the empty-state branch in
   `render`.
+
+So the running total is **one closed, two withdrawn as equivalent, seven open** — and the
+lesson generalises past this file: a cluster of survivors sharing a subject is not evidence
+that they share a cause. These three all touched language resolution and only one was a gap.
 
 **What remains is breadth**, and specifically `src/rendering/` — `leaves.ts`, `render.ts`,
 `column.ts`, `presentation.ts` and `styles.ts` have not been mutation-tested at all.

--- a/tests/host-language.test.ts
+++ b/tests/host-language.test.ts
@@ -1,0 +1,166 @@
+/**
+ * The host's `effectiveLanguage` getter, and that the language it resolves reaches the DOM.
+ *
+ * Nothing read this getter. `tests/host-updated-wiring.test.ts` covers the *re-derivation*
+ * side — it asserts `_language` follows a config edit — but `_language` is the private field,
+ * and every consumer of the language (`groupedEvents`, `visibleEventCount`, `render`) goes
+ * through the getter instead. So the fallback arm was free: replacing `this._language || 'en'`
+ * with `&&` returns `'en'` for every configured language and `''` when none is set, and the
+ * whole suite stayed green. Measured at 68 of 74 rows changed in a lifecycle differential,
+ * against 0 for the two sibling mutants in `updated()`, which recompute more often and reach
+ * the same answer.
+ *
+ * The DOM assertions are the half that matters. A getter test alone would pass on a card whose
+ * renderers had stopped consulting the language at all, and this suite is otherwise built from
+ * English fixtures, where a hard-wired `'en'` is indistinguishable from a correct resolution.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW } from './fixtures';
+import '../src/calendar-card-pro';
+
+interface CardUnderTest extends HTMLElement {
+  setConfig(config: Record<string, unknown>): void;
+  hass: unknown;
+  events: unknown[];
+  isInitialLoad: boolean;
+  updateComplete: Promise<boolean>;
+  effectiveLanguage: string;
+}
+
+/** A Thursday, so the weekday abbreviation differs between English and German. */
+const EVENT = {
+  start: { dateTime: '2026-06-18T09:00:00.000Z' },
+  end: { dateTime: '2026-06-18T10:00:00.000Z' },
+  summary: 'Zahnarzt',
+  _entityId: 'calendar.personal',
+};
+
+/** An all-day event, whose label is a translated string rather than a formatted date. */
+const ALL_DAY = {
+  start: { date: '2026-06-18' },
+  end: { date: '2026-06-19' },
+  summary: 'Urlaub',
+  _entityId: 'calendar.personal',
+};
+
+function make(config: Record<string, unknown>): CardUnderTest {
+  const card = document.createElement('calendar-card-pro-dev') as unknown as CardUnderTest;
+  card.setConfig({ entities: ['calendar.personal'], days_to_show: 7, ...config });
+  card.isInitialLoad = false;
+  return card;
+}
+
+/** Mount with events already in hand, so nothing depends on the fetch path. */
+async function render(
+  config: Record<string, unknown>,
+  locale: { language: string } | undefined,
+  events: unknown[] = [EVENT],
+): Promise<CardUnderTest> {
+  const card = make(config);
+  document.body.appendChild(card);
+  card.hass = { states: {}, locale, connection: {} };
+  card.events = events;
+  await card.updateComplete;
+  return card;
+}
+
+describe('effectiveLanguage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('prefers the configured language over the Home Assistant locale', async () => {
+    const card = await render({ language: 'de' }, { language: 'en' });
+
+    expect(card.effectiveLanguage).toBe('de');
+  });
+
+  it('falls back to the Home Assistant locale when none is configured', async () => {
+    const card = await render({}, { language: 'de' });
+
+    expect(card.effectiveLanguage).toBe('de');
+  });
+
+  it('falls back to English when neither names a supported language', async () => {
+    // The `|| 'en'` arm. Reachable in production: `_language` is only assigned once `hass`
+    // has arrived, and `render()` reads the getter before that on the very first paint.
+    const card = await render({ language: 'klingon' }, { language: 'klingon' });
+
+    expect(card.effectiveLanguage).toBe('en');
+  });
+
+  it('resolves a regional locale to its base language', async () => {
+    // `de-DE` is not a translation of its own; `getEffectiveLanguage` splits it. Included
+    // because it is the shape a real Home Assistant profile sends.
+    const card = await render({}, { language: 'de-DE' });
+
+    expect(card.effectiveLanguage).toBe('de');
+  });
+
+  it('is English before hass arrives', async () => {
+    // The other half of the fallback: with no `hass` there is nothing to resolve against,
+    // and the getter must still return a usable language rather than an empty string.
+    const card = make({ language: 'de' });
+    document.body.appendChild(card);
+
+    expect(card.effectiveLanguage).toBe('en');
+  });
+});
+
+describe('the resolved language reaches the rendered card', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('renders weekday names in the configured language', async () => {
+    const german = await render({ language: 'de' }, { language: 'en' });
+    const text = german.shadowRoot?.textContent ?? '';
+
+    // 2026-06-18 is a Thursday: `Do` in German, `Thu` in English.
+    expect(text).toContain('Do');
+    expect(text).not.toContain('Thu');
+  });
+
+  it('renders weekday names in English when that is what resolves', async () => {
+    // The control. Without it, an assertion that German renders `Do` is also satisfied by a
+    // card that renders `Do` regardless of language — and every other fixture in this suite
+    // is English, so nothing else would notice.
+    const english = await render({ language: 'en' }, { language: 'de' });
+    const text = english.shadowRoot?.textContent ?? '';
+
+    expect(text).toContain('Thu');
+    expect(text).not.toContain('Do');
+  });
+
+  it('renders translated strings, not just formatted dates', async () => {
+    // A weekday could in principle come from `Intl` rather than from the card's own
+    // translations. `allDay` cannot: it exists only in the language files.
+    const german = await render({ language: 'de' }, { language: 'en' }, [ALL_DAY]);
+    const text = german.shadowRoot?.textContent ?? '';
+
+    expect(text).toContain('Ganztägig');
+    expect(text).not.toContain('All day');
+  });
+
+  it('follows the Home Assistant locale when no language is configured', async () => {
+    // Ties the two halves together: the getter's locale fallback is what the DOM shows.
+    const card = await render({}, { language: 'de' }, [ALL_DAY]);
+
+    expect(card.effectiveLanguage).toBe('de');
+    expect(card.shadowRoot?.textContent ?? '').toContain('Ganztägig');
+  });
+});


### PR DESCRIPTION
Continues closing the mutation gaps found auditing v4. One real gap closed, and **two of my own earlier findings withdrawn** as equivalent mutants.

## The gap

`effectiveLanguage` was read by no test. `host-updated-wiring.test.ts` covers the re-derivation side, but it asserts the private `_language` field — and every consumer (`groupedEvents`, `visibleEventCount`, `render`) reaches the language *through the getter*. So the `|| 'en'` arm was free: relaxing it to `&&` returns `'en'` for every configured language and `''` when none is set, with the whole suite green.

Killed by 7 of the new file's 9 tests; verified still surviving the full suite with the file removed.

## The DOM half is the half that matters

A getter test alone would pass on a card whose renderers had stopped consulting the language at all. This suite is otherwise built from English fixtures, where a hard-wired `'en'` is indistinguishable from a correct resolution — so each language assertion carries its English counterpart as a control ("German renders `Do`" is also satisfied by a card that renders `Do` regardless), and one case asserts a *translated string* (`Ganztägig`) rather than a formatted date, since a weekday could in principle come from `Intl` rather than the card's own translations.

## Two findings withdrawn

The backlog claimed one non-English test would close **three** survivors. It closes **one**. Both halves of the language-recompute condition in `updated()` are **equivalent mutants**: relaxing either `&&` to `||` only makes the condition true more often, and recomputing the language is idempotent, so the resolved value never differs.

Measured across a 74-row lifecycle differential — 5 Home Assistant locales x 5 configured languages x 3 follow-up config edits, sampling `_language` and `effectiveLanguage` at three lifecycle points:

| mutant | differing rows |
| --- | --- |
| `effectiveLanguage` fallback arm | **68** |
| `updated()` hass-locale arm | 0 |
| `updated()` config arm | 0 |
| control (force resolution to `lv`) | 63 |

The generalisable part, now recorded in the backlog: **a cluster of survivors sharing a subject is not evidence that they share a cause.** All three touched language resolution and only one was a gap.

Running total on the host element: one closed, two withdrawn, seven open.

9/9 gates. Suite 2,263 to 2,272.
