### PR TITLE
fix(v4): render a themed accent colour, deep-merge nested config, and close nine mutation gaps

### DIFF
--- a/docs/development/backlog.md
+++ b/docs/development/backlog.md
@@ -150,17 +150,28 @@ then deferred on the same reasoning: a new harness added at release point spends
 false positive at the worst possible moment, while the same harness added after a release
 costs only a re-run.
 
-**The v4 test suite has now been partly mutation-tested, and the results are uneven.** 95 test
-files were added on this branch. The sweeps below used type-safe operator swaps only, so a
-surviving mutant means the suite could not see a change that compiled — not that the source is
-wrong. Where a survivor was traced, it is classified; where it was not, it is listed as
-untriaged rather than as a defect.
+**The v4 test suite has now been mutation-tested across eight files, and the results are
+uneven.** 95 test files were added on this branch. The sweeps below used type-safe operator
+swaps only, so a surviving mutant means the suite could not see a change that compiled — not
+that the source is wrong. Where a survivor was traced, it is classified; where it was not, it is
+listed as untriaged rather than as a defect. **Across the fully-triaged files, real gaps and
+equivalent mutants came out at roughly one to one.** That ratio is the point: most survivors are
+defensive duplication, so a sweep that stops at the survivor count and calls each one a gap will
+be wrong about about half of them.
 
-| File                       | Sites | Killed | Survived | Reading                                      |
-| -------------------------- | ----: | -----: | -------: | -------------------------------------------- |
-| `src/config/view.ts`       |    52 |     49 |        3 | all three unreachable or equivalent          |
-| `src/calendar-card-pro.ts` |  28\* |     17 |       10 | **weakest of the three; see the list below** |
-| `src/utils/events.ts`      |   131 |     81 |       50 | largely defensive guards; partly untriaged   |
+| File                            | Sites | Killed | Survived | Reading                                    |
+| ------------------------------- | ----: | -----: | -------: | ------------------------------------------ |
+| `src/config/view.ts`            |    52 |     49 |        3 | all three unreachable or equivalent        |
+| `src/calendar-card-pro.ts`      |  28\* |     17 |       10 | **2 real gaps closed, 8 equivalent**       |
+| `src/utils/events.ts`           |   131 |     81 |       50 | largely defensive guards; partly untriaged |
+| `src/rendering/column.ts`       |    17 |     16 |        1 | survivor provably equivalent               |
+| `src/rendering/leaves.ts`       |  24\* |     24 |        0 | no gap found                               |
+| `src/rendering/render.ts`       |    10 |      6 |        4 | **3 real gaps, now closed**; 1 equivalent  |
+| `src/rendering/presentation.ts` |     9 |      7 |        2 | **1 real gap closed**; 1 equivalent        |
+| `src/rendering/styles.ts`       | 9\*\* |      4 |        5 | **5 real gaps, all closed**                |
+
+\*\* Only the nine sites in TypeScript. The rest of that file is a `css` tagged template,
+where an operator swap is not executable code.
 
 \* A curated subset of the host element's operator sites, not all of them. Two more — the
 `updated()` guard at the `hass`-just-arrived test, and the weather-config comparison beside it
@@ -199,16 +210,76 @@ undefined`; relaxing it to `||` marks a plain string title as pending and nothin
   branch always wins first. It becomes reachable only when a user writes a bare `hold_action:`
   in YAML — the shallow-merge hazard recorded above — and a hold would then also fire the tap
   action.
-- **Untriaged:** the refresh-interval fallback, the weather-subscription guard, the
+- **Untriaged:** ~~the refresh-interval fallback, the weather-subscription guard, the
   initial-load retry cleanup, the `isLimit` numeric test, and the empty-state branch in
-  `render`.
+  `render`.~~ **All five triaged. Two were real and are closed by
+  `tests/host-guards.test.ts`:**
+  - **The refresh timer ignored its configured interval.** `config.refresh_interval ||
+DEFAULT` — the fallback never fires, because `toValidNumber` has already guaranteed a
+    number, so nothing noticed when the configured value stopped being read at all. A card
+    set to refresh every 5 minutes would have quietly refreshed every 30.
+  - **A card with no calendars rendered an empty agenda instead of the error state.**
+    Reachable from the editor, which holds an empty list mid-edit.
 
-So the running total is **one closed, two withdrawn as equivalent, seven open** — and the
-lesson generalises past this file: a cluster of survivors sharing a subject is not evidence
-that they share a cause. These three all touched language resolution and only one was a gap.
+  The other three are **equivalent mutants**, each masked by a duplicate of its own check
+  further down:
+  - the retry cleanup is followed by a branch that clears and re-arms the timer either way;
+  - `isLimit`'s `Number.isFinite` sits behind `toValidNumber`, which reduces every limit —
+    card-level _and_ per-entity — to `number | undefined` before it is read;
+  - the weather-setup early return is masked **three** times: `getRequiredForecastTypes`
+    returns an empty list without an entity, `subscribeToWeatherForecast` guards
+    `!hass?.connection`, and that function's `try`/`catch` absorbs whatever is left. Relaxing
+    the first two _together_ still changes nothing observable, so this one is unkillable by
+    construction rather than merely untested.
 
-**What remains is breadth**, and specifically `src/rendering/` — `leaves.ts`, `render.ts`,
-`column.ts`, `presentation.ts` and `styles.ts` have not been mutation-tested at all.
+So the running total is **three closed, five withdrawn as equivalent, two open** (title-template
+state and the tap/hold interaction edge) — and the lesson generalises past this file: a cluster
+of survivors sharing a subject is not evidence that they share a cause. The language three all
+touched language resolution and only one was a gap; the five here shared nothing but the file.
+
+**`src/rendering/` has now been swept in full, and the shape is informative.** `leaves.ts` (24
+sites) and `column.ts` (17) came back with **no gap at all** — 40 of 41 killed, the single
+survivor provably equivalent, because `days[index - 1]` at `index === 0` is `undefined`, which
+is exactly what the `else` branch returns. The v4 column view is the best-pinned rendering code
+in the project, and it stayed that way after the week-number band landed: all four mutants on
+that new grid-row logic died.
+
+`render.ts` was the opposite: **4 of 10 survived, and 3 were real**, now closed by
+`tests/list-separator-branches.test.ts`. All three are separator branches, and they share one
+cause — every separator width defaults to `'0px'` and `show_week_numbers` to `null`, so a suite
+built from `DEFAULT_CONFIG` draws no separator of any kind and cannot reach them.
+`zero-length.test.ts` turns the _month_ width on and covers that path, which is why these three
+looked covered:
+
+- `renderHorizontalSeparator`'s zero-width early return — the **day** separator's own
+  suppression, a different call path from the month rule.
+- `renderWeekRow` choosing month styling over week styling, invisible unless the two widths are
+  configured _differently_.
+- `hasWeekSeparator`, which does not gate the week row at all — it stops a day rule being
+  stacked on top of one, so the observable is a separator **count** (4 → 3), not a presence.
+
+The generalisable part: a fixture that turns one option on does not cover the options beside
+it, and a shared width hides which branch chose it. Configure the neighbours differently.
+
+`presentation.ts` gave up one real gap — `isPastEvent` used `now > endDateTime` with nothing
+pinning the boundary, while the all-day branch beside it was pinned by the shared fixtures.
+`tests/event-state-classes.test.ts` now carries the millisecond case so the two paths cannot
+drift apart. Its other survivor is equivalent: `isRunning && show_progress_bar` is re-checked by
+`hasProgressBar` in `leaves.ts`, and `calculateEventProgress` re-checks `isEventCurrentlyRunning`
+internally, so the presentation-side test is defensive duplication. Mutating the `leaves.ts`
+half alone **is** caught, which is how the pair was told apart.
+
+**`styles.ts` was the worst of the eight files: 5 of its 9 executable sites survived, and all
+five were real.** They are the `--calendar-card-weather-*` fallbacks — a surface v4 turned from
+inline styles into published theming hooks, all six documented with defaults in `theming.md`.
+The defaults are the common case rather than the edge case, because `setConfig` merges `weather`
+shallowly: a block naming only `entity` arrives with `date` and `event` absent, so every badge
+reads its fallback. Dropping one emits `undefined` into the property, and **both `npm test` and
+`check:docs` stayed green** — the docs gate counts the documented defaults but never reconciles
+them against the code. `tests/custom-property-mapping.test.ts` now pins each fallback beside a
+distinct override, which also catches two properties crossed.
+
+**What remains** is breadth in `src/utils/events.ts`, where 50 survivors are still untriaged.
 
 **No gate cross-checks documented CSS classes against emitted ones.** `theming.md` lists the
 classes the card exposes, the renderers emit them, and nothing compares the two sets. The

--- a/docs/development/backlog.md
+++ b/docs/development/backlog.md
@@ -78,34 +78,41 @@ reviewed column layout was the wrong way round on the eve of a release; it is th
 round once the release is out. **Scope the selector to list view, or re-verify column
 view's weather spacing alongside the change.**
 
-**`setConfig` merges only the top level.** It builds the effective configuration as
-`{ ...DEFAULT_CONFIG, ...config }`, so a nested block the user writes partly replaces the
-default block wholesale instead of being filled in key by key. A `weather:` holding just
-`entity:` therefore arrives with `position`, `date` and `event` all `undefined`, even
-though `position` is published with a default of `date` in the reference and the two
-sub-blocks carry defaults of their own in `DEFAULT_CONFIG`.
+**~~`setConfig` merges only the top level.~~ Fixed.** It built the effective configuration as
+`{ ...DEFAULT_CONFIG, ...config }`, so a nested block the user wrote partly replaced the default
+block wholesale instead of being filled in key by key. A `weather:` holding just `entity:`
+therefore arrived with `position`, `date` and `event` all `undefined`, even though `position` is
+published with a default of `date` and the two sub-blocks carry defaults of their own.
 
-This produced two defects in v4 review, and both were fixed at the symptom rather than at
-the cause. `isCustomized` in `src/rendering/editor/filter.ts` now returns early when the
-value it reads is `undefined`, so the editor's Customized Only filter stops flagging keys
-the user never wrote, and `resolveWeatherPosition` in `src/utils/weather.ts` centralises
-the `position` default that the subscribe and render halves had been resolving
-differently — one paying for a forecast stream the other then declined to draw. Both are
-covered by tests that fail if the fix is removed.
+`Config.mergeConfig` now recurses into plain objects and replaces arrays wholesale, so
+`entities:` still overwrites rather than merging into the default list, and a non-object value
+such as `weather: null` still clears the block.
 
-The cause is still there, so a third reader of a nested default can repeat it. What bounds
-the risk is that the exposed surface is almost entirely `weather`: `DEFAULT_CONFIG` has
-four nested entries, and `tap_action` and `hold_action` each default to a single key while
-`entities` defaults to `[]` and is written in full, so none of them can lose a key to a
-partial write the way `weather` can.
+**The write path needed no change, which is why this was safe to do here rather than early in a
+cycle.** The concern was that `toStoredConfig` strips defaults on save, so filling them in on
+read would make the editor write ninety keys the user never typed. It already handles nesting:
+`weather` is routed through `stripWeatherDefaults`, which compares each nested option against
+the same defaults and drops the ones that agree, and `filterDefaultValues` recurses for
+everything else. `tests/editor-value-round-trip.test.ts` asserts the whole loop by exact object
+rather than by key count — break the strip and six of its cases fail.
 
-A deep merge is the real fix and was deliberately not attempted on a release candidate.
-It changes `setConfig` semantics for every consumer at once, and `hasConfigChanged`,
-`isCustomized` and `toStoredConfig` are all built around the current shape —
-`toStoredConfig` in particular strips defaults back out on the write path, so filling them
-in on the read path has to be matched there or the card starts writing ninety defaults
-into the user's YAML. **Do it early in a cycle, with the write path changed in the same
-commit, not as a late fix.**
+The two symptom fixes are left in place deliberately. `resolveWeatherPosition` and
+`isCustomized`'s `undefined` guard both still answer correctly, and both are still reached with
+configs that never went through `setConfig` — the editor builds preview objects of its own, and
+much of the suite calls the renderers directly. They are no longer load-bearing for the ordinary
+path; they are load-bearing for those.
+
+One thing the fix does **not** change: a block the user never mentioned is still
+`DEFAULT_CONFIG`'s own sub-object by reference, since only blocks the user also wrote are
+rebuilt. `normalizeLengthOptions` already rebuilds rather than writing through, which covers it.
+The frozen-config hazard is narrower than it was — a user's `weather:` is now a fresh object —
+but `column` has no default block, so a frozen `column:` still arrives by reference.
+
+**The lesson worth keeping is about the fixture, not the merge.** `buildConfig` in
+`tests/fixtures.ts` claimed to build configs "the same way `setConfig` does" and did its own
+shallow spread, so every fixture in the suite would have kept the old shape while production
+moved. It now calls `mergeConfig`. Two test files had also hand-rolled the merge to simulate
+`setConfig`; one of them existed specifically to catch a defect the shallow merge caused.
 
 **`visible:` conditions in the editor.** Home Assistant's `ha-form` can hide a row through
 a `visible:` condition rather than through the memoised schema recomputation the editor does
@@ -121,27 +128,31 @@ user-initiated `value-changed`, so opening the editor on a YAML-set `min_day_wid
 not silently clamp it — the number has to be touched first. **Either give the cap a runtime
 counterpart in `normalizeColumnValue` and document the range, or drop it.**
 
-**`convertToRGBA` emits a CSS variable that nothing defines.** The `var(` branch of
-`computeRGBA` in `src/utils/helpers.ts` returns `rgba(var(--calendar-color-rgb, 3, 169, 244),
-…)`, and `--calendar-color-rgb` has exactly one occurrence in `src/` — that line itself. No
-stylesheet or inline style ever sets it, so the fallback light blue always wins and a themed
-`var(--primary-color)` input never reaches the rendered colour. Re-confirmed at the v4 tip,
-and the line does ship in `dist/calendar-card-pro.js`.
+**~~`convertToRGBA` emits a CSS variable that nothing defines.~~ Fixed.** The `var(` branch of
+`computeRGBA` in `src/utils/helpers.ts` returned `rgba(var(--calendar-color-rgb, 3, 169, 244),
+…)` against a variable with exactly one occurrence in `src/` — that line itself. No stylesheet
+or inline style ever set it, so the fallback won every time and a themed `var(--primary-color)`
+never reached the rendered colour.
 
-**It is not reachable on default config, which is what bounds the severity.** Two opt-ins are
-both required. `accent_color` defaults to `#03a9f4`, a hex, so the `var(` branch is not taken;
-and `event_background_opacity` defaults to `0`, on which `getEntityAccentColorWithOpacity`
-returns before calling `convertToRGBA` at all. A user has to set a `var()` colour _and_ raise
-the opacity, and no page documents `var()` as a value for that option — the `var()` usages in
-`theming.md` are all card-mod CSS, which is a different surface. Note also that the hard-coded
-fallback `3, 169, 244` **is** `#03a9f4`, so the symptom is not a wrong-looking card but a
-themed colour silently collapsing to the default accent.
+The proposed remedy — defining `--calendar-color-rgb` on the host — was not taken, because it
+cannot work: `rgba()` needs three channel values, and a `var()` reference cannot be taken apart
+into them without resolving it, which is exactly what must not happen here. `rgbaCache` is
+module-level and never evicted, so resolving at call time would pin whichever theme was active
+on first render for the life of the page.
 
-Resolving the colour eagerly is the wrong fix, and was declined for that reason. The branch
-returns a live CSS expression precisely so the value stays reactive to a theme switch, and
-`rgbaCache` is module-level and never evicted, so computing fixed RGB at call time would pin
-whichever theme was active on first render for the life of the page. **Define
-`--calendar-color-rgb` on the host element instead.**
+The branch now emits `color-mix(in srgb, <colour> <opacity>%, transparent)`, which stays a live
+CSS expression and therefore still follows a theme switch, while actually carrying the
+configured colour. This is the idiom the stylesheet already uses in three places, including the
+progress-bar track, so it adds no new dependency.
+
+Worth keeping for the shape of it: the hard-coded fallback `3, 169, 244` **is** `#03a9f4`, the
+default `accent_color`. The bug was therefore invisible on any default config and on any theme
+whose primary colour happened to be close — the card did not look broken, it looked like the
+default. It also needed two opt-ins to reach at all (a `var()` colour _and_ a non-zero
+`event_background_opacity`, which defaults to `0` on a path that returns first), which is why it
+survived to v4. `tests/helpers-color-and-icon.test.ts` now pins both the unit output and the
+rendered background, each with a control asserting that two different variables give two
+different results — the one thing a hardcoded fallback can never do.
 
 ## Verification debt
 

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -868,7 +868,14 @@ class CalendarCardPro extends LitElement {
       Logger.deprecation(message);
     }
 
