### PR TITLE
docs(release): start the v4.1 notes as features land

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,11 @@ Swap `calendar.family` for one of your own `calendar.*` entities and you have a 
 
 **➡️ View the [Full Release Notes](https://calendar-card-pro.alexpfau.com/RELEASE_NOTES) for a complete list of features.**
 
-### Latest Release: v4.0
+### Latest Release: v4.1
+
+- 🎨 **Follow Home Assistant's Calendar Colors**: Set `accent_color` to `home-assistant` and each calendar takes [the color Home Assistant already holds for it](https://calendar-card-pro.alexpfau.com/features/core-settings), so it looks the same on every card — whether you picked that color by hand or Google Calendar imported it
+
+### v4.0
 
 - 🗓️ **Column View**: Lay the days [side by side, one column each](https://calendar-card-pro.alexpfau.com/features/column-view), instead of stacking them — the same agenda, rotated, with its own per-view overrides and a responsive fallback to the list layout
 - ⚙️ **Rebuilt Visual Editor**: Nine panels built on Home Assistant's own form components, with a [search box that finds any setting by name or YAML key](https://calendar-card-pro.alexpfau.com/features/editor#search-customized-only), a customized-only filter, per-calendar settings, and [per-view exceptions](https://calendar-card-pro.alexpfau.com/features/editor#column-view-exceptions)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,22 @@
 title: Release Notes
 ---
 
+# Calendar Card Pro v4.1.0
+
+## 🎉 New Features
+
+### 🎨 Follow the Calendar Colors Home Assistant Holds
+
+**A calendar can look the same everywhere now, instead of being colored twice in two places.** Home Assistant stores a color for each calendar entity — the one the built-in calendar card and the calendar panel already use — and setting `accent_color` to `home-assistant` makes Calendar Card Pro follow it. Set it [card-wide](/features/core-settings) and every calendar picks up its own color, or set it per calendar and mix it freely with colors you choose yourself.
+
+The color has to exist in Home Assistant first, and most do not yet: Google Calendar is the only integration that sets one, and only when it is first added, so calendars from before Home Assistant 2026.2 have none — re-adding the integration will not create them. Set those by hand under **Settings → Devices & Services → Entities**; any calendar still without one falls back to the card's own color rather than losing it. Requires Home Assistant 2026.2 (#314)
+
+## Related Issues
+
+- [#314](https://github.com/alexpfau/calendar-card-pro/issues/314) - Use color from entity registry by @karwosts, who also contributed the upstream Home Assistant support
+
+---
+
 # Calendar Card Pro v4.0.0
 
 ![Calendar Card Pro v4 — the week, side by side](https://raw.githubusercontent.com/alexpfau/calendar-card-pro/main/.github/img/header_column_view.png)

--- a/docs/guide/whats-new.md
+++ b/docs/guide/whats-new.md
@@ -6,7 +6,11 @@ Each entry below covers a whole minor release line — the `X.Y.0` release plus 
 patch that followed it — so this page reads as the card's progression from the first
 public release in January 2025 to today.
 
-## Latest Release: v4.0
+## Latest Release: v4.1
+
+- 🎨 **Follow Home Assistant's Calendar Colors**: Set `accent_color` to `home-assistant` and each calendar takes [the color Home Assistant already holds for it](/features/core-settings), so it looks the same on every card — whether you picked that color by hand or Google Calendar imported it
+
+## v4.0
 
 - 🗓️ **Column View**: Lay the days [side by side, one column each](/features/column-view), instead of stacking them — the same agenda, rotated, with its own per-view overrides and a responsive fallback to the list layout
 - ⚙️ **Rebuilt Visual Editor**: Nine panels built on Home Assistant's own form components, with a [search box that finds any setting by name or YAML key](/features/editor#search-customized-only), a customized-only filter, per-calendar settings, and [per-view exceptions](/features/editor#column-view-exceptions)


### PR DESCRIPTION
Starts the v4.1 release notes now, as features land, instead of reconstructing them from merged PRs at release time.

Reconstruction works, but it loses the detail that was only obvious while the work was fresh. This entry is the example: Google Calendar seeds a calendar's color when the integration is *first set up*, so an integration added before Home Assistant 2026.2 has no colors stored and they never appear retroactively. Nothing in the diff or the commit messages says that — it came out of live testing, and it is the difference between the feature looking like it works and looking broken.

## Why it is safe to carry on `dev`

The docs site builds only on push to `main`, so an unreleased entry sitting in `dev` is invisible to users until the release PR merges. There is no window in which the site advertises a version that does not exist.

## No version bump needed yet

Check 18 requires the version in `package.json` to be present in all three release surfaces; it does not require that version to be the newest one. `check:docs` confirms it — **17 release lines documented**, **release surfaces agree on v4.0.0** — so a v4.1 section coexists with `package.json` at 4.0.0, and the bump stays where it belongs, with the release.

## Gates

`check:docs`, `prettier --check` and `docs:build` all pass.

## Follow-up

The entry links to `/features/core-settings` at page level rather than to the `#using-the-colors-from-home-assistant` anchor, because that heading arrives with #528 and `docs:build` fails on a dead fragment. Add the fragment once #528 has merged.
