### PR TITLE
fix(check-docs): stop flagging design docs as unreachable, and write down their lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,6 +500,23 @@ deployed by Cloudflare on every push to `main`. `README.md` is now only a landin
 badges, overview, installation, a quick-start example, What's New, and contributing.
 Everything else moved to `docs/`.
 
+**A spec is working state, not a deliverable, and never reaches `dev`.** Design documents —
+a specification, an implementation plan, the reasoning behind a large change — live under
+`docs/development/` for the life of the feature branch that needs them, and are **deleted
+there before the single PR into `dev` is opened**. One finished feature, one PR, no working
+notes inside it. A spec is reviewed on its branch; it does not get a PR of its own.
+
+Verify the deletion rather than remembering it:
+
+```bash
+git diff --name-only origin/dev...HEAD | grep '^docs/development/'
+```
+
+No output is the passing case. Nothing else will catch this: `docs/development/` is
+`srcExclude`d from the VitePress build and exempt from the docs-coverage checks, so a spec
+that slips through never appears on the site and simply ships as a repository file
+describing work as though it were still pending.
+
 The screenshots under `.github/img/` are **not** captured by anything in this repo. They
 come from a Home Assistant instance only the maintainer has, so they cannot be regenerated
 from a PR. Two consequences: a change that alters how the card renders by default — spacing,
@@ -1073,10 +1090,12 @@ citations that quote a released tag, such as `v3.6.0 leaves.ts:324`, are exempt 
 is immutable.
 
 **When a planning document is retired, grep for its vocabulary.** `docs/development/column-view.md`
-was deleted once the column view shipped, and nineteen references to its phases survived in
-four test files — still written in the future tense, still describing work as upcoming that
-had already landed. Comments that name a document outlive the document, so deleting one is
-not finished until `grep -rn "Phase [0-9]" src tests` comes back empty.
+was deleted once the column view shipped — late, under the older workflow that let a spec
+reach `dev` at all, where the rule under _Documenting a change_ now retires one on its own
+branch — and nineteen references to its phases survived in four test files, still written in
+the future tense, still describing work as upcoming that had already landed. Comments that
+name a document outlive the document whenever it goes, so deleting one is not finished until
+`grep -rn "Phase [0-9]" src tests` comes back empty.
 
 **A JSDoc block touches the thing it documents — no blank line between them.** This is the
 one style rule in the project that nothing mechanical enforces, so it is the one that

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -2005,13 +2005,21 @@ function readNavRoutes() {
  * links to still ships - reachable only by guessing the URL. Neither `docs:build` nor
  * any other check notices, which is how a documented option can still be undiscoverable.
  *
- * @param {string[]} docs absolute paths to every published markdown page
+ * `development/` is the exception, and it has to be excluded rather than listed in
+ * UNLISTED_ROUTES: `srcExclude: ['development/**']` keeps those files out of the build
+ * entirely, so they have no route to be unreachable from. Demanding a sidebar entry for
+ * one would ask the nav to link a page the site never publishes. This was latent until
+ * the first design doc since the check was written - the folder was empty, so the check
+ * had no instance to be wrong about. Verified by building: `docs:build` emits no
+ * `dist/development/` directory at all.
+ *
+ * @param {string[]} docs absolute paths to every markdown page under docs/
  * @param {Set<string>} routes routes referenced by the navigation
  * @returns {number} pages reachable from the navigation
  */
 function checkPageReachability(docs, routes) {
   const published = new Map();
-  for (const file of docs) {
+  for (const file of docs.filter((f) => !isExcluded(f, ['development/']))) {
     const route = `/${relative(DOCS_DIR, file)
       .split(sep)
       .join('/')


### PR DESCRIPTION
Two halves of one change: make design documents work properly, and write down the rule that governs them. Split out of the #314 work — **this is not the #314 feature**, which is #528.

## 1. The gate

Check 23 treats every markdown file under `docs/` as published and demands a sidebar entry for each. But `srcExclude: ['development/**']` in the VitePress config keeps design notes out of the build entirely, so they have no route to be unreachable *from*. Asking the nav to link one is asking it to link a page the site never publishes.

It is latent rather than newly broken. `docs/development/` has been empty since the v4 development record was retired, and check 23 landed after that — so it never had an instance to be wrong about, and its healthy state and its broken state looked identical. Writing the first design doc since then is what surfaced it. That is the failure mode AGENTS.md describes under _a gate's normal state is having no instance_: judge the pattern against the runtime, not against a corpus that happens to be empty.

The fix narrows the corpus to what VitePress actually publishes, using the same `isExcluded(f, ['development/'])` boundary `buildAnchorMap` already applies for the same reason. The `assertFound` guard now runs over the filtered map, so the check still fails loudly if it ever stops matching anything.

Chose this over adding the route to `UNLISTED_ROUTES`, which would have recorded the wrong reason — those routes are "deliberately absent from the nav", whereas these pages are not published at all.

## 2. The rule

`AGENTS.md` now states the lifecycle the gate exists to serve: a spec is working state, not a deliverable, and never reaches `dev`. Design documents live under `docs/development/` for the life of the feature branch that needs them and are deleted there before the single PR into `dev` is opened — one finished feature, one PR, no working notes inside it. A spec is reviewed on its branch rather than through a PR of its own.

It carries the falsifiable check rather than an instruction to remember, because nothing mechanical will catch a spec that slips through — the directory is excluded from the build and exempt from the docs-coverage checks, so such a file never appears on the site and simply ships as a repository file describing work as though it were still pending.

```bash
git diff --name-only origin/dev...HEAD | grep '^docs/development/'
```

No output is the passing case. Verified both ways on this branch: silent when clean, and it names the file when one is planted.

The retired-planning-document passage is reconciled rather than left to contradict it. It described `column-view.md` being deleted "once the column view shipped", which stays true as history but is no longer the workflow — and its lateness is the point, since retiring it only after it had reached `dev` is what left nineteen stale phase references across four test files. The grep it recommends still applies whenever the document goes.

**Why these are one PR.** #529 already owns how `docs/development/` is handled; the rule governs the lifecycle of that same directory. Separating them would land a gate that serves a convention written nowhere, and a convention with no gate behind it.

## Verification

The gate, three ways, none of them by reading:

- `docs:build` emits **no `dist/development/` directory at all**, so the check's premise is false for those files.
- With a design doc present the check **errors before this change and passes after it** — run in this branch, both directions.
- A genuinely unreachable *published* page under `docs/features/` is **still caught**, so the narrowing did not disable the check.

`AGENTS.md` is outside `check:docs`, which reads `docs/` and the README, but prettier covers the whole repo and `check:format` passes. All nine gates green.