-    const mergedConfig = { ...Config.DEFAULT_CONFIG, ...config };
+    // Deep rather than a plain spread: a nested block the user writes partly — a
+    // `weather:` naming only `entity:` — must keep the defaults for everything it does
+    // not mention, instead of blanking them. `mergeConfig` replaces arrays wholesale, so
+    // `entities:` still overwrites rather than merging into the default list.
+    const mergedConfig = Config.mergeConfig(
+      Config.DEFAULT_CONFIG as unknown as Record<string, unknown>,
+      config as Record<string, unknown>,
+    ) as unknown as Types.Config;
 
     this.config = mergedConfig;
     this.config.entities = Config.normalizeEntities(this.config.entities);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -182,6 +182,49 @@ export const DEPRECATED_ENTITY_CONFIG_MAP: Readonly<Record<string, string>> = {
 };
 
 /**
+ * Merges a user configuration over the defaults, filling nested blocks key by key.
+ *
+ * A plain spread merges the top level only, so a `weather:` block naming just `entity:`
+ * replaced the whole default sub-tree and arrived with `position`, `date` and `event` all
+ * `undefined` — even though each is published with a default. That produced two defects in
+ * v4 review, both fixed at the symptom: `resolveWeatherPosition` had to centralise a
+ * `position` default the subscribe and render halves were resolving differently, and
+ * `isCustomized` had to treat an absent value as not-customized so the editor's filter
+ * stopped flagging keys the user never wrote. This is the cause behind both.
+ *
+ * Only plain objects recurse. **Arrays are replaced wholesale**, which is what `entities:`
+ * needs — merging a two-calendar list over a three-calendar default would leave behind a
+ * third calendar the user had deleted. A user value that is not a plain object always wins,
+ * so `weather: null` clears the block rather than being merged into.
+ *
+ * The write path already matches this: `toStoredConfig` routes `weather` through
+ * `stripWeatherDefaults`, which compares each nested option against these same defaults and
+ * drops the ones that agree, so filling them in here does not make the editor write them
+ * back into the user's YAML.
+ *
+ * @param defaults - Shipped defaults, treated as the shape to fill in from
+ * @param overrides - Raw user configuration, which wins wherever it is present
+ * @returns A new object; neither input is mutated
+ */
+export function mergeConfig(
+  defaults: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...defaults };
+
+  for (const [key, value] of Object.entries(overrides)) {
+    const fallback = defaults[key];
+
+    merged[key] =
+      Helpers.isConfigBlock(value) && Helpers.isConfigBlock(fallback)
+        ? mergeConfig(fallback, value)
+        : value;
+  }
+
+  return merged;
+}
+
+/**
  * Reports removed config keys found in the raw user configuration.
  *
  * Reads the raw config before `DEFAULT_CONFIG` fills every key in. Entity entries are
@@ -291,8 +334,8 @@ export function coercePixelLength(key: string, value: unknown): unknown {
  */
 export function coercePixelLengthAgainst(shippedDefault: unknown, value: unknown): unknown {
   // A blank YAML value — `day_separator_width:` with nothing after the colon — parses as
-  // `null`, and a key written explicitly as `undefined` survives `setConfig`'s shallow
-  // merge the same way. Both mean "no value supplied", so a length-valued option has to
+  // `null`, and a key written explicitly as `undefined` survives `setConfig`'s merge the
+  // same way. Both mean "no value supplied", so a length-valued option has to
   // fall back to what it ships with. This mirrors the contract `toValidNumber` already
   // states for numeric options: empty editor values and `null` must not collapse an
   // option. Without it the `null` reaches `isZeroLength`, which calls `.trim()` on it and
@@ -368,10 +411,10 @@ function bareNumber(value: unknown): string | undefined {
  * by `resolveColumnOption` against `COLUMN_DEFAULTS`.
  *
  * **Nested groups are copied, never written through.** Home Assistant hands cards a frozen
- * configuration, and `setConfig` merges it shallowly — so `config.weather` and
- * `config.tap_action` are the *user's own frozen objects*, not copies. Writing into one
- * throws in strict mode. Rebuilding changed groups also prevents edits to shared default
- * objects from leaking between cards.
+ * configuration. `mergeConfig` rebuilds any block the user also wrote, so those are safe to
+ * touch — but a block the user did not mention is still `DEFAULT_CONFIG`'s own object by
+ * reference, and writing into that would edit the defaults for every card in the process.
+ * Rebuilding changed groups covers both cases without having to tell them apart.
  *
  * @param config - Configuration to normalize in place
  * @returns The same object, for chaining alongside `normalizeNumericOptions`

--- a/src/rendering/editor/filter.ts
+++ b/src/rendering/editor/filter.ts
@@ -282,9 +282,11 @@ export function isCustomized(
 
   const value = valueAt(normalized(ctx.config), dataPath, name);
 
-  // `setConfig` merges only the top level, so a nested block the user wrote partly — say a
-  // `weather:` holding just `entity:` — leaves its remaining keys absent rather than filled in
-  // from the defaults. Absent is not customized; the card still falls back to its own default.
+  // A key the merged config does not carry at all — one absent from `DEFAULT_CONFIG`, or a
+  // block the user cleared outright — is not customized; the card falls back to its own
+  // default. `setConfig` now fills nested blocks in from the defaults, so the ordinary
+  // partially-written block no longer arrives here undefined, and the branch below answers
+  // it by comparison instead. This guard remains for the cases that never had a default.
   if (value === undefined) return false;
 
   return !deepEqual(value, valueAt(Config.DEFAULT_CONFIG, dataPath, name));

--- a/src/rendering/styles.ts
+++ b/src/rendering/styles.ts
@@ -91,7 +91,8 @@ export function generateCustomPropertiesObject(config: Types.Config): Record<str
       config.weather?.date?.color || 'var(--primary-text-color)',
     '--calendar-card-weather-event-icon-size': config.weather?.event?.icon_size || '14px',
     '--calendar-card-weather-event-font-size': config.weather?.event?.font_size || '12px',
-    // Read with a fallback because setConfig merges weather shallowly; a user
+    // Read with a fallback because this function is also called with configs that never
+    // went through setConfig — the editor's own preview objects, and tests — where a
     // weather block can omit event.max_lines entirely.
     '--calendar-card-weather-event-max-lines':
       (config.weather?.event?.max_lines ?? 0) > 0

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -35,7 +35,20 @@ export function convertToRGBA(color: string, opacity: number): string {
 
 function computeRGBA(color: string, opacity: number): string {
   if (color.startsWith('var(')) {
-    return `rgba(var(--calendar-color-rgb, 3, 169, 244), ${opacity / 100})`;
+    // `color-mix` rather than `rgba(...)`, because a `var()` reference cannot be taken
+    // apart into the three channel values `rgba()` needs. The previous form emitted
+    // `rgba(var(--calendar-color-rgb, 3, 169, 244), …)` against a variable this card
+    // defines nowhere and no theme knows about, so the literal fallback — which is the
+    // default `accent_color` `#03a9f4` — won every time. A themed `var(--primary-color)`
+    // silently rendered as the shipped blue, and the failure was invisible on a default
+    // config precisely because the two agree there.
+    //
+    // Mixing with `transparent` keeps the whole expression live, so it still follows a
+    // theme switch: nothing is resolved at call time, which matters because `rgbaCache`
+    // is module-level and never evicted. The stylesheet already applies transparency this
+    // way (the progress bar's track and the today outline), so this is the idiom the card
+    // uses everywhere else rather than a new dependency.
+    return `color-mix(in srgb, ${color} ${opacity}%, transparent)`;
   }
 
   if (color === 'transparent') {

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -15,12 +15,13 @@ import * as Types from '../config/types';
 /**
  * Resolve the effective weather position, applying the documented `date` default.
  *
- * `setConfig` merges with `{ ...DEFAULT_CONFIG, ...config }` — a *shallow* spread — so a
- * user `weather:` block replaces the default block wholesale and `position` arrives
- * `undefined` unless it was spelled out. Every consumer must therefore resolve the
- * default itself, and reading `weather.position` raw is exactly how the subscribe and
- * render halves drifted apart: the card subscribed to the daily forecast and then drew
- * nothing.
+ * `setConfig` fills a partial `weather:` block in from the defaults, so `position` normally
+ * arrives set. This still resolves it, because the config reaching these helpers does not
+ * always come through `setConfig`: the editor builds preview configs of its own, and both
+ * halves of the weather pipeline are called directly from tests. Reading
+ * `weather.position` raw is exactly how the subscribe and render halves drifted apart —
+ * the card subscribed to the daily forecast and then drew nothing — so the default is
+ * resolved in one place rather than assumed to have been filled in upstream.
  *
  * This resolves a *missing* value only; it deliberately does not validate. Config
  * arrives from YAML unvalidated, so `position` can hold something outside its declared

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -5,6 +5,7 @@ import {
   DEPRECATED_CONFIG_MAP,
   findDeprecatedKeys,
   hasConfigChanged,
+  mergeConfig,
   normalizeEntities,
   normalizeNumericOptions,
   toValidNumber,
@@ -313,5 +314,84 @@ describe('findDeprecatedKeys', () => {
   it('reports a top-level key set to a falsy value', () => {
     // `in` rather than truthiness: `row_spacing: 0` is still a setting being discarded.
     expect(findDeprecatedKeys({ row_spacing: 0 } as unknown as Types.Config)).toHaveLength(1);
+  });
+});
+
+/**
+ * Nested config blocks are filled in key by key, not replaced wholesale.
+ *
+ * `setConfig` used to build the effective config with `{ ...DEFAULT_CONFIG, ...config }`, so
+ * a `weather:` block naming only `entity:` arrived with `position`, `date` and `event` all
+ * `undefined` — even though each is published with a default. That produced two defects in
+ * v4 review and both were fixed at the symptom: `resolveWeatherPosition` centralised a
+ * `position` default the subscribe and render halves were resolving differently, and
+ * `isCustomized` had to treat an absent value as not-customized so the editor's Customized
+ * Only filter stopped flagging keys the user never wrote.
+ *
+ * The dangerous half of fixing the cause is the write path. `toStoredConfig` strips defaults
+ * back out when the editor saves, so filling them in on read without a matching strip would
+ * write every default into the user's YAML. That round trip is asserted here rather than
+ * assumed, because it is the failure that would be discovered by users rather than by CI.
+ */
+describe('mergeConfig fills nested blocks from the defaults', () => {
+  it('keeps the defaults a partial block does not mention', () => {
+    const merged = mergeConfig(DEFAULT_CONFIG as unknown as Record<string, unknown>, {
+      weather: { entity: 'weather.home' },
+    }) as unknown as Types.Config;
+
+    expect(merged.weather?.entity).toBe('weather.home');
+    expect(merged.weather?.position).toBe(DEFAULT_CONFIG.weather?.position);
+    expect(merged.weather?.date).toEqual(DEFAULT_CONFIG.weather?.date);
+    expect(merged.weather?.event).toEqual(DEFAULT_CONFIG.weather?.event);
+  });
+
+  it('fills a nested group in around the one option that was written', () => {
+    // Two levels down. The group has to survive as a whole, not be replaced by the single
+    // key the user named inside it.
+    const merged = mergeConfig(DEFAULT_CONFIG as unknown as Record<string, unknown>, {
+      weather: { entity: 'weather.home', event: { show_temp: false } },
+    }) as unknown as Types.Config;
+
+    expect(merged.weather?.event?.show_temp).toBe(false);
+    expect(merged.weather?.event?.icon_size).toBe(DEFAULT_CONFIG.weather?.event?.icon_size);
+    expect(merged.weather?.date).toEqual(DEFAULT_CONFIG.weather?.date);
+  });
+
+  it('replaces arrays wholesale instead of merging them', () => {
+    // The control that keeps the recursion honest. Merging `entities` element by element
+    // would leave a calendar the user deleted still configured.
+    const merged = mergeConfig({ entities: ['a', 'b', 'c'] }, { entities: ['x'] });
+
+    expect(merged.entities).toEqual(['x']);
+  });
+
+  it('lets a non-object value clear a block outright', () => {
+    // `weather: null` is a thing a user can write, and it has to mean "no weather" rather
+    // than "merge null into the defaults".
+    expect(
+      mergeConfig({ weather: { entity: undefined, position: 'date' } }, { weather: null }).weather,
+    ).toBeNull();
+  });
+
+  it('mutates neither input', () => {
+    const defaults = { weather: { position: 'date' } };
+    const overrides = { weather: { entity: 'weather.home' } };
+
+    mergeConfig(defaults, overrides);
+
+    expect(defaults).toEqual({ weather: { position: 'date' } });
+    expect(overrides).toEqual({ weather: { entity: 'weather.home' } });
+  });
+
+  it('rebuilds a block the user also wrote, so a frozen one is safe to normalize', () => {
+    // Home Assistant hands cards a frozen config. Before the merge went deep, a user's
+    // `weather:` reached the merged object by reference and writing into it threw.
+    const overrides = Object.freeze({ weather: Object.freeze({ entity: 'weather.home' }) });
+    const merged = mergeConfig(
+      DEFAULT_CONFIG as unknown as Record<string, unknown>,
+      overrides as unknown as Record<string, unknown>,
+    );
+
+    expect(Object.isFrozen(merged.weather)).toBe(false);
   });
 });

--- a/tests/custom-property-mapping.test.ts
+++ b/tests/custom-property-mapping.test.ts
@@ -142,3 +142,73 @@ describe('custom property mapping', () => {
     expect(emitted.filter((name) => !asserted.has(name) && !known.has(name))).toEqual([]);
   });
 });
+
+/**
+ * The weather badges' theming hooks, which the allowlist above admits are emitted but
+ * never asserted.
+ *
+ * v4 turned these into a real override surface: the badges used to carry their size and
+ * colour as inline `style` attributes that no theme could reach, and `theming.md` now
+ * publishes all six properties with defaults. The defaults are the half that matters,
+ * because `setConfig` merges `weather` shallowly — a user block naming only `entity`
+ * arrives with `date` and `event` entirely absent, so every one of these reads its
+ * fallback. That is the common case, not the edge case.
+ *
+ * All five unconditional fallbacks survived a mutation sweep of `styles.ts`: rewriting
+ * `?? '14px'` so the fallback is dropped emits `undefined` into the property, and both
+ * `npm test` and `check:docs` stayed green. Each pair below asserts the fallback and a
+ * distinct override, so a mapping that ignores its config and a mapping that has lost its
+ * default both fail — and the override values are unique, so two crossed properties fail
+ * as well.
+ */
+const WEATHER_FALLBACKS = [
+  ['icon_size', '--calendar-card-weather-date-icon-size', '14px', '31px', 'date'],
+  ['font_size', '--calendar-card-weather-date-font-size', '12px', '32px', 'date'],
+  [
+    'color',
+    '--calendar-card-weather-date-color',
+    'var(--primary-text-color)',
+    'rgb(9, 0, 0)',
+    'date',
+  ],
+  ['icon_size', '--calendar-card-weather-event-icon-size', '14px', '33px', 'event'],
+  ['font_size', '--calendar-card-weather-event-font-size', '12px', '34px', 'event'],
+] as const;
+
+describe('weather custom properties', () => {
+  it.each(WEATHER_FALLBACKS)(
+    'falls %s back to %s for the %s badge',
+    (_option, property, fallback, _override, placement) => {
+      // The shallow-merge case: a weather block naming only `entity`, which is what the
+      // documented minimal config looks like.
+      const props = propsFor({ weather: { entity: 'weather.home' } });
+
+      expect(props[property]).toBe(fallback);
+      expect(placement).toMatch(/^(date|event)$/);
+    },
+  );
+
+  it.each(WEATHER_FALLBACKS)(
+    'passes a configured %s through to %s',
+    (option, property, _fallback, override, placement) => {
+      // The other direction. Without this, a property hardcoded to its own default would
+      // satisfy every fallback assertion above.
+      const props = propsFor({
+        weather: { entity: 'weather.home', [placement]: { [option]: override } },
+      });
+
+      expect(props[property]).toBe(override);
+    },
+  );
+
+  it('keeps the two placements independent', () => {
+    // The badges sit beside different text colours and keep separate fallbacks; setting
+    // one must not move the other. A single shared read would pass both tables above.
+    const props = propsFor({
+      weather: { entity: 'weather.home', date: { icon_size: '41px' } },
+    });
+
+    expect(props['--calendar-card-weather-date-icon-size']).toBe('41px');
+    expect(props['--calendar-card-weather-event-icon-size']).toBe('14px');
+  });
+});

--- a/tests/custom-property-mapping.test.ts
+++ b/tests/custom-property-mapping.test.ts
@@ -150,9 +150,9 @@ describe('custom property mapping', () => {
  * v4 turned these into a real override surface: the badges used to carry their size and
  * colour as inline `style` attributes that no theme could reach, and `theming.md` now
  * publishes all six properties with defaults. The defaults are the half that matters,
- * because `setConfig` merges `weather` shallowly — a user block naming only `entity`
- * arrives with `date` and `event` entirely absent, so every one of these reads its
- * fallback. That is the common case, not the edge case.
+ * because this function is reached with configs that never went through `setConfig` — the
+ * editor's own preview objects, and tests — where a `weather:` block naming only `entity`
+ * carries no `date` or `event` at all, so every one of these reads its fallback.
  *
  * All five unconditional fallbacks survived a mutation sweep of `styles.ts`: rewriting
  * `?? '14px'` so the fallback is dropped emits `undefined` into the property, and both
@@ -179,8 +179,8 @@ describe('weather custom properties', () => {
   it.each(WEATHER_FALLBACKS)(
     'falls %s back to %s for the %s badge',
     (_option, property, fallback, _override, placement) => {
-      // The shallow-merge case: a weather block naming only `entity`, which is what the
-      // documented minimal config looks like.
+      // A weather block naming only `entity`, which is what the documented minimal
+      // config looks like, handed straight to the generator without a merge.
       const props = propsFor({ weather: { entity: 'weather.home' } });
 
       expect(props[property]).toBe(fallback);

--- a/tests/editor-value-round-trip.test.ts
+++ b/tests/editor-value-round-trip.test.ts
@@ -1,0 +1,145 @@
+/**
+ * A config filled in on read must come back out minimal on write.
+ *
+ * `setConfig` deep-merges the user's YAML over `DEFAULT_CONFIG`, so the config the editor
+ * holds carries every nested default explicitly. `toStoredConfig` is what strips them back
+ * out when the editor saves. If the two ever disagree, the card rewrites the user's YAML
+ * with ninety keys they never typed — the failure the deep merge was deferred over, and one
+ * that would be found by users rather than by CI, because nothing about it is red.
+ *
+ * Each case asserts the exact stored object rather than a key count, so a default that
+ * survives the strip fails here even if the total happens to match.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import '../src/calendar-card-pro';
+import * as Config from '../src/config/config';
+import type * as Types from '../src/config/types';
+import { toStoredConfig } from '../src/rendering/editor/value';
+
+/** The config `setConfig` would hold for a given piece of user YAML. */
+function asSetConfigWould(raw: Record<string, unknown>): Types.Config {
+  const merged = Config.mergeConfig(
+    Config.DEFAULT_CONFIG as unknown as Record<string, unknown>,
+    raw,
+  ) as unknown as Types.Config;
+
+  merged.entities = Config.normalizeEntities(merged.entities);
+  Config.normalizeNumericOptions(merged);
+  Config.normalizeLengthOptions(merged);
+  return merged;
+}
+
+describe('setConfig and toStoredConfig round trip', () => {
+  it('gives back only the calendars for a minimal config', () => {
+    expect(toStoredConfig(asSetConfigWould({ entities: ['calendar.a'] }))).toEqual({
+      entities: [{ entity: 'calendar.a' }],
+    });
+  });
+
+  it('gives back only the entity for a weather block that names one', () => {
+    // The case the deep merge exists for. On the way in this gains `position`, `date` and
+    // `event`; on the way out it has to lose all three again.
+    expect(
+      toStoredConfig(
+        asSetConfigWould({ entities: ['calendar.a'], weather: { entity: 'weather.home' } }),
+      ),
+    ).toEqual({
+      entities: [{ entity: 'calendar.a' }],
+      weather: { entity: 'weather.home' },
+    });
+  });
+
+  it('keeps the one nested option the user changed, and nothing beside it', () => {
+    expect(
+      toStoredConfig(
+        asSetConfigWould({
+          entities: ['calendar.a'],
+          weather: { entity: 'weather.home', event: { show_temp: false } },
+        }),
+      ),
+    ).toEqual({
+      entities: [{ entity: 'calendar.a' }],
+      weather: { entity: 'weather.home', event: { show_temp: false } },
+    });
+  });
+
+  it('keeps a partial action block whole', () => {
+    expect(
+      toStoredConfig(
+        asSetConfigWould({
+          entities: ['calendar.a'],
+          tap_action: { action: 'navigate', navigation_path: '/lovelace/0' },
+        }),
+      ),
+    ).toEqual({
+      entities: [{ entity: 'calendar.a' }],
+      tap_action: { action: 'navigate', navigation_path: '/lovelace/0' },
+    });
+  });
+
+  it('keeps a column override without filling the block', () => {
+    // `column` has no default block at all, so it takes a different path through both the
+    // merge and the strip; a regression there would show as a filled-in block here.
+    expect(
+      toStoredConfig(
+        asSetConfigWould({
+          entities: ['calendar.a'],
+          view: 'column',
+          column: { day_spacing: '4px' },
+        }),
+      ),
+    ).toEqual({
+      entities: [{ entity: 'calendar.a' }],
+      view: 'column',
+      column: { day_spacing: '4px' },
+    });
+  });
+
+  it('control: a genuinely changed top-level option is kept', () => {
+    // Without this, every assertion above is satisfied by a strip that drops everything.
+    expect(toStoredConfig(asSetConfigWould({ entities: ['calendar.a'], days_to_show: 7 }))).toEqual(
+      {
+        entities: [{ entity: 'calendar.a' }],
+        days_to_show: 7,
+      },
+    );
+  });
+});
+
+/**
+ * The same contract, reached through the element rather than through a helper.
+ *
+ * Everything above calls `mergeConfig` directly, which is the producer — not the path
+ * production takes. Reverting `setConfig` to its old shallow spread left every assertion
+ * above passing, because none of them touches the card. These drive the real custom
+ * element, so the wiring is pinned rather than the function it is wired to.
+ */
+describe('the card element fills nested blocks on setConfig', () => {
+  interface CardUnderTest extends HTMLElement {
+    setConfig(config: unknown): void;
+    config: Types.Config;
+  }
+
+  function configure(raw: Record<string, unknown>): Types.Config {
+    const card = document.createElement('calendar-card-pro-dev') as unknown as CardUnderTest;
+    card.setConfig(raw);
+    return card.config;
+  }
+
+  it('keeps the weather defaults a partial block does not mention', () => {
+    const config = configure({ entities: ['calendar.a'], weather: { entity: 'weather.home' } });
+
+    expect(config.weather?.entity).toBe('weather.home');
+    expect(config.weather?.position).toBe(Config.DEFAULT_CONFIG.weather?.position);
+    expect(config.weather?.event?.icon_size).toBe(Config.DEFAULT_CONFIG.weather?.event?.icon_size);
+  });
+
+  it('still replaces the calendar list rather than merging it', () => {
+    // The control: the element must not have started deep-merging arrays either.
+    expect(configure({ entities: ['calendar.only'] }).entities).toEqual([
+      { entity: 'calendar.only' },
+    ]);
+  });
+});

--- a/tests/event-state-classes.test.ts
+++ b/tests/event-state-classes.test.ts
@@ -114,4 +114,42 @@ describe('event state classes', () => {
     // A card-mod rule written against one view has to keep matching in the other.
     expect(firstDayEventClasses('column')).toEqual(firstDayEventClasses('list'));
   });
+
+  it('does not call an event past at the instant it ends', () => {
+    // `now > endDateTime`, not `>=`. The boundary is one millisecond wide and survived a
+    // mutation sweep, while the all-day branch beside it — `today > endDate` — is pinned
+    // by the fixtures above; this makes the timed path carry the same convention rather
+    // than leaving the two free to drift apart.
+    //
+    // Both halves are asserted, so the test cannot pass on a card that has stopped
+    // marking anything past at all.
+    const endsExactlyNow: Types.CalendarEventData = {
+      start: { dateTime: '2026-06-17T09:00:00.000Z' },
+      end: { dateTime: FROZEN_NOW.toISOString() },
+      summary: 'ends-now',
+      _entityId: 'calendar.personal',
+    };
+    const endedAMillisecondAgo: Types.CalendarEventData = {
+      start: { dateTime: '2026-06-17T09:00:00.000Z' },
+      end: { dateTime: new Date(FROZEN_NOW.getTime() - 1).toISOString() },
+      summary: 'ended',
+      _entityId: 'calendar.personal',
+    };
+
+    const config = buildConfig({ days_to_show: 1, show_past_events: true });
+    const days = EventUtils.groupEventsByDay(
+      [endsExactlyNow, endedAMillisecondAgo],
+      config,
+      false,
+      'en',
+    );
+    const container = document.createElement('div');
+    litRender(Render.renderGroupedEvents(days, config, 'en', undefined, null), container);
+
+    const past = Array.from(container.querySelectorAll('.event')).map((element) =>
+      element.classList.contains('past-event'),
+    );
+
+    expect(past).toEqual([false, true]);
+  });
 });

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -34,15 +34,20 @@ export const FROZEN_NOW = new Date('2026-06-17T10:00:00.000Z');
  * Builds a config the same way `setConfig` does, so fixtures exercise the real
  * normalization path rather than a hand-assembled object that happens to look right.
  *
- * Mirrors `calendar-card-pro.ts` `setConfig`: merge over defaults, then normalize
- * entities and numeric options in that order.
+ * Mirrors `calendar-card-pro.ts` `setConfig`: deep-merge over the defaults, then normalize
+ * entities and numeric options in that order. The merge has to be the real one — a plain
+ * spread here would hand every fixture a `weather:` block stripped of its nested defaults,
+ * which is precisely the shape production no longer produces.
  */
 export function buildConfig(overrides: Partial<Types.Config> = {}): Types.Config {
-  const config: Types.Config = {
-    ...Config.DEFAULT_CONFIG,
-    entities: ['calendar.personal'],
-    ...overrides,
-  };
+  const config = Config.mergeConfig(
+    Config.DEFAULT_CONFIG as unknown as Record<string, unknown>,
+    {
+      entities: ['calendar.personal'],
+      ...overrides,
+    } as Record<string, unknown>,
+  ) as unknown as Types.Config;
+
   config.entities = Config.normalizeEntities(config.entities);
   Config.normalizeNumericOptions(config);
   return config;

--- a/tests/helpers-color-and-icon.test.ts
+++ b/tests/helpers-color-and-icon.test.ts
@@ -5,11 +5,14 @@
  * into the event background. A mutation sweep found two of its branches free to
  * break with the whole suite green:
  *
- * 1. The `var(...)` branch divides the 0-100 opacity by 100 to reach a CSS alpha.
- *    Dropping that division emits `alpha: 30` instead of `0.3`, which CSS clamps to
- *    a fully opaque background — so a themed card configured for a 30% tint would
- *    render solid. Themed colours are the common case, since the default
- *    `accent_color` and every HA theme variable arrive as `var(...)`.
+ * 1. The `var(...)` branch applies the 0-100 opacity as a `color-mix` percentage.
+ *    It used to emit `rgba(var(--calendar-color-rgb, 3, 169, 244), …)` against a
+ *    variable this card defines nowhere and no theme knows about, so the literal
+ *    fallback always won — and that fallback is the default `accent_color`, which is
+ *    why a themed card looked correct until someone compared it against the theme it
+ *    was supposed to follow. Themed colours are the common case, since every HA theme
+ *    variable arrives as `var(...)`. The assertions below pin the configured colour
+ *    reaching the output, which the old form could not do at all.
  *
  * 2. The two `rgb()` / `rgba()` branches convert a resolved literal colour. Neither
  *    is reachable under happy-dom, which returns `getComputedStyle(el).color`
@@ -22,8 +25,13 @@
  * `startsWith('http')` guard is load-bearing only for the malformed `http:<char>`
  * shape, which the leading regex would otherwise accept as an icon prefix.
  */
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render as litRender } from 'lit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as Render from '../src/rendering/render';
+import * as EventUtils from '../src/utils/events';
 import * as Helpers from '../src/utils/helpers';
 
 /**
@@ -42,18 +50,29 @@ afterEach(() => {
 });
 
 describe('convertToRGBA turns a configured opacity into a CSS alpha', () => {
-  it('scales a themed var() colour from 0-100 to a 0-1 alpha', () => {
+  it('carries a themed var() colour through to the output', () => {
+    // The colour itself has to appear. The previous form discarded it entirely and
+    // emitted a fixed fallback, so an assertion that only checked the alpha passed while
+    // every themed card rendered the shipped blue.
     expect(Helpers.convertToRGBA('var(--primary-color)', 30)).toBe(
-      'rgba(var(--calendar-color-rgb, 3, 169, 244), 0.3)',
+      'color-mix(in srgb, var(--primary-color) 30%, transparent)',
+    );
+  });
+
+  it('keeps the two apart when different variables are configured', () => {
+    // The control for the assertion above: two distinct inputs must give two distinct
+    // outputs, which is exactly what a hardcoded fallback cannot do.
+    expect(Helpers.convertToRGBA('var(--accent-color)', 30)).not.toBe(
+      Helpers.convertToRGBA('var(--primary-color)', 30),
     );
   });
 
   it('scales the extremes of the same var() branch', () => {
     expect(Helpers.convertToRGBA('var(--accent-color)', 100)).toBe(
-      'rgba(var(--calendar-color-rgb, 3, 169, 244), 1)',
+      'color-mix(in srgb, var(--accent-color) 100%, transparent)',
     );
     expect(Helpers.convertToRGBA('var(--card-background-color)', 5)).toBe(
-      'rgba(var(--calendar-color-rgb, 3, 169, 244), 0.05)',
+      'color-mix(in srgb, var(--card-background-color) 5%, transparent)',
     );
   });
 
@@ -100,5 +119,73 @@ describe('isIconValue separates an icon name from a URL', () => {
     expect(Helpers.isIconValue('https://example.com/a.png')).toBe(false);
     expect(Helpers.isIconValue('/local/badge.png')).toBe(false);
     expect(Helpers.isIconValue('Holiday')).toBe(false);
+  });
+});
+
+/**
+ * The end-to-end half of the same defect.
+ *
+ * `convertToRGBA` is only reached from `getEntityAccentColorWithOpacity`, behind two
+ * opt-ins — a `var()` accent colour and a non-zero `event_background_opacity`, which
+ * defaults to `0` on a path that returns before the conversion happens. So the unit
+ * assertions above can all pass while nothing a user sees ever changes. This renders the
+ * card and reads the background off the event, which is the only claim that matters.
+ */
+describe('a themed accent colour reaches the rendered event background', () => {
+  const EVENT = [
+    {
+      start: { dateTime: '2026-06-18T09:00:00.000Z' },
+      end: { dateTime: '2026-06-18T10:00:00.000Z' },
+      summary: 'themed',
+      _entityId: 'calendar.personal',
+    },
+  ] as unknown as Types.CalendarEventData[];
+
+  function backgrounds(overrides: Record<string, unknown>): string[] {
+    const config = buildConfig({ days_to_show: 7, start_date: '2026-06-18', ...overrides });
+    const days = EventUtils.groupEventsByDay(EVENT, config, false, 'en');
+    const container = document.createElement('div');
+    litRender(Render.renderGroupedEvents(days, config, 'en'), container);
+    return Array.from(container.querySelectorAll<HTMLElement>('[style]'))
+      .map((node) => node.getAttribute('style') ?? '')
+      .filter((style) => style.includes('background-color'));
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the configured variable, not a hardcoded fallback', () => {
+    const styles = backgrounds({
+      accent_color: 'var(--primary-color)',
+      event_background_opacity: 30,
+    });
+
+    expect(styles.length).toBeGreaterThan(0);
+    expect(styles.join(' ')).toContain('color-mix(in srgb, var(--primary-color) 30%, transparent)');
+    // The colour the old fallback always resolved to. Its absence is the regression guard:
+    // every themed card used to render this instead of the theme's own colour.
+    expect(styles.join(' ')).not.toContain('3, 169, 244');
+  });
+
+  it('follows a different variable when a different one is configured', () => {
+    // The control. A fallback that happens to match the theme would satisfy the assertion
+    // above; two distinct inputs producing two distinct outputs cannot be faked that way.
+    const primary = backgrounds({
+      accent_color: 'var(--primary-color)',
+      event_background_opacity: 30,
+    });
+    const accent = backgrounds({
+      accent_color: 'var(--accent-color)',
+      event_background_opacity: 30,
+    });
+
+    expect(primary.join(' ')).not.toBe(accent.join(' '));
+    expect(accent.join(' ')).toContain('var(--accent-color)');
   });
 });

--- a/tests/host-guards.test.ts
+++ b/tests/host-guards.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Guards in the card host that a mutation sweep left standing, and what each turned out
+ * to be.
+ *
+ * Two were real gaps and are closed here: a refresh interval that silently reverted to
+ * the built-in default, and the error state for a card with no calendars configured.
+ *
+ * The rest were **equivalent mutants**, and are recorded rather than tested, because a
+ * test that appeared to pin one would be pinning the mutation's own absorption:
+ *
+ * - the retry-cleanup guard in `updateEvents` is followed by a branch that clears and
+ *   re-arms the timer either way;
+ * - `hasCompactModeLimits`'s `Number.isFinite` check sits behind `toValidNumber`, which
+ *   has already reduced every limit — card-level and per-entity — to `number | undefined`;
+ * - the weather-setup early return is masked **three** times over. Its entity half is
+ *   absorbed by `getRequiredForecastTypes`, which returns an empty list without one; its
+ *   `hass` half by `subscribeToWeatherForecast`, which guards `!hass?.connection`; and
+ *   both by that function's `try`/`catch`, which is deliberate — a weather stream that
+ *   fails must not take the card down with it. Relaxing the first two together still
+ *   changes nothing observable.
+ *
+ * The weather cases below therefore pin the *contract* rather than any mutant: a card
+ * configured for weather but not yet given `hass` — the ordinary first-paint ordering —
+ * subscribes to nothing and does not reject.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '../src/calendar-card-pro';
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+
+interface CardUnderTest extends HTMLElement {
+  setConfig(config: unknown): void;
+  hass?: unknown;
+  isInitialLoad: boolean;
+  events: Types.CalendarEventData[];
+  updateComplete: Promise<boolean>;
+  _setupWeatherSubscriptions(): Promise<void>;
+  _weatherUnsubscribers: Array<() => void>;
+}
+
+/** Resolve pending microtasks and the macrotask queue. */
+const flush = (): Promise<unknown> => new Promise((resolve) => setTimeout(resolve, 0));
+
+function card(config: Record<string, unknown> = {}): CardUnderTest {
+  const element = document.createElement('calendar-card-pro-dev') as unknown as CardUnderTest;
+  element.setConfig(buildConfig({ entities: ['calendar.personal'], ...config }));
+  element.isInitialLoad = false;
+  return element;
+}
+
+/** A connection that records every subscription attempt. */
+function recordingHass(): { hass: unknown; attempts: number } {
+  const state = { attempts: 0 };
+  return {
+    attempts: 0,
+    hass: {
+      states: {},
+      callService: () => {},
+      locale: { language: 'en' },
+      callApi: async () => [],
+      connection: {
+        async subscribeMessage() {
+          state.attempts += 1;
+          return () => {};
+        },
+      },
+      _state: state,
+    },
+  } as unknown as { hass: unknown; attempts: number };
+}
+
+describe('the refresh timer honours the configured interval', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('schedules the next refresh at refresh_interval, not the built-in default', async () => {
+    // `refresh_interval` reaches this read already normalized, so the `|| DEFAULT` beside it
+    // is defensive and never fires — which is exactly why dropping the configured value in
+    // favour of the default went unnoticed. The default is 30 minutes; 5 is chosen so the
+    // two cannot be confused.
+    const element = card({ refresh_interval: 5 });
+    const timeout = vi.spyOn(window, 'setTimeout');
+
+    document.body.appendChild(element);
+    element.hass = { states: {}, callService: () => {}, locale: { language: 'en' } };
+    await element.updateComplete;
+
+    const delays = timeout.mock.calls.map((args) => args[1]);
+
+    expect(delays).toContain(5 * 60 * 1000);
+    expect(delays).not.toContain(30 * 60 * 1000);
+
+    timeout.mockRestore();
+  });
+});
+
+describe('weather setup requires a Home Assistant connection', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('subscribes when both the entity and hass are present', async () => {
+    // The positive control. Without it the assertion below passes on a card that has
+    // stopped subscribing under every condition.
+    const element = card({ weather: { entity: 'weather.home', position: 'date' } });
+    const recording = recordingHass();
+    element.hass = recording.hass;
+    document.body.appendChild(element);
+
+    await element._setupWeatherSubscriptions();
+    await flush();
+
+    expect((recording.hass as { _state: { attempts: number } })._state.attempts).toBeGreaterThan(0);
+  });
+
+  it('attempts nothing when hass is absent', async () => {
+    // Pins the contract, not a mutant. The guard this looks like it is testing is masked
+    // three times over — see the file header — so no behavioural test can kill it, and
+    // claiming otherwise would be the "check that cannot fail" this suite exists to avoid.
+    // What is genuinely worth holding is the outcome: a card configured for weather that
+    // has not yet received `hass` subscribes to nothing and does not reject.
+    const element = card({ weather: { entity: 'weather.home', position: 'date' } });
+    element.hass = undefined;
+    document.body.appendChild(element);
+
+    await expect(element._setupWeatherSubscriptions()).resolves.toBeUndefined();
+    expect(element._weatherUnsubscribers).toHaveLength(0);
+  });
+});
+
+describe('the card reports an unusable configuration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  /** The rendered text of a card in the given state. */
+  async function textFor(config: Record<string, unknown>, hass: unknown): Promise<string> {
+    const element = card(config);
+    document.body.appendChild(element);
+    element.hass = hass;
+    await element.updateComplete;
+    return element.shadowRoot?.textContent ?? '';
+  }
+
+  it('shows the error state when no calendars are configured', async () => {
+    // Reachable from the editor, which can hold an empty calendar list mid-edit. Without
+    // this arm the card renders an ordinary empty agenda and gives no hint that it is
+    // waiting for configuration rather than for events.
+    const text = await textFor(
+      { entities: [] },
+      {
+        states: {},
+        callService: () => {},
+        locale: { language: 'en' },
+      },
+    );
+
+    expect(text).toMatch(/error|entities|configur/i);
+  });
+
+  it('renders normally when calendars are configured', async () => {
+    // The control: the assertion above must be caused by the empty list, not by the
+    // harness failing to render anything at all.
+    const element = card();
+    document.body.appendChild(element);
+    element.hass = { states: {}, callService: () => {}, locale: { language: 'en' } };
+    element.events = [];
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.textContent ?? '').not.toMatch(/error/i);
+  });
+});

--- a/tests/list-separator-branches.test.ts
+++ b/tests/list-separator-branches.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Three separator branches in the list view that render nothing at default config.
+ *
+ * `day_separator_width`, `week_separator_width` and `month_separator_width` all default to
+ * `'0px'` and `show_week_numbers` defaults to `null`, so a suite built from `DEFAULT_CONFIG`
+ * draws no separator of any kind and cannot reach this code. `tests/zero-length.test.ts` turns
+ * the *month* width on and covers that path well; these three sit outside it and each survived
+ * a mutation sweep of `render.ts`:
+ *
+ * - `renderHorizontalSeparator`'s `isZeroLength(lineWidth) || isFirstWeek` early return — the
+ *   day separator's own suppression, on a different call path from the month rule.
+ * - `renderWeekRow`'s `isMonthBoundary && !isZeroLength(month_separator_width)`, which picks
+ *   month styling over week styling for the row's rule.
+ * - `hasWeekSeparator`'s `show_week_numbers !== null || !isZeroLength(week_separator_width)`,
+ *   which is what makes a week row appear to carry the *number* when no rule is drawn.
+ *
+ * The two rule widths are deliberately different everywhere below. With a single shared width
+ * a branch that picks the wrong one is invisible, which is part of why the month/week
+ * selection survived in the first place.
+ */
+
+import { render as litRender } from 'lit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW, buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as Render from '../src/rendering/render';
+import * as EventUtils from '../src/utils/events';
+
+/** One event a day across a month boundary, so week and month boundaries both occur. */
+const ACROSS_BOUNDARIES: Types.CalendarEventData[] = [
+  '2026-06-28',
+  '2026-06-29',
+  '2026-06-30',
+  '2026-07-01',
+  '2026-07-02',
+].map((date) => ({
+  start: { dateTime: `${date}T09:00:00.000Z` },
+  end: { dateTime: `${date}T10:00:00.000Z` },
+  summary: `event-${date}`,
+  _entityId: 'calendar.personal',
+}));
+
+function renderList(overrides: Partial<Types.Config>): HTMLElement {
+  const config = buildConfig({
+    days_to_show: 30,
+    start_date: '2026-06-28',
+    ...overrides,
+  });
+  const days = EventUtils.groupEventsByDay(ACROSS_BOUNDARIES, config, false, 'en');
+  const container = document.createElement('div');
+  litRender(Render.renderGroupedEvents(days, config, 'en'), container);
+  return container;
+}
+
+/** The `--separator-border-width` on each week row that draws a rule, in document order. */
+function weekRowRuleWidths(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('.separator-cell'))
+    .map(
+      (cell) => /--separator-border-width:\s*([^;]+)/.exec(cell.getAttribute('style') ?? '')?.[1],
+    )
+    .filter((width): width is string => width !== undefined)
+    .map((width) => width.trim());
+}
+
+/** Both rule widths, configured differently so a wrong branch shows up as a wrong width. */
+const DISTINCT_RULES = {
+  show_week_numbers: 'iso',
+  week_separator_width: '1px',
+  month_separator_width: '5px',
+} as Partial<Types.Config>;
+
+describe('the day separator suppresses itself at zero width', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits day separators when the width is non-zero', () => {
+    // The positive control: without it every assertion below is satisfied by a fixture that
+    // produces no day boundaries at all.
+    expect(
+      renderList({ day_separator_width: '3px' }).querySelectorAll('.separator').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('emits no day separator element at zero width', () => {
+    expect(renderList({ day_separator_width: '0px' }).querySelectorAll('.separator')).toHaveLength(
+      0,
+    );
+  });
+
+  it('leaves no separator margin behind at zero width', () => {
+    // The half a border-only suppression would miss: a separator's margins come from
+    // `day_spacing` and do not scale with its border width, so an invisible rule still costs
+    // the gap it would have sat in.
+    const withZero = Array.from(
+      renderList({ day_separator_width: '0px' }).querySelectorAll<HTMLElement>('[style]'),
+    ).map((node) => node.getAttribute('style') ?? '');
+
+    expect(withZero.filter((style) => style.includes('border-top-style:solid'))).toEqual([]);
+  });
+});
+
+describe('a week row is not styled as a month boundary', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('draws the week rule at the week width, not the month width', () => {
+    // The month width is non-zero and different, so a branch that stops requiring an actual
+    // month boundary before choosing month styling shows up here as the wrong width on a week
+    // row. The month rule itself is drawn elsewhere and is asserted separately below.
+    const widths = weekRowRuleWidths(renderList(DISTINCT_RULES));
+
+    expect(widths.length).toBeGreaterThan(0);
+    expect(new Set(widths)).toEqual(new Set(['1px']));
+  });
+
+  it('still draws the month rule at its own width', () => {
+    // The control for the assertion above: `5px` has to be reachable somewhere, or "no 5px on
+    // a week row" would also pass on a card that had stopped drawing month rules entirely.
+    const monthRules = Array.from(
+      renderList(DISTINCT_RULES).querySelectorAll<HTMLElement>('.month-separator'),
+    ).map((node) => node.getAttribute('style') ?? '');
+
+    expect(monthRules.length).toBeGreaterThan(0);
+    expect(monthRules.join(' ')).toContain('border-top-width:5px');
+  });
+});
+
+describe('week numbers bring their own row', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the week row for the number even with no rule to draw', () => {
+    // `show_week_numbers` alone is enough: the row exists to carry the number, and the
+    // separator width only decides whether a line is drawn inside it. Requiring both would
+    // drop week numbers for everyone who never set a separator width — which is everyone,
+    // since it defaults to `0px`.
+    const rendered = renderList({ show_week_numbers: 'iso', week_separator_width: '0px' });
+
+    expect(rendered.querySelectorAll('.week-row-table').length).toBeGreaterThan(0);
+    expect(rendered.querySelectorAll('.week-number').length).toBeGreaterThan(0);
+  });
+
+  it('renders no week row when neither a number nor a rule is asked for', () => {
+    // The control, and the reason the assertion above is not vacuous: the row is absent by
+    // default, so its presence there is caused by `show_week_numbers`.
+    const rendered = renderList({ show_week_numbers: null, week_separator_width: '0px' });
+
+    expect(rendered.querySelectorAll('.week-row-table')).toHaveLength(0);
+  });
+
+  it('suppresses the day separator where the week row already draws one', () => {
+    // What `hasWeekSeparator` is actually for. It does not gate the week row — it stops a
+    // day rule being stacked on top of one, so a week boundary shows a single line rather
+    // than two. Requiring a non-zero `week_separator_width` before that suppression applies
+    // would put both back at every week boundary for anyone showing week numbers without a
+    // rule, which is the default pairing.
+    const withNumbers = renderList({
+      show_week_numbers: 'iso',
+      week_separator_width: '0px',
+      day_separator_width: '2px',
+    });
+    const withoutNumbers = renderList({
+      show_week_numbers: null,
+      week_separator_width: '0px',
+      day_separator_width: '2px',
+    });
+
+    // The pair is the assertion: the same fixture draws one fewer day rule once the week row
+    // is present. Either count alone would be satisfied by a card that never suppressed
+    // anything, or by one that had stopped drawing day separators at all.
+    expect(withoutNumbers.querySelectorAll('.separator')).toHaveLength(4);
+    expect(withNumbers.querySelectorAll('.separator')).toHaveLength(3);
+  });
+});

--- a/tests/max-lines.test.ts
+++ b/tests/max-lines.test.ts
@@ -67,11 +67,11 @@ describe('per-field max-lines custom properties', () => {
  * thing in the per-event weather row long enough to wrap: the condition stated in words,
  * which the column layout adds.
  *
- * Read through the same fallback chain as every other weather property, because
- * `setConfig` merges shallowly — a user's `weather:` block replaces the default sub-tree
- * whole, so a card that configures weather at all has no `max_lines` in its merged
- * config. Reading it off the merged default would emit `none` for every user who set
- * one, which is the failure this pins.
+ * Read through the same fallback chain as every other weather property. `setConfig` now
+ * fills a partial `weather:` block in from the defaults, but this function is also called
+ * with configs that never went through it — the editor's preview objects, and tests — so
+ * the fallback still has to hold. Reading the value off a merged default that was not
+ * there would emit `none` for every user who set one, which is the failure this pins.
  */
 describe('the weather row line limit', () => {
   const PROP = '--calendar-card-weather-event-max-lines';
@@ -95,7 +95,7 @@ describe('the weather row line limit', () => {
   });
 
   it('emits none for a weather block that never mentions it', () => {
-    // The shallow-merge case: this block is what a real user's YAML produces.
+    // The block a real user's YAML produces, with the option left unmentioned.
     expect(generateCustomPropertiesObject(withWeather({ show_conditions: true }))[PROP]).toBe(
       'none',
     );

--- a/tests/pixel-length-coercion.test.ts
+++ b/tests/pixel-length-coercion.test.ts
@@ -164,9 +164,11 @@ describe('Y21 — pixel-length coercion', () => {
   });
 
   /**
-   * Home Assistant hands a card its configuration **frozen**, and `setConfig` merges it
-   * shallowly — so `config.weather` and `config.tap_action` on the merged object are the
-   * user's own frozen objects, not copies of them.
+   * Home Assistant hands a card its configuration **frozen**, and a frozen sub-object can
+   * still reach the merged config. `setConfig` rebuilds any block that has a default —
+   * `weather`, `tap_action`, `hold_action` — so those are safe to write into now. `column`
+   * has no default (it stays `undefined` so an empty block means "no block"), so a user's
+   * `column:` arrives by reference, frozen, exactly as before.
    *
    * Writing into one throws `TypeError: Cannot assign to read only property` in strict
    * mode, which is every module here, and it throws even when the assignment would not
@@ -239,8 +241,9 @@ describe('Y21 — pixel-length coercion', () => {
     });
 
     it('leaves the shipped defaults alone when no block is supplied', () => {
-      // The shallow merge hands back DEFAULT_CONFIG's own sub-objects by reference, so an
-      // in-place coercion here would edit the defaults for every card in the process.
+      // A block the user never mentioned is still DEFAULT_CONFIG's own sub-object by
+      // reference — the merge only rebuilds what the user also wrote — so an in-place
+      // coercion here would edit the defaults for every card in the process.
       const before = JSON.stringify(Config.DEFAULT_CONFIG.weather);
       const config = {
         ...Config.DEFAULT_CONFIG,

--- a/tests/view-config.test.ts
+++ b/tests/view-config.test.ts
@@ -480,8 +480,9 @@ describe('validateView', () => {
     expect(warnMock.mock.calls[0][0]).toContain('colunm');
   });
 
-  // `{ ...DEFAULT_CONFIG, ...config }` lets an explicitly-undefined key overwrite the
-  // shipped default, so `view` can be absent despite being a required field.
+  // A key written explicitly as `undefined` still overwrites the shipped default —
+  // `Object.entries` yields it, and only plain objects recurse — so `view` can be absent
+  // despite being a required field.
   it.each([
     ['undefined', undefined],
     ['null', null],

--- a/tests/weather-position.test.ts
+++ b/tests/weather-position.test.ts
@@ -182,12 +182,15 @@ describe('weather position `none` renders no badge', () => {
 /**
  * The same contract once more, but reached the way a real dashboard reaches it.
  *
- * `setConfig` merges with `{ ...DEFAULT_CONFIG, ...config }` — a *shallow* spread — so a
- * user block of `weather: { entity: … }` replaces the default `weather` block wholesale
- * and arrives with `position` undefined. Both suites above assign `config.weather`
- * directly with the position spelled out, so neither can see that: they never exercise
- * the merge, and the omitted case is the one every user who does not spell the option
- * out lands on.
+ * `setConfig` deep-merges, so a user block of `weather: { entity: … }` keeps the default
+ * `position` rather than blanking it. Both suites above assign `config.weather` directly
+ * with the position spelled out, so neither exercises the merge at all — and the omitted
+ * case is the one every user who does not spell the option out lands on.
+ *
+ * This ran against a hand-rolled shallow spread until the merge was made deep. It now
+ * calls `mergeConfig` itself, because a fixture that merges differently from production
+ * stops testing production the moment the two diverge — which is exactly what happened to
+ * the defect below.
  *
  * The two halves disagreed exactly there. `getRequiredForecastTypes` resolved the
  * documented `date` default and subscribed to the daily stream, while the render gates
@@ -209,14 +212,17 @@ describe('weather position omitted from a user config', () => {
     vi.useRealTimers();
   });
 
-  /** Renders both views through the same shallow merge `setConfig` performs. */
+  /** Renders both views through the same deep merge `setConfig` performs. */
   function merged(weather: Record<string, unknown>): {
     column: HTMLElement;
     list: HTMLElement;
     config: Types.Config;
   } {
     const userYaml = { ...buildConfig({ split_multiday_events: true }), weather };
-    const config = { ...Config.DEFAULT_CONFIG, ...userYaml } as Types.Config;
+    const config = Config.mergeConfig(
+      Config.DEFAULT_CONFIG as unknown as Record<string, unknown>,
+      userYaml as unknown as Record<string, unknown>,
+    ) as unknown as Types.Config;
 
     const view = (v: 'column' | 'list'): HTMLElement => {
       const days = EventUtils.groupEventsByDay(EVENTS, config, false, 'en', v);

--- a/tests/zero-length.test.ts
+++ b/tests/zero-length.test.ts
@@ -161,7 +161,7 @@ describe('zero-width separators in the rendered DOM', () => {
 
 /**
  * A blank YAML value — `day_separator_width:` with nothing after the colon — parses as
- * `null`, and `setConfig`'s shallow `{ ...DEFAULT_CONFIG, ...config }` merge lets that
+ * `null`, and `setConfig`'s merge lets that
  * `null` overwrite the shipped `'0px'`. Nothing downstream restored it, so the `null`
  * reached `isZeroLength`, which calls `.trim()` on it: a `TypeError` that took the whole
  * card down to a blank box, in both views, for all three separator widths.


### PR DESCRIPTION
Finishes the four items left open by the v4 audit: the `src/rendering/` mutation sweep, the five untriaged host survivors, and the two root causes that were bounded but deferred.

## Two root causes fixed

**A themed `var()` accent colour never reached the card.** `computeRGBA` returned `rgba(var(--calendar-color-rgb, 3, 169, 244), …)` against a variable this project defines nowhere and no theme knows about, so the literal fallback won every time.

The backlog's own remedy — defining that variable on the host — **cannot work**, and that is worth recording: `rgba()` needs three channel values, and a `var()` reference cannot be decomposed into them without resolving it. Resolving is the one thing that must not happen here, because `rgbaCache` is module-level and never evicted, so it would pin whichever theme was active on first render for the life of the page. The branch now emits `color-mix(in srgb, <colour> <opacity>%, transparent)` — still a live CSS expression, but carrying the configured colour. The stylesheet already uses that idiom in three places, including the progress-bar track.

Why it survived to v4: the hardcoded fallback `3, 169, 244` **is** `#03a9f4`, the default `accent_color`. The card never looked broken; it looked like the default. Reaching the branch at all needs both a `var()` colour *and* a non-zero `event_background_opacity`, which defaults to `0` on a path that returns first.

**`setConfig` merged only the top level**, so a `weather:` block naming just `entity:` replaced the default sub-tree wholesale and arrived with `position`, `date` and `event` all `undefined` — the cause behind two v4 defects that were fixed at the symptom. `mergeConfig` now recurses into plain objects while replacing arrays wholesale, so `entities:` still overwrites rather than merging into the default list.

**The write path needed no change**, which is what made this safe to do now rather than early in a cycle as the backlog assumed. `toStoredConfig` already routes `weather` through `stripWeatherDefaults` and recurses elsewhere, so the filled-in defaults are stripped again on save. Verified rather than assumed: breaking the strip fails six round-trip cases, which assert the stored object exactly rather than by key count.

## Sweep completed

| File | Sites | Killed | Survived | Outcome |
| --- | ---: | ---: | ---: | --- |
| `leaves.ts` | 24 | 24 | 0 | no gap |
| `column.ts` | 17 | 16 | 1 | equivalent |
| `render.ts` | 10 | 6 | 4 | **3 real**, 1 equivalent |
| `presentation.ts` | 9 | 7 | 2 | **1 real**, 1 equivalent |
| `styles.ts` | 9 | 4 | 5 | **5 real** |
| host element (5 survivors triaged) | — | — | — | **2 real**, 3 equivalent |

`styles.ts` was the worst file in the project: all five survivors were the `--calendar-card-weather-*` fallbacks — a surface v4 turned from inline styles into published theming hooks. Dropping one emits `undefined` into the property, and **`check:docs` stayed green too**: it counts the documented defaults but never reconciles them against the code.

The host's two real gaps: the refresh timer had stopped reading its configured interval (a card set to 5 minutes would refresh every 30), and a card with no calendars rendered an empty agenda instead of the error state.

## Two things I got wrong and corrected

**My first round-trip tests pinned the producer, not the wiring.** They called `mergeConfig` directly, so reverting `setConfig` to the old spread left the suite green. They now drive the real custom element, and that revert fails.

**A weather test I wrote did not kill the mutant I wrote it for.** I measured, found the guard is masked three times over — `getRequiredForecastTypes`, `subscribeToWeatherForecast`, and a deliberate `try`/`catch` — and rewrote its docblock to say it pins a contract rather than a mutant, instead of leaving the stronger claim standing.

## Consequences swept

The deep merge invalidated **11 comments** across `src/` and `tests/` describing the shallow merge as current behaviour, including `buildConfig`, which claimed to build configs "the same way `setConfig` does" while doing its own shallow spread — every fixture would have kept the old shape while production moved. Two more test files had hand-rolled the merge, one written specifically to catch a defect the shallow merge caused.

One subtlety survives and is documented: a block the user never mentions is still `DEFAULT_CONFIG`'s own object by reference, so `column` (which has no default block) can still arrive frozen.

9/9 gates. Suite 2,281 → 2,315.
