### PR TITLE
docs: make closing resolved issues a release step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,8 +450,14 @@ because two branches had filled different columns of the same table, and once wh
 paragraph was restored that had been superseded in code.
 
 Because `main` is the default branch, `Fixes #123` in a PR merged to `dev` will **not**
-auto-close the issue — closing keywords only fire on the default branch. Issues close
-when the release PR merges, or close them manually.
+auto-close the issue — closing keywords fire only on the default branch, and GitHub
+evaluates the keyword against the PR's _own_ base. The release PR does not clean up after
+them either: merging `dev` → `main` closes only what the individual **commit messages**
+reference, and that is not a convention here — 1 of the 574 commits in the v4 range carried
+a closing keyword, and 25 of 1,277 in the project's whole history. So in practice **nothing
+closes an issue automatically**, and doing it by hand is a step of the release rather than
+an afterthought. See step 7 of _Release process_; v4.0.0 shipped with six resolved requests
+still open, the column-view epic among them.
 
 ### `dev` must never fall behind `main`
 
@@ -746,6 +752,29 @@ vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements.
 6. `.github/workflows/release.yml` builds and creates a **draft** GitHub release. It
    attaches `dist/*.js` and nothing else — since the two-file split that is **both**
    `calendar-card-pro.js` and `editor.js`. Publish it manually.
+7. **Close the issues the release resolved.** Nothing does this for you — see _Branch
+   model_ for why — so it is a step here or it does not happen. v4.0.0 shipped with six
+   still open, including the epic it was named after.
+
+   Start from the notes' _Related Issues_ section, but do not stop there: an issue is
+   linked only if whoever wrote the feature remembered to link it, and the ones nobody
+   remembered are exactly the ones that stay open. **Read the open list against what the
+   release actually shipped.** #290 asked for a dashboard-path picker; v4 delivered one as
+   a side effect of rebuilding the editor on HA's own selectors, and appeared in no commit
+   message, no PR body and no release note — it was found by diffing the editor against
+   the open issues, months late.
+
+   ```bash
+   gh issue list --state open --limit 100
+   gh issue close <n> --comment "Shipped in [vX.Y.Z](https://github.com/alexpfau/calendar-card-pro/releases/tag/vX.Y.Z) …"
+   ```
+
+   Close with a comment that names the release and deep-links the docs page, so the
+   author gets one notification that answers their request rather than a bare state
+   change. Where a release answers only part of a request, comment and leave it open —
+   #300 asked for columns _and_ a time grid, and got the first. And add anything you find
+   this way to _Related Issues_ in `docs/RELEASE_NOTES.md`, so the next person auditing
+   the same release does not have to rediscover it.
 
 `hacs.json` pins the distributed filename to `calendar-card-pro.js` — do not rename it.
 HACS downloads every asset attached to a release, so it gets the editor without being told

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -128,8 +128,10 @@ None of what follows is opt-in. It applies to every card on every dashboard, inc
 ## Related Issues
 
 - [#14](https://github.com/alexpfau/calendar-card-pro/issues/14) - Add Column View to Calendar-Card-Pro by @chrannen
+- [#190](https://github.com/alexpfau/calendar-card-pro/issues/190) - Location length selector by @joaopequeno-git — answered by `location_max_lines`, a line cap rather than the character cap requested
 - [#253](https://github.com/alexpfau/calendar-card-pro/issues/253) - Landscape mode - days next to each other on desktop and tablet by @fugazzy
 - [#263](https://github.com/alexpfau/calendar-card-pro/issues/263) - Horizontal mode by @wsw70
+- [#290](https://github.com/alexpfau/calendar-card-pro/issues/290) - Navigation path autocomplete by @oerix — the rebuilt editor uses Home Assistant's action selector, which supplies the dashboard-path picker
 - [#300](https://github.com/alexpfau/calendar-card-pro/issues/300) - Time grid + seven days view (columns) by @rozrabiak — the columns half only; the time grid is a separate view and is not in this release
 - [#377](https://github.com/alexpfau/calendar-card-pro/issues/377) - [Epic] Column view — days side by side by @alexpfau
 


### PR DESCRIPTION
v4.0.0 shipped with six resolved requests still open, including the column-view epic it was named after (#377, #14, #253, #263, #290, #190 — all now closed by hand).

## Why nothing closed them

AGENTS.md said *"Issues close when the release PR merges, or close them manually."* The first half is true only for a path this project doesn't use:

- A `Fixes #123` in a PR targeting `dev` never fires — GitHub evaluates the keyword against **that PR's own base**, not against wherever the commits eventually land.
- Merging `dev` → `main` closes only what the individual **commit messages** reference. That isn't a convention here: **1 of the 574** commits in the `v3.6.0..v4.0.0` range carried a closing keyword, and **25 of 1,277** in the project's whole history.

So in practice nothing closes automatically, and the note read as though something did.

## Changes

**`AGENTS.md` — _Branch model_**: corrected, with the counts above so the claim carries its own evidence.

**`AGENTS.md` — _Release process_**: new step 7, after publishing the draft. The load-bearing part is *don't just work the notes' Related Issues list* — an issue is linked there only if whoever wrote the feature remembered to link it, and the ones nobody remembered are exactly the ones that stay open. #290 is the worked example: v4 delivered its dashboard-path picker as a side effect of rebuilding the editor on HA's own selectors, and it appeared in no commit message, no PR body and no release note. It was found by diffing the editor against the open issue list, months late.

**`docs/RELEASE_NOTES.md`**: added #190 and #290 to v4.0.0's Related Issues, both found by that sweep.

## Also done outside this PR

The published [v4.0.0 release](https://github.com/alexpfau/calendar-card-pro/releases/tag/v4.0.0) body was regenerated from the updated notes via `scripts/extract-release-notes.mjs`, after diffing it against the published body to confirm the only change was those two lines.

## Verification

`npm run format`, `check:format` and `check:docs` all pass — the docs gate reports *"release surfaces agree on v4.0.0"*. Docs-only change; no `src/` files touched.