### PR TITLE
feat(editor): name calendar panels as Home Assistant does, and duplicate one

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Swap `calendar.family` for one of your own `calendar.*` entities and you have a 
 ### Latest Release: v4.1
 
 - 🎨 **Follow Home Assistant's Calendar Colors**: Set `accent_color` to `home-assistant` and each calendar takes [the color Home Assistant already holds for it](https://calendar-card-pro.alexpfau.com/features/core-settings), so it looks the same on every card — whether you picked that color by hand or Google Calendar imported it
-- 🗂️ **Show All-Day and Timed Events Separately**: [`event_type`](https://calendar-card-pro.alexpfau.com/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, and its all-day and timed events get a color each
+- 🗂️ **Split One Calendar by Event Type**: [`event_type`](https://calendar-card-pro.alexpfau.com/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, for a color on each, and [**Duplicate** in the editor](https://calendar-card-pro.alexpfau.com/features/editor#per-calendar-panels-actions) builds it for you
 
 ### v4.0
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -26,11 +26,11 @@ Until now the two panels ordered the same settings differently, and neither said
 
 ### 📑 List One Calendar Twice, Without Leaving the Editor
 
-**Splitting a calendar in two no longer means dropping into YAML.** Every calendar's panel now carries **Duplicate**, which lists that calendar a second time with the settings it already has — so giving a calendar's all-day events their own color is a click and then one dropdown, rather than hand-writing a second block. It is the pattern `event_type` above describes, now reachable where you were already standing.
+**Splitting a calendar in two no longer means dropping into YAML.** Every calendar's panel now opens with **Duplicate**, which gives that calendar a second block carrying the settings it already has — so giving a calendar's all-day events their own color is a click and then one dropdown, rather than hand-writing a second block. It is the pattern `event_type` above describes, now reachable where you were already standing.
 
-Home Assistant's calendar picker cannot do this: it hides a calendar you have already chosen, ignores a duplicate added through it, and deletes the row outright when an existing one is pointed at a calendar already in the list. Rendering a separate single-calendar picker per block would sidestep all three, but it would also cost the drag-reordering the list depends on, so the card writes the second block itself and leaves the picker alone.
+Home Assistant's calendar picker cannot do this: it will not hold the same calendar twice, and there is no opting out of that. So the picker no longer tries to be two things at once. It lists each calendar **once** and answers only which calendars the card shows; how many blocks a calendar has, and what is on each, is the business of its own panel below. Clearing a row therefore takes the calendar off the card entirely, blocks and all, while **Remove** on a panel drops a single block — the only control that can, now that one row can stand for several.
 
-Two things come with it. Both panels for one calendar carry the same heading, because they name the same calendar, so their second line is numbered **Entry 1 of 2** and **Entry 2 of 2**. And each panel gains **Remove**, which is not merely a shortcut for clearing the picker row — the picker matches rows by which calendar they name, so clearing one takes every block for that calendar, along with the settings on each (#533)
+Both panels for one calendar carry the same heading, because they name the same calendar, so their second line is numbered **Entry 1 of 2** and **Entry 2 of 2**. The four per-calendar actions have also moved to the top of each panel, where they are visible as it opens rather than below every setting, with Remove held apart from the three that can be undone by doing them again (#533)
 
 ## 🐛 Bug Fixes
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -16,7 +16,7 @@ The color has to exist in Home Assistant first, and most do not yet: Google Cale
 
 **A calendar can now show only its all-day events, only its timed ones, or both in colors you can tell apart.** The new `event_type` option takes `all`, `timed` or `all_day`, and works card-wide or per calendar. Because `timed` and `all_day` are exact complements, listing the same calendar twice — once each way, with a different `accent_color` on each block — splits it into two colors without showing anything twice or losing anything.
 
-It names the kind of event, not how long one lasts: a dinner running from 23:30 to 00:30 is `timed`, however many dates it touches. The two-block pattern has to be written in YAML, because Home Assistant's calendar picker will not offer the same calendar twice; the editor reads and edits it correctly once it exists. (#132)
+It names the kind of event, not how long one lasts: a dinner running from 23:30 to 00:30 is `timed`, however many dates it touches. The two blocks are built with **Duplicate** on the calendar's own panel in the visual editor — see below. (#132)
 
 ### ⚙️ Editor Settings Grouped Under Sub-Headings
 
@@ -24,10 +24,23 @@ It names the kind of event, not how long one lasts: a dinner running from 23:30 
 
 Until now the two panels ordered the same settings differently, and neither said what a run of settings was for.
 
+### 📑 List One Calendar Twice, Without Leaving the Editor
+
+**Splitting a calendar in two no longer means dropping into YAML.** Every calendar's panel now carries **Duplicate**, which lists that calendar a second time with the settings it already has — so giving a calendar's all-day events their own color is a click and then one dropdown, rather than hand-writing a second block. It is the pattern `event_type` above describes, now reachable where you were already standing.
+
+Home Assistant's calendar picker cannot do this: it hides a calendar you have already chosen, ignores a duplicate added through it, and deletes the row outright when an existing one is pointed at a calendar already in the list. Rendering a separate single-calendar picker per block would sidestep all three, but it would also cost the drag-reordering the list depends on, so the card writes the second block itself and leaves the picker alone.
+
+Two things come with it. Both panels for one calendar carry the same heading, because they name the same calendar, so their second line is numbered **Entry 1 of 2** and **Entry 2 of 2**. And each panel gains **Remove**, which is not merely a shortcut for clearing the picker row — the picker matches rows by which calendar they name, so clearing one takes every block for that calendar, along with the settings on each (#533)
+
+## 🐛 Bug Fixes
+
+- **A Calendar's Panel Named It Differently From the Picker Directly Above It** - Home Assistant's entity picker moved to friendly names some time ago, so the Calendars row read _Calendar card pro - family_ while the settings panel a few pixels below it read `calendar.calendar_card_pro_family`. An entity id need not resemble its name at all, which left no reliable way to tell which panel belonged to which row on a card listing several calendars. Panels are now headed with the same name Home Assistant shows. A calendar that has been removed from Home Assistant keeps its entity id, since that is the only thing left identifying it
+
 ## Related Issues
 
 - [#132](https://github.com/alexpfau/calendar-card-pro/issues/132) - Filter based on all-day events by @syst3x
 - [#314](https://github.com/alexpfau/calendar-card-pro/issues/314) - Use color from entity registry by @karwosts, who also contributed the upstream Home Assistant support
+- [#533](https://github.com/alexpfau/calendar-card-pro/issues/533) - Duplicate a calendar block from the visual editor by @alexpfau
 
 ---
 

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -210,11 +210,13 @@ This is the same technique as [Advanced Filtering Techniques](#advanced-filterin
 below, and it composes with the name filters: a block may set `event_type` and an
 `allowlist` together, and an event has to satisfy both to appear.
 
-::: warning Listing a Calendar Twice Needs YAML
-Home Assistant's calendar picker removes duplicates, so the visual editor cannot add the
-same calendar a second time. Write the two blocks in YAML — three dots → Show code editor —
-and the editor handles them correctly from then on: both blocks are kept, each with its own
-settings, and opening the editor does not collapse them.
+::: tip Listing a Calendar Twice in the Visual Editor
+Home Assistant's calendar picker hides a calendar you have already chosen, so the second
+listing cannot be added there. Use **Duplicate** at the foot of the calendar's own panel
+instead: it lists the calendar again with the same settings, ready for you to change the
+one option that differs. The two panels are numbered so you can tell them apart, and
+**Remove** on the panel drops one block without taking the other — see
+[Per-Calendar Panels & Actions](/features/editor#per-calendar-panels-actions).
 :::
 
 ::: tip It Describes the Kind of Event, Not Its Length
@@ -291,6 +293,10 @@ This technique lets you:
 - Create category-based visual organization without needing multiple calendar sources
 - Use accent colors with backgrounds (when event_background_opacity > 0) for even more distinction
 - Avoid needing to create separate calendars for different event categories
+
+In the visual editor, build this with **Duplicate** at the foot of the calendar's panel —
+once for each extra block — and then give each copy its own filter, label and color. See
+[Per-Calendar Panels & Actions](/features/editor#per-calendar-panels-actions).
 
 ## 📊 Compact Mode & Event Limits
 

--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -81,6 +81,8 @@ The clipboard behind **Copy Settings** outlives the dialog, so settings copied w
 
 **Duplicate** is how you list one calendar twice, each time with its own settings. That is what [splitting a calendar by event type](/features/core-settings#separating-all-day-from-timed-events) needs, and Home Assistant's calendar picker will not do it: the picker hides a calendar you have already chosen, so the second listing has to be made here. Both panels then carry the same heading, because they are the same calendar, and their secondary lines are numbered **Entry 1 of 2** and **Entry 2 of 2** so you can tell which is which.
 
+The copy starts out identical to the block it came from, so until you change something on one of them the card shows every event from that calendar **twice** — two blocks, both matching everything. That is expected, and setting **Event Type** on each is usually the change that resolves it.
+
 ::: tip Remove a Duplicate From Its Panel, Not From the Picker
 Clearing a row in the picker removes **every** listing of that calendar, along with the settings on each — the picker matches rows by which calendar they name, and two duplicates name the same one. **Remove** on the panel drops only that block, so it is the one to use once a calendar is listed more than once.
 :::

--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -64,27 +64,31 @@ The editor only offers the settings your current configuration calls for: a fixe
 
 ## 📋 Per-Calendar Panels & Actions
 
-Each calendar you pick gets a collapsible panel of its own beneath the picker, headed with the calendar's name as Home Assistant knows it — the same name the picker itself shows, rather than the entity id underneath it. A calendar that has been removed from Home Assistant keeps its id in the heading, since that is all there is left to identify it by.
+The Calendars picker lists each calendar **once**, however many times the card uses it. It answers one question — which calendars this card shows — and the panels beneath it answer the other: how many blocks each calendar has, and what is set on each.
+
+Every calendar gets a collapsible panel of its own, headed with the calendar's name as Home Assistant knows it — the same name the picker shows, rather than the entity id underneath it. A calendar that has been removed from Home Assistant keeps its id in the heading, since that is all there is left to identify it by.
 
 The line under the heading says what the panel holds: your own label if you have set one, **Configured** if the calendar carries settings of its own, and **Using the card settings** if it does not.
 
-At the foot of every panel are four actions:
+Each panel opens with four actions:
 
-| Action             | What it does                                                             |
-| ------------------ | ------------------------------------------------------------------------ |
-| **Copy Settings**  | Takes this calendar's settings, without taking the calendar itself       |
-| **Paste Settings** | Applies them to this calendar, keeping the calendar it is applied to     |
-| **Duplicate**      | Lists the same calendar a second time, carrying the first one's settings |
-| **Remove**         | Drops this calendar from the card                                        |
+| Action             | What it does                                                          |
+| ------------------ | --------------------------------------------------------------------- |
+| **Copy Settings**  | Takes this calendar's settings, without taking the calendar itself    |
+| **Paste Settings** | Applies them to this calendar, keeping the calendar it is applied to  |
+| **Duplicate**      | Gives this calendar a second block, carrying the first one's settings |
+| **Remove**         | Drops this block                                                      |
+
+They sit above the settings rather than below them, so they are visible the moment a panel opens. **Remove** is held apart from the other three because it is the only one that discards anything, and a card editor has no undo.
 
 The clipboard behind **Copy Settings** outlives the dialog, so settings copied while editing one card can be pasted into another — useful when several cards list the same calendars.
 
-**Duplicate** is how you list one calendar twice, each time with its own settings. That is what [splitting a calendar by event type](/features/core-settings#separating-all-day-from-timed-events) needs, and Home Assistant's calendar picker will not do it: the picker hides a calendar you have already chosen, so the second listing has to be made here. Both panels then carry the same heading, because they are the same calendar, and their secondary lines are numbered **Entry 1 of 2** and **Entry 2 of 2** so you can tell which is which.
+**Duplicate** is how you give one calendar two sets of settings. That is what [splitting a calendar by event type](/features/core-settings#separating-all-day-from-timed-events) needs, and it cannot be done from the picker, which will not hold the same calendar twice. Both panels then carry the same heading, because they are the same calendar, and their secondary lines are numbered **Entry 1 of 2** and **Entry 2 of 2** so you can tell which is which.
 
 The copy starts out identical to the block it came from, so until you change something on one of them the card shows every event from that calendar **twice** — two blocks, both matching everything. That is expected, and setting **Event Type** on each is usually the change that resolves it.
 
-::: tip Remove a Duplicate From Its Panel, Not From the Picker
-Clearing a row in the picker removes **every** listing of that calendar, along with the settings on each — the picker matches rows by which calendar they name, and two duplicates name the same one. **Remove** on the panel drops only that block, so it is the one to use once a calendar is listed more than once.
+::: tip Two Ways to Take Something Away, and They Differ
+Clearing a calendar's row in the **picker** removes that calendar from the card altogether, along with every block it had. **Remove** on a panel drops just that one block and leaves the calendar's others alone. The picker is where you decide a calendar is no longer on this card; Remove is where you decide it needs one fewer set of settings.
 :::
 
 **→ [Entity configuration options](/features/core-settings#available-options-for-entity-configuration-objects)** — everything a single calendar's panel can set.

--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -62,6 +62,31 @@ Three things follow their own rule under it, for reasons worth knowing:
 The editor only offers the settings your current configuration calls for: a fixed card height appears once the height mode is fixed, and the compact-mode modifier appears once there is an event limit for it to modify. A search cannot turn up a control that is not on screen, so if nothing matches, check whether the option it depends on is switched on.
 :::
 
+## 📋 Per-Calendar Panels & Actions
+
+Each calendar you pick gets a collapsible panel of its own beneath the picker, headed with the calendar's name as Home Assistant knows it — the same name the picker itself shows, rather than the entity id underneath it. A calendar that has been removed from Home Assistant keeps its id in the heading, since that is all there is left to identify it by.
+
+The line under the heading says what the panel holds: your own label if you have set one, **Configured** if the calendar carries settings of its own, and **Using the card settings** if it does not.
+
+At the foot of every panel are four actions:
+
+| Action             | What it does                                                             |
+| ------------------ | ------------------------------------------------------------------------ |
+| **Copy Settings**  | Takes this calendar's settings, without taking the calendar itself       |
+| **Paste Settings** | Applies them to this calendar, keeping the calendar it is applied to     |
+| **Duplicate**      | Lists the same calendar a second time, carrying the first one's settings |
+| **Remove**         | Drops this calendar from the card                                        |
+
+The clipboard behind **Copy Settings** outlives the dialog, so settings copied while editing one card can be pasted into another — useful when several cards list the same calendars.
+
+**Duplicate** is how you list one calendar twice, each time with its own settings. That is what [splitting a calendar by event type](/features/core-settings#separating-all-day-from-timed-events) needs, and Home Assistant's calendar picker will not do it: the picker hides a calendar you have already chosen, so the second listing has to be made here. Both panels then carry the same heading, because they are the same calendar, and their secondary lines are numbered **Entry 1 of 2** and **Entry 2 of 2** so you can tell which is which.
+
+::: tip Remove a Duplicate From Its Panel, Not From the Picker
+Clearing a row in the picker removes **every** listing of that calendar, along with the settings on each — the picker matches rows by which calendar they name, and two duplicates name the same one. **Remove** on the panel drops only that block, so it is the one to use once a calendar is listed more than once.
+:::
+
+**→ [Entity configuration options](/features/core-settings#available-options-for-entity-configuration-objects)** — everything a single calendar's panel can set.
+
 ## 🏷️ Per-Calendar Labels
 
 Each calendar under the picker gets its own collapsible form, and the first control in it

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -60,7 +60,7 @@ question. HACS does all of this for you, which is why it is the recommended rout
 ::: tip Optional: Compress The Files Yourself
 Home Assistant serves a pre-compressed `.gz` beside a file when it finds one, and does not
 compress on the fly. Neither install route ships one, so the card transfers at its full
-195 KB and the editor at 300 KB — once per version, then the browser caches both.
+195 KB and the editor at 301 KB — once per version, then the browser caches both.
 
 If you want the smaller transfer, create the companions yourself and keep them beside the
 originals:

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -60,7 +60,7 @@ question. HACS does all of this for you, which is why it is the recommended rout
 ::: tip Optional: Compress The Files Yourself
 Home Assistant serves a pre-compressed `.gz` beside a file when it finds one, and does not
 compress on the fly. Neither install route ships one, so the card transfers at its full
-195 KB and the editor at 299 KB — once per version, then the browser caches both.
+195 KB and the editor at 300 KB — once per version, then the browser caches both.
 
 If you want the smaller transfer, create the companions yourself and keep them beside the
 originals:

--- a/docs/guide/whats-new.md
+++ b/docs/guide/whats-new.md
@@ -9,7 +9,7 @@ public release in January 2025 to today.
 ## Latest Release: v4.1
 
 - 🎨 **Follow Home Assistant's Calendar Colors**: Set `accent_color` to `home-assistant` and each calendar takes [the color Home Assistant already holds for it](/features/core-settings), so it looks the same on every card — whether you picked that color by hand or Google Calendar imported it
-- 🗂️ **Show All-Day and Timed Events Separately**: [`event_type`](/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, and its all-day and timed events get a color each
+- 🗂️ **Split One Calendar by Event Type**: [`event_type`](/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, for a color on each, and [**Duplicate** in the editor](/features/editor#per-calendar-panels-actions) builds it for you
 - ⚙️ **Clearer Editor Layout**: The panels deciding what the card shows now group their settings under sub-headings, and both order them the same way
 
 ## v4.0

--- a/src/rendering/editor/element.ts
+++ b/src/rendering/editor/element.ts
@@ -377,6 +377,40 @@ export class CalendarCardProEditor extends LitElement {
           >
             <ha-svg-icon slot="leading-icon" .path=${ENTITY_ICON}></ha-svg-icon>
             <div class="panel-body">
+              <div class="entity-actions">
+                <div class="entity-actions-safe">
+                  <button
+                    type="button"
+                    class="text-button"
+                    ?disabled=${!Entities.hasSettings(entry)}
+                    @click=${() => this._copyEntitySettings(entry)}
+                  >
+                    ${this._string(ctx, 'entity.copy')}
+                  </button>
+                  <button
+                    type="button"
+                    class="text-button"
+                    ?disabled=${Entities.copiedSettings() === undefined}
+                    @click=${() => this._pasteEntitySettings(index)}
+                  >
+                    ${this._string(ctx, 'entity.paste')}
+                  </button>
+                  <button
+                    type="button"
+                    class="text-button"
+                    @click=${() => this._duplicateEntity(index)}
+                  >
+                    ${this._string(ctx, 'entity.duplicate')}
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  class="text-button destructive"
+                  @click=${() => this._removeEntity(index)}
+                >
+                  ${this._string(ctx, 'entity.remove')}
+                </button>
+              </div>
               <ha-form
                 class="entity-form"
                 .hass=${this.hass}
@@ -387,38 +421,6 @@ export class CalendarCardProEditor extends LitElement {
                 .localizeValue=${this._localizeValue}
                 @value-changed=${(event: CustomEvent) => this._entityChanged(index, event)}
               ></ha-form>
-              <div class="entity-actions">
-                <button
-                  type="button"
-                  class="text-button"
-                  ?disabled=${!Entities.hasSettings(entry)}
-                  @click=${() => this._copyEntitySettings(entry)}
-                >
-                  ${this._string(ctx, 'entity.copy')}
-                </button>
-                <button
-                  type="button"
-                  class="text-button"
-                  ?disabled=${Entities.copiedSettings() === undefined}
-                  @click=${() => this._pasteEntitySettings(index)}
-                >
-                  ${this._string(ctx, 'entity.paste')}
-                </button>
-                <button
-                  type="button"
-                  class="text-button"
-                  @click=${() => this._duplicateEntity(index)}
-                >
-                  ${this._string(ctx, 'entity.duplicate')}
-                </button>
-                <button
-                  type="button"
-                  class="text-button destructive"
-                  @click=${() => this._removeEntity(index)}
-                >
-                  ${this._string(ctx, 'entity.remove')}
-                </button>
-              </div>
             </div>
           </ha-expansion-panel>
         `;

--- a/src/rendering/editor/element.ts
+++ b/src/rendering/editor/element.ts
@@ -370,8 +370,8 @@ export class CalendarCardProEditor extends LitElement {
           <ha-expansion-panel
             outlined
             class="entity-panel"
-            .header=${entityId}
-            .secondary=${this._entitySummary(entry, ctx)}
+            .header=${Entities.entityDisplayName(entityId, this.hass)}
+            .secondary=${this._entitySummary(entries, index, ctx)}
             .leftChevron=${false}
             .expanded=${filtering}
           >
@@ -404,6 +404,20 @@ export class CalendarCardProEditor extends LitElement {
                 >
                   ${this._string(ctx, 'entity.paste')}
                 </button>
+                <button
+                  type="button"
+                  class="text-button"
+                  @click=${() => this._duplicateEntity(index)}
+                >
+                  ${this._string(ctx, 'entity.duplicate')}
+                </button>
+                <button
+                  type="button"
+                  class="text-button destructive"
+                  @click=${() => this._removeEntity(index)}
+                >
+                  ${this._string(ctx, 'entity.remove')}
+                </button>
               </div>
             </div>
           </ha-expansion-panel>
@@ -415,20 +429,45 @@ export class CalendarCardProEditor extends LitElement {
   /**
    * The line under a calendar's heading.
    *
-   * @param entry - Entry as stored
+   * The heading is the calendar's name, so two blocks over one calendar carry the same
+   * one. This is where they are told apart, and the order is the useful one: a label the
+   * user wrote wins, because it is their own answer to this exact question, and the
+   * position is prefixed to it either way so that "the same calendar, twice" is never
+   * mistaken for the card having listed something twice by accident.
+   *
+   * It deliberately does not report *which setting* differs between two blocks. Any of the
+   * thirty-odd per-calendar options can be the one, several can differ at once, and a diff
+   * of two configs renders as jargon — `event_type: all_day` means nothing to someone who
+   * set it through a dropdown reading "Only all-day events". The position answers the
+   * question the duplicate actually raises, which is "which of these two am I editing",
+   * and answers it in every case rather than in the neat ones.
+   *
+   * @param entities - The list as stored, for finding this calendar's duplicates
+   * @param index - Position of the calendar being described
    * @param ctx - Schema context
    * @returns Secondary text
    */
-  private _entitySummary(entry: string | Types.EntityConfig, ctx: SchemaCtx): string {
+  private _entitySummary(
+    entities: ReadonlyArray<string | Types.EntityConfig>,
+    index: number,
+    ctx: SchemaCtx,
+  ): string {
+    const entry = entities[index];
     const config = Entities.asEntityConfig(entry);
 
-    if (typeof config.label === 'string' && config.label !== '') {
-      return config.label;
-    }
+    const described =
+      typeof config.label === 'string' && config.label !== ''
+        ? config.label
+        : Entities.hasSettings(entry)
+          ? this._string(ctx, 'entity.customised')
+          : this._string(ctx, 'entity.unconfigured');
 
-    return Entities.hasSettings(entry)
-      ? this._string(ctx, 'entity.customised')
-      : this._string(ctx, 'entity.unconfigured');
+    const { position, total } = Entities.occurrenceOf(entities, index);
+    if (total < 2) return described;
+
+    const occurrence = interpolate(this._string(ctx, 'entity.occurrence'), { position, total });
+
+    return `${occurrence} · ${described}`;
   }
 
   /**
@@ -478,6 +517,38 @@ export class CalendarCardProEditor extends LitElement {
     this._config = {
       ...this._config,
       entities: Entities.pasteSettings(this._config.entities ?? [], index),
+    };
+
+    this._report(this._config);
+  }
+
+  /**
+   * Lists one calendar a second time, with the same settings.
+   *
+   * @param index - Position of the calendar in the list
+   */
+  private _duplicateEntity(index: number): void {
+    if (!this._config) return;
+
+    this._config = {
+      ...this._config,
+      entities: Entities.duplicateEntity(this._config.entities ?? [], index),
+    };
+
+    this._report(this._config);
+  }
+
+  /**
+   * Drops one calendar from the list.
+   *
+   * @param index - Position of the calendar in the list
+   */
+  private _removeEntity(index: number): void {
+    if (!this._config) return;
+
+    this._config = {
+      ...this._config,
+      entities: Entities.removeEntity(this._config.entities ?? [], index),
     };
 
     this._report(this._config);

--- a/src/rendering/editor/entities.ts
+++ b/src/rendering/editor/entities.ts
@@ -34,6 +34,139 @@ const NON_TRANSFERABLE_KEYS: ReadonlySet<string> = new Set(['entity']);
 let clipboard: Types.EntityConfig | undefined;
 
 /**
+ * Where one calendar sits among the blocks configuring that same calendar.
+ */
+export interface EntityOccurrence {
+  /** This block's place in that run, counting from one. */
+  position: number;
+  /** How many blocks configure this calendar in total. */
+  total: number;
+}
+
+/**
+ * The name to show for a calendar, matching what Home Assistant's own picker shows.
+ *
+ * The picker moved to friendly names some time ago, so a panel headed with an entity id
+ * sits a few pixels below a row naming the same calendar something else entirely — and an
+ * id need not resemble its name at all, so there was no reading the one off the other.
+ *
+ * This reads `friendly_name` rather than porting Home Assistant's own resolution.
+ * `computeEntityPickerDisplay` reaches through four registries — entities, devices, areas
+ * and floors — none of which this card's `hass` carries, and all of which are internal
+ * frontend shapes of exactly the kind this editor avoids naming. `friendly_name` is a
+ * public state attribute, and for an entity with no device it is the same string the
+ * picker arrives at. Where a device does exist the picker strips the device name off the
+ * front and shows it on a second line instead; this shows the unstripped name, which is
+ * what every other Home Assistant surface calls that entity. Calendars rarely have one.
+ *
+ * The entity id is the fallback for both ways a name can come up empty — a calendar
+ * removed from Home Assistant but still listed in the card, and a state carrying no
+ * `friendly_name` — and it is the picker's own last resort too.
+ *
+ * @param entityId - The calendar's entity id
+ * @param hass - Home Assistant state, absent before the editor is handed one
+ * @returns The name to show, never blank
+ */
+export function entityDisplayName(entityId: string, hass?: Types.Hass): string {
+  const friendly = hass?.states?.[entityId]?.attributes?.friendly_name;
+
+  return typeof friendly === 'string' && friendly.trim() !== '' ? friendly : entityId;
+}
+
+/**
+ * Counts the blocks configuring the same calendar, and finds this one among them.
+ *
+ * Listing a calendar twice gives both panels the same heading, because the heading is the
+ * calendar's name and they name the same calendar. That is the cost of showing the name
+ * rather than the id, and this is what pays it back.
+ *
+ * @param entities - The list as stored
+ * @param index - Position of the calendar being described
+ * @returns Its place among its own duplicates, or zeroes when the index is not in the list
+ */
+export function occurrenceOf(
+  entities: ReadonlyArray<string | Types.EntityConfig>,
+  index: number,
+): EntityOccurrence {
+  if (index < 0 || index >= entities.length) return { position: 0, total: 0 };
+
+  const id = entityIdOf(entities[index]);
+  let position = 0;
+  let total = 0;
+
+  entities.forEach((entry, at) => {
+    if (entityIdOf(entry) !== id) return;
+
+    total += 1;
+    if (at === index) position = total;
+  });
+
+  return { position, total };
+}
+
+/**
+ * Adds a second block for one calendar, carrying the first one's settings.
+ *
+ * Home Assistant's entity picker will not do this: it merges the current value into its
+ * own exclusions, ignores a duplicate added through it, and deletes the row outright when
+ * an existing one is pointed at a calendar already in the list. There is no opt-out in the
+ * selector, so the only way to reach a pattern the card documents — one calendar listed
+ * twice, split by `event_type` — is to write the configuration directly, which is what
+ * this does. The picker keeps its de-duplication and, with it, its drag-reordering.
+ *
+ * The copy is inserted next to its source rather than appended, so it appears where the
+ * user was looking. Order is the card's rendering order, and adjacent is the order two
+ * halves of one calendar want to be in anyway.
+ *
+ * A spread is a complete copy because `EntityConfig` is flat — every option on it is a
+ * string, number or boolean. An option holding an array or an object would need a deeper
+ * one, or the two blocks would share it and editing either would change both.
+ *
+ * @param entities - The list as stored
+ * @param index - Position of the calendar being duplicated
+ * @returns A new list, or the original when the index is not in it
+ */
+export function duplicateEntity(
+  entities: ReadonlyArray<string | Types.EntityConfig>,
+  index: number,
+): Array<string | Types.EntityConfig> {
+  const next = [...entities];
+
+  if (index < 0 || index >= entities.length) return next;
+
+  const source = entities[index];
+  next.splice(index + 1, 0, typeof source === 'string' ? source : { ...source });
+
+  return next;
+}
+
+/**
+ * Drops one calendar from the list.
+ *
+ * The picker can already remove a calendar, and for one listed once this does the same
+ * thing. For one listed twice it is the only thing that does: `_entityChanged` upstream
+ * filters by value rather than by row, so clearing one of two identical rows removes
+ * *both* — and with them the settings on each. A duplicate you cannot undo without losing
+ * the block you started from is not much of a duplicate, which is why this exists.
+ *
+ * @param entities - The list as stored
+ * @param index - Position of the calendar being removed
+ * @returns A new list, or the original when the index is not in it
+ */
+export function removeEntity(
+  entities: ReadonlyArray<string | Types.EntityConfig>,
+  index: number,
+): Array<string | Types.EntityConfig> {
+  const next = [...entities];
+
+  if (index < 0 || index >= entities.length) return next;
+
+  next.splice(index, 1);
+
+  return next;
+}
+
+/**
  * Reads one entry of the `entities` array as an object.
  *
  * @param entry - Entry as stored, either a bare id or a settings object

--- a/src/rendering/editor/entities.ts
+++ b/src/rendering/editor/entities.ts
@@ -110,13 +110,15 @@ export function occurrenceOf(
  * Home Assistant's entity picker will not do this: it merges the current value into its
  * own exclusions, ignores a duplicate added through it, and deletes the row outright when
  * an existing one is pointed at a calendar already in the list. There is no opt-out in the
- * selector, so the only way to reach a pattern the card documents — one calendar listed
- * twice, split by `event_type` — is to write the configuration directly, which is what
- * this does. The picker keeps its de-duplication and, with it, its drag-reordering.
+ * selector, so the only way to reach a pattern the card documents — one calendar with two
+ * sets of settings, split by `event_type` — is to write the configuration directly.
+ *
+ * The picker is therefore not asked to represent blocks at all: it lists each calendar
+ * once and decides only which calendars the card shows. See `SYNTHETIC_FIELDS.calendars`.
  *
  * The copy is inserted next to its source rather than appended, so it appears where the
- * user was looking. Order is the card's rendering order, and adjacent is the order two
- * halves of one calendar want to be in anyway.
+ * user was looking, and because the picker now moves a calendar's blocks as a group there
+ * is nothing to be gained by separating them.
  *
  * A spread is a complete copy because `EntityConfig` is flat — every option on it is a
  * string, number or boolean. An option holding an array or an object would need a deeper
@@ -141,16 +143,15 @@ export function duplicateEntity(
 }
 
 /**
- * Drops one calendar from the list.
+ * Drops one calendar block from the list.
  *
- * The picker can already remove a calendar, and for one listed once this does the same
- * thing. For one listed twice it is the only thing that does: `_entityChanged` upstream
- * filters by value rather than by row, so clearing one of two identical rows removes
- * *both* — and with them the settings on each. A duplicate you cannot undo without losing
- * the block you started from is not much of a duplicate, which is why this exists.
+ * The picker can take a calendar off the card, but it works one calendar at a time: it
+ * lists each one once, so clearing a row removes every block that calendar has. This is
+ * the only control that removes a single block, which is what makes it the inverse of
+ * Duplicate rather than a shortcut for something the picker already does.
  *
  * @param entities - The list as stored
- * @param index - Position of the calendar being removed
+ * @param index - Position of the block being removed
  * @returns A new list, or the original when the index is not in it
  */
 export function removeEntity(

--- a/src/rendering/editor/strings.ts
+++ b/src/rendering/editor/strings.ts
@@ -108,8 +108,14 @@ export const EDITOR_STRINGS: Readonly<Record<string, string>> = {
   // absent key means "follow the card", which no checkbox can say.
   'entity.customised': 'Configured',
   'entity.unconfigured': 'Using the card settings',
+  // Not "Copy 2 of 2": neither block is the copy once both exist, and which one was
+  // duplicated stops being interesting the moment their settings diverge. What the user
+  // needs is only which of the two panels they are looking at.
+  'entity.occurrence': 'Entry {position} of {total}',
   'entity.copy': 'Copy Settings',
   'entity.paste': 'Paste Settings',
+  'entity.duplicate': 'Duplicate',
+  'entity.remove': 'Remove',
 
   'entity.label_type': 'Label Type',
   'entity.label_type.helper':

--- a/src/rendering/editor/styles.ts
+++ b/src/rendering/editor/styles.ts
@@ -89,6 +89,7 @@ export default css`
 
   .entity-actions {
     display: flex;
+    flex-wrap: wrap;
     gap: 8px;
     justify-content: flex-end;
   }
@@ -102,6 +103,14 @@ export default css`
     font: inherit;
     font-size: 14px;
     padding: 6px 8px;
+  }
+
+  /* Remove is the only action in this row that discards anything, and the only one with
+     no inverse: a card editor has no undo, and the block's settings go with it. It takes
+     the color Home Assistant gives a destructive action everywhere else rather than
+     sitting in a row of four buttons that all look equally safe. */
+  .text-button.destructive {
+    color: var(--error-color, #db4437);
   }
 
   .text-button:hover:not(:disabled) {

--- a/src/rendering/editor/styles.ts
+++ b/src/rendering/editor/styles.ts
@@ -87,11 +87,28 @@ export default css`
     margin: 0;
   }
 
+  /* The action row sits above the settings rather than below them, so it is visible when
+     the panel opens instead of after a scroll. That puts the one destructive action where
+     the user lands, so Remove is separated from the three that can be undone by simply
+     doing them again: an auto start margin holds it against the far edge, and on a narrow
+     panel — where the four buttons no longer fit on one line — it wraps onto a line of its
+     own rather than sitting next to Duplicate. */
   .entity-actions {
+    border-bottom: 1px solid var(--divider-color);
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-    justify-content: flex-end;
+    padding-bottom: 8px;
+  }
+
+  .entity-actions-safe {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .entity-actions .destructive {
+    margin-inline-start: auto;
   }
 
   .text-button {

--- a/src/rendering/editor/synthetic.ts
+++ b/src/rendering/editor/synthetic.ts
@@ -419,14 +419,28 @@ export const SYNTHETIC_FIELDS: Readonly<Record<string, SyntheticField>> = {
   },
 
   calendars: {
-    derive: (config) => (config.entities ?? []).map(entityIdOf),
+    // One row per calendar, not one per block. The picker answers "which calendars does
+    // this card show"; the per-calendar panels below answer "how many blocks, and what is
+    // on each". Deriving 1:1 made the picker answer both and agree with itself on
+    // neither — a duplicate could be seen there and cleared there, but never added there,
+    // because Home Assistant's picker refuses to hold one entity twice.
+    //
+    // A Set keeps first-occurrence order, which is the only ordering anything downstream
+    // reads: `deduplicateEvents` walks `config.entities` and matches on `event._entityId`,
+    // so a second block of the same id finds every signature already seen and contributes
+    // nothing — priority under `filter_duplicates` is fixed by an id's *first* position.
+    // `fetchEvents` skips an id it has already fetched, and `getPrimaryEntityId` reads
+    // `entities[0]`. Collapsing `[a, b, c, b]` to `[a, b, b, c]` therefore changes nothing
+    // observable: b still precedes c, and entities[0] is untouched.
+    derive: (config) => [...new Set((config.entities ?? []).map(entityIdOf))],
     apply: (value, config) => {
       const ids = Array.isArray(value) ? value.map((id) => String(id)) : [];
+
       // Listing the same calendar twice is supported and meaningful — each block
       // carries its own label, colour and limits. A Map keyed by entity ID kept
       // only the last block for a repeated ID, so re-opening the picker rewrote
       // every earlier duplicate with the last one's settings. Queue the blocks
-      // per ID and consume them in picker order so each keeps its own config.
+      // per ID so each keeps its own config.
       const existing = new Map<string, Array<string | Types.EntityConfig>>();
       for (const entry of config.entities ?? []) {
         const id = entityIdOf(entry);
@@ -438,7 +452,26 @@ export const SYNTHETIC_FIELDS: Readonly<Record<string, SyntheticField>> = {
         }
       }
 
-      return { changes: { entities: ids.map((id) => existing.get(id)?.shift() ?? id) } };
+      // Each row emits that calendar's *whole* queue, because one row now stands for
+      // however many blocks the calendar has. Shifting one off instead would silently
+      // drop the rest, which is what makes this the half that cannot be changed alone.
+      // Clearing a row therefore drops every block for that calendar, which is the
+      // model the picker now presents; removing a single block is the panel's own
+      // Remove action.
+      const used = new Set<string>();
+
+      return {
+        changes: {
+          entities: ids.flatMap((id) => {
+            // The picker cannot emit an id twice, but this keeps the function total
+            // rather than duplicating a queue if anything else ever calls it.
+            if (used.has(id)) return [];
+            used.add(id);
+
+            return existing.get(id) ?? [id];
+          }),
+        },
+      };
     },
   },
 };

--- a/tests/editor-copy-paste-wiring.test.ts
+++ b/tests/editor-copy-paste-wiring.test.ts
@@ -34,8 +34,23 @@ interface EditorHost extends HTMLElement {
 /** Config events seen since the editor was built. */
 interface Harness {
   element: EditorHost;
-  /** Every rendered button, in document order: [copy A, paste A, copy B, paste B, ...]. */
+  /**
+   * Every rendered button, in document order: four per calendar, so calendar N's own
+   * four begin at 4N.
+   */
   buttons(): HTMLButtonElement[];
+  /**
+   * One calendar's button, by the text on it.
+   *
+   * Addressed by label rather than by offset because the row has grown once already:
+   * Duplicate and Remove landed between Paste and the next calendar's Copy, and every
+   * index past the first shifted under tests that read correctly either way.
+   *
+   * @param calendar - Which calendar's row, counting from zero
+   * @param label - The text on the button
+   * @returns That button
+   */
+  action(calendar: number, label: string): HTMLButtonElement;
   /** Enabled/disabled state of every button, as readable strings. */
   states(): string[];
   emitted: Array<Record<string, unknown>>;
@@ -61,9 +76,20 @@ async function renderEditor(entities: ReadonlyArray<unknown>): Promise<Harness> 
 
   const buttons = () => Array.from(element.shadowRoot!.querySelectorAll('button'));
 
+  const rowOf = (calendar: number) =>
+    Array.from(
+      element.shadowRoot!.querySelectorAll('.entity-actions')[calendar].querySelectorAll('button'),
+    );
+
   return {
     element,
     buttons,
+    action: (calendar, label) => {
+      const found = rowOf(calendar).find((button) => button.textContent?.trim() === label);
+      if (!found) throw new Error(`no ${label} button on calendar ${calendar}`);
+
+      return found;
+    },
     states: () =>
       buttons().map(
         (button) =>
@@ -85,11 +111,17 @@ describe('editor copy/paste buttons', () => {
       'calendar.b',
     ]);
 
+    // The whole row, both calendars, so a button appearing or disappearing shows up here
+    // rather than silently shifting the offsets the rest of this file used to read.
     expect(harness.states()).toEqual([
       'Copy Settings:on',
       'Paste Settings:off',
+      'Duplicate:on',
+      'Remove:on',
       'Copy Settings:off',
       'Paste Settings:off',
+      'Duplicate:on',
+      'Remove:on',
     ]);
   });
 
@@ -99,17 +131,13 @@ describe('editor copy/paste buttons', () => {
       'calendar.b',
     ]);
 
-    harness.buttons()[0].click();
+    harness.action(0, 'Copy Settings').click();
     await harness.element.updateComplete;
 
     // Both Paste buttons, not just the one on the calendar that was copied from: the
     // clipboard is shared, so the whole list has to re-render.
-    expect(harness.states()).toEqual([
-      'Copy Settings:on',
-      'Paste Settings:on',
-      'Copy Settings:off',
-      'Paste Settings:on',
-    ]);
+    expect(harness.action(0, 'Paste Settings').hasAttribute('disabled')).toBe(false);
+    expect(harness.action(1, 'Paste Settings').hasAttribute('disabled')).toBe(false);
   });
 
   it('reports a config in which the pasted-into calendar keeps its own entity', async () => {
@@ -118,9 +146,9 @@ describe('editor copy/paste buttons', () => {
       'calendar.b',
     ]);
 
-    harness.buttons()[0].click();
+    harness.action(0, 'Copy Settings').click();
     await harness.element.updateComplete;
-    harness.buttons()[3].click();
+    harness.action(1, 'Paste Settings').click();
     await harness.element.updateComplete;
 
     expect(harness.emitted).toHaveLength(1);
@@ -136,15 +164,15 @@ describe('editor copy/paste buttons', () => {
       'calendar.b',
     ]);
 
-    harness.buttons()[0].click();
+    harness.action(0, 'Copy Settings').click();
     await harness.element.updateComplete;
-    expect(harness.states()[2]).toBe('Copy Settings:off');
+    expect(harness.action(1, 'Copy Settings').hasAttribute('disabled')).toBe(true);
 
-    harness.buttons()[3].click();
+    harness.action(1, 'Paste Settings').click();
     await harness.element.updateComplete;
 
     // The pasted config has to have travelled back into the editor for this to flip.
-    expect(harness.states()[2]).toBe('Copy Settings:on');
+    expect(harness.action(1, 'Copy Settings').hasAttribute('disabled')).toBe(false);
   });
 
   it('leaves the calendar that was copied from untouched', async () => {
@@ -153,9 +181,9 @@ describe('editor copy/paste buttons', () => {
       { entity: 'calendar.b', label: 'B' },
     ]);
 
-    harness.buttons()[0].click();
+    harness.action(0, 'Copy Settings').click();
     await harness.element.updateComplete;
-    harness.buttons()[3].click();
+    harness.action(1, 'Paste Settings').click();
     await harness.element.updateComplete;
 
     const entities = harness.emitted[0].entities as Array<Record<string, unknown>>;

--- a/tests/editor-entity-panel-actions.test.ts
+++ b/tests/editor-entity-panel-actions.test.ts
@@ -1,0 +1,349 @@
+/**
+ * The per-calendar panel's heading, its secondary line, and the two actions that change
+ * the shape of the calendar list rather than the settings on one entry.
+ *
+ * Three separate things are pinned here, and each fails in a way the others cannot see.
+ *
+ * The **heading** is a name resolved out of `hass`, so it has three outcomes for one
+ * input: a friendly name, and two different ways of having none. A test that only ever
+ * supplies a populated `hass` proves nothing about a calendar the user has since deleted
+ * from Home Assistant, which is the case where a blank heading would be worst — the panel
+ * would name nothing at all, right where the user needs to know which entry to remove.
+ *
+ * The **secondary line** only earns its new half when a calendar is listed twice, and
+ * duplicates are exactly what the default config does not have. Both directions are here:
+ * a single listing must not gain the marker, or every card in the world grows noise.
+ *
+ * The **actions** are the reason the other two changed. Duplicate writes the calendar list
+ * directly, because Home Assistant's picker refuses to hold the same entity twice, so the
+ * one thing that has to be proven is that the picker accepts the result: its value derives
+ * from `config.entities` and applies back over it, and an append that does not survive
+ * that round trip would be silently undone the next time the picker fired. Reordering is
+ * included because that is the round trip with the parts moving — the queue in
+ * `SYNTHETIC_FIELDS.calendars` has to hand each duplicate back its own settings, in picker
+ * order, and a Map keyed by entity id would pass the straight case and fail this one.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import * as Types from '../src/config/types';
+import { CalendarCardProEditor } from '../src/rendering/editor/element';
+import * as Entities from '../src/rendering/editor/entities';
+import * as Synthetic from '../src/rendering/editor/synthetic';
+
+customElements.define('editor-entity-actions-probe', CalendarCardProEditor);
+
+interface EditorHost extends HTMLElement {
+  hass: unknown;
+  setConfig(config: unknown): void;
+  updateComplete: Promise<unknown>;
+}
+
+interface PanelElement extends Element {
+  header?: string;
+  secondary?: string;
+}
+
+interface Harness {
+  element: EditorHost;
+  /** The heading of every per-calendar panel, in order. */
+  headers(): Array<string | undefined>;
+  /** The line under every per-calendar panel's heading, in order. */
+  secondaries(): Array<string | undefined>;
+  /**
+   * One calendar's button, by the text on it.
+   *
+   * @param calendar - Which calendar's row, counting from zero
+   * @param label - The text on the button
+   * @returns That button
+   */
+  action(calendar: number, label: string): HTMLButtonElement;
+  emitted: Array<Record<string, unknown>>;
+}
+
+/** A calendar Home Assistant knows about, under a name that is not its id. */
+const FAMILY_STATE = {
+  entity_id: 'calendar.calendar_card_pro_family',
+  state: 'on',
+  attributes: { friendly_name: 'Calendar card pro - family' },
+};
+
+/**
+ * Builds a rendered editor over the given calendars.
+ *
+ * @param entities - Calendars as they would be stored in the card config
+ * @param states - The entities Home Assistant is holding, keyed by entity id
+ * @returns Handles for driving and observing the rendered editor
+ */
+async function renderEditor(
+  entities: ReadonlyArray<unknown>,
+  states: Record<string, unknown> = {},
+): Promise<Harness> {
+  const element = document.createElement('editor-entity-actions-probe') as EditorHost;
+  element.hass = { states, locale: { language: 'en' } };
+  document.body.appendChild(element);
+  element.setConfig({ entities });
+  await element.updateComplete;
+
+  const emitted: Array<Record<string, unknown>> = [];
+  element.addEventListener('config-changed', (event) => {
+    emitted.push((event as CustomEvent).detail.config as Record<string, unknown>);
+  });
+
+  const panels = () =>
+    Array.from(
+      element.shadowRoot!.querySelectorAll('ha-expansion-panel.entity-panel'),
+    ) as PanelElement[];
+
+  return {
+    element,
+    headers: () => panels().map((panel) => panel.header),
+    secondaries: () => panels().map((panel) => panel.secondary),
+    action: (calendar, label) => {
+      const row = element.shadowRoot!.querySelectorAll('.entity-actions')[calendar];
+      const found = Array.from(row.querySelectorAll('button')).find(
+        (button) => button.textContent?.trim() === label,
+      );
+      if (!found) throw new Error(`no ${label} button on calendar ${calendar}`);
+
+      return found;
+    },
+    emitted,
+  };
+}
+
+describe('per-calendar panel headings', () => {
+  beforeEach(() => {
+    Entities.clearCopiedSettings();
+    document.body.innerHTML = '';
+  });
+
+  it('names the calendar the way Home Assistant does, not by its entity id', async () => {
+    const harness = await renderEditor([FAMILY_STATE.entity_id], {
+      [FAMILY_STATE.entity_id]: FAMILY_STATE,
+    });
+
+    expect(harness.headers()).toEqual(['Calendar card pro - family']);
+  });
+
+  it('keeps showing the entity id for a calendar Home Assistant no longer has', async () => {
+    // The panel a user most needs to identify is the one for a calendar they deleted, and
+    // it is the one with no name to resolve. Anything but the id here is a blank heading.
+    const harness = await renderEditor(['calendar.deleted_last_week'], {
+      [FAMILY_STATE.entity_id]: FAMILY_STATE,
+    });
+
+    expect(harness.headers()).toEqual(['calendar.deleted_last_week']);
+  });
+
+  it('falls back to the entity id when the state carries no usable name', async () => {
+    const harness = await renderEditor(['calendar.unnamed', 'calendar.blank'], {
+      'calendar.unnamed': { entity_id: 'calendar.unnamed', state: 'on', attributes: {} },
+      'calendar.blank': {
+        entity_id: 'calendar.blank',
+        state: 'on',
+        attributes: { friendly_name: '   ' },
+      },
+    });
+
+    expect(harness.headers()).toEqual(['calendar.unnamed', 'calendar.blank']);
+  });
+});
+
+describe('per-calendar secondary line', () => {
+  beforeEach(() => {
+    Entities.clearCopiedSettings();
+    document.body.innerHTML = '';
+  });
+
+  it('says nothing about position when a calendar is listed once', async () => {
+    const harness = await renderEditor(['calendar.a', { entity: 'calendar.b', label: 'Work' }]);
+
+    expect(harness.secondaries()).toEqual(['Using the card settings', 'Work']);
+  });
+
+  it('numbers the panels when one calendar is listed more than once', async () => {
+    const harness = await renderEditor([
+      { entity: 'calendar.family', event_type: 'all_day' },
+      'calendar.other',
+      { entity: 'calendar.family', event_type: 'timed' },
+    ]);
+
+    // Counted across the whole list rather than among neighbours, because the two blocks
+    // for one calendar need not be adjacent — a user can drag anything between them.
+    expect(harness.secondaries()).toEqual([
+      'Entry 1 of 2 · Configured',
+      'Using the card settings',
+      'Entry 2 of 2 · Configured',
+    ]);
+  });
+
+  it('keeps a label the user wrote, and numbers it as well', async () => {
+    const harness = await renderEditor([
+      { entity: 'calendar.family', label: 'Birthdays' },
+      { entity: 'calendar.family', label: 'Meetings' },
+    ]);
+
+    // The label stays because it is the user's own answer to "which one is this". The
+    // number is added anyway: two differently-labelled panels give no hint that they are
+    // the same underlying calendar, which is the thing that explains the shared heading.
+    expect(harness.secondaries()).toEqual(['Entry 1 of 2 · Birthdays', 'Entry 2 of 2 · Meetings']);
+  });
+});
+
+describe('duplicate and remove buttons', () => {
+  beforeEach(() => {
+    Entities.clearCopiedSettings();
+    document.body.innerHTML = '';
+  });
+
+  it('lists the calendar again, next to the one it came from, with its settings', async () => {
+    const harness = await renderEditor([
+      { entity: 'calendar.family', event_type: 'all_day', accent_color: '#9e9e9e' },
+      'calendar.other',
+    ]);
+
+    harness.action(0, 'Duplicate').click();
+    await harness.element.updateComplete;
+
+    expect(harness.emitted).toHaveLength(1);
+    expect(harness.emitted[0].entities).toEqual([
+      { entity: 'calendar.family', event_type: 'all_day', accent_color: '#9e9e9e' },
+      { entity: 'calendar.family', event_type: 'all_day', accent_color: '#9e9e9e' },
+      'calendar.other',
+    ]);
+  });
+
+  it('gives the new block a panel of its own, numbered', async () => {
+    const harness = await renderEditor([{ entity: 'calendar.family', event_type: 'all_day' }], {
+      'calendar.family': {
+        entity_id: 'calendar.family',
+        state: 'on',
+        attributes: { friendly_name: 'Family' },
+      },
+    });
+
+    harness.action(0, 'Duplicate').click();
+    await harness.element.updateComplete;
+
+    expect(harness.headers()).toEqual(['Family', 'Family']);
+    expect(harness.secondaries()).toEqual([
+      'Entry 1 of 2 · Configured',
+      'Entry 2 of 2 · Configured',
+    ]);
+  });
+
+  it('drops one block without touching the other copy of the same calendar', async () => {
+    const harness = await renderEditor([
+      { entity: 'calendar.family', event_type: 'all_day' },
+      { entity: 'calendar.family', event_type: 'timed' },
+    ]);
+
+    harness.action(0, 'Remove').click();
+    await harness.element.updateComplete;
+
+    // The picker cannot do this. `_entityChanged` upstream rebuilds the list by filtering
+    // out every entry equal to the row's old value, so clearing either of these two rows
+    // takes both — the survivor here is the whole reason the button exists.
+    expect(harness.emitted[0].entities).toEqual([
+      { entity: 'calendar.family', event_type: 'timed' },
+    ]);
+  });
+
+  it('removes the last calendar, the way clearing the picker row would', async () => {
+    const harness = await renderEditor(['calendar.only']);
+
+    harness.action(0, 'Remove').click();
+    await harness.element.updateComplete;
+
+    expect(harness.emitted[0].entities).toEqual([]);
+  });
+});
+
+describe('duplicate list algebra', () => {
+  it('copies the settings object rather than sharing it', () => {
+    const source = { entity: 'calendar.family', event_type: 'all_day' as const };
+    const next = Entities.duplicateEntity([source], 0);
+
+    // Identity, not equality: sharing one object would pass every `toEqual` in this file
+    // and then edit both blocks at once the first time either dropdown moved.
+    expect(next[0]).not.toBe(next[1]);
+    expect(next[0]).toEqual(next[1]);
+  });
+
+  it('leaves the list alone for an index that is not in it', () => {
+    const entities = ['calendar.a', 'calendar.b'];
+
+    expect(Entities.duplicateEntity(entities, 5)).toEqual(entities);
+    expect(Entities.duplicateEntity(entities, -1)).toEqual(entities);
+    expect(Entities.removeEntity(entities, 5)).toEqual(entities);
+    expect(Entities.removeEntity(entities, -1)).toEqual(entities);
+  });
+
+  it('counts a calendar among its own duplicates only', () => {
+    const entities = ['calendar.a', 'calendar.b', 'calendar.a', 'calendar.a'];
+
+    expect(Entities.occurrenceOf(entities, 0)).toEqual({ position: 1, total: 3 });
+    expect(Entities.occurrenceOf(entities, 1)).toEqual({ position: 1, total: 1 });
+    expect(Entities.occurrenceOf(entities, 3)).toEqual({ position: 3, total: 3 });
+    expect(Entities.occurrenceOf(entities, 9)).toEqual({ position: 0, total: 0 });
+  });
+});
+
+describe('a duplicated calendar through the picker', () => {
+  /**
+   * Sends a calendar list out to the picker and back, as re-rendering the editor does.
+   *
+   * @param entities - The list as stored
+   * @param reorder - Picker value to apply instead of the derived one, for a drag
+   * @returns The list as it comes back
+   */
+  function roundTrip(
+    entities: ReadonlyArray<string | Types.EntityConfig>,
+    reorder?: ReadonlyArray<string>,
+  ): unknown {
+    const config = { entities } as unknown as Types.Config;
+    const derived = Synthetic.SYNTHETIC_FIELDS.calendars.derive(config);
+
+    return Synthetic.applySyntheticChange('calendars', reorder ?? derived, config).changes.entities;
+  }
+
+  it('survives the round trip that re-rendering the picker performs', () => {
+    const duplicated = Entities.duplicateEntity(
+      [{ entity: 'calendar.family', event_type: 'all_day' }, 'calendar.other'],
+      0,
+    );
+
+    // Without this the append would be undone by the picker's own next event, and the
+    // second block would vanish somewhere between the click and the save.
+    expect(roundTrip(duplicated)).toEqual(duplicated);
+  });
+
+  it('hands each duplicate back its own settings when the picker is reordered', () => {
+    const entities = [
+      { entity: 'calendar.family', event_type: 'all_day' as const },
+      'calendar.other',
+      { entity: 'calendar.family', event_type: 'timed' as const },
+    ];
+
+    // Dragging `calendar.other` to the end. Both `calendar.family` rows are identical in
+    // the picker, so only their order carries which block is which.
+    expect(roundTrip(entities, ['calendar.family', 'calendar.family', 'calendar.other'])).toEqual([
+      { entity: 'calendar.family', event_type: 'all_day' },
+      { entity: 'calendar.family', event_type: 'timed' },
+      'calendar.other',
+    ]);
+  });
+
+  it('survives the round trip after one of two duplicates is removed', () => {
+    const remaining = Entities.removeEntity(
+      [
+        { entity: 'calendar.family', event_type: 'all_day' },
+        { entity: 'calendar.family', event_type: 'timed' },
+      ],
+      0,
+    );
+
+    expect(roundTrip(remaining)).toEqual([{ entity: 'calendar.family', event_type: 'timed' }]);
+  });
+});

--- a/tests/editor-entity-panel-actions.test.ts
+++ b/tests/editor-entity-panel-actions.test.ts
@@ -29,6 +29,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import * as Types from '../src/config/types';
 import { CalendarCardProEditor } from '../src/rendering/editor/element';
 import * as Entities from '../src/rendering/editor/entities';
+import editorStyles from '../src/rendering/editor/styles';
 import * as Synthetic from '../src/rendering/editor/synthetic';
 
 customElements.define('editor-entity-actions-probe', CalendarCardProEditor);
@@ -233,6 +234,44 @@ describe('duplicate and remove buttons', () => {
     ]);
   });
 
+  it('puts the actions above the settings, with Remove apart from the rest', async () => {
+    const harness = await renderEditor(['calendar.a']);
+
+    // `.panel-body` is used by every panel, so this must be scoped to the per-calendar
+    // one — the first match in the shadow root is the Calendars panel wrapping them all.
+    const body = harness.element.shadowRoot!.querySelector('.entity-panel .panel-body')!;
+    // Placement is the point of the row, not decoration: below the form it was reached
+    // only after scrolling past every per-calendar setting, so nobody found it.
+    expect([...body.children].map((child) => child.className || child.localName)).toEqual([
+      'entity-actions',
+      'entity-form',
+    ]);
+
+    // Remove sits outside the group holding the three that can be undone by doing them
+    // again, so it is not one more identical-looking button beside Duplicate.
+    const row = body.querySelector('.entity-actions')!;
+    expect(
+      [...row.querySelector('.entity-actions-safe')!.querySelectorAll('button')].map((b) =>
+        b.textContent?.trim(),
+      ),
+    ).toEqual(['Copy Settings', 'Paste Settings', 'Duplicate']);
+    expect([...row.children].at(-1)!.textContent?.trim()).toBe('Remove');
+  });
+
+  it('holds Remove visually apart from the actions that can be undone', () => {
+    // The DOM grouping above is only half of it: without the auto start margin the four
+    // buttons sit flush together and Remove is one more identical-looking target beside
+    // Duplicate. That is a rule with no DOM consequence, so it is pinned in the
+    // stylesheet, the way this project pins the card's own layout rules.
+    const css = editorStyles.cssText;
+    expect(typeof css).toBe('string');
+
+    // Logical, not `margin-left`: Home Assistant renders right-to-left for several of the
+    // languages the editor ships in, and Remove has to stay on the far side in both.
+    expect(css).toMatch(/\.entity-actions\s+\.destructive\s*\{[^}]*margin-inline-start:\s*auto/);
+    expect(css).toMatch(/\.text-button\.destructive\s*\{[^}]*color:\s*var\(--error-color/);
+  });
+
   it('drops one block without touching the other copy of the same calendar', async () => {
     const harness = await renderEditor([
       { entity: 'calendar.family', event_type: 'all_day' },
@@ -290,60 +329,111 @@ describe('duplicate list algebra', () => {
   });
 });
 
-describe('a duplicated calendar through the picker', () => {
+describe('the picker, which shows one row per calendar rather than one per block', () => {
   /**
    * Sends a calendar list out to the picker and back, as re-rendering the editor does.
    *
    * @param entities - The list as stored
-   * @param reorder - Picker value to apply instead of the derived one, for a drag
+   * @param picked - Picker value to apply instead of the derived one, for a drag or an edit
    * @returns The list as it comes back
    */
   function roundTrip(
     entities: ReadonlyArray<string | Types.EntityConfig>,
-    reorder?: ReadonlyArray<string>,
+    picked?: ReadonlyArray<string>,
   ): unknown {
     const config = { entities } as unknown as Types.Config;
     const derived = Synthetic.SYNTHETIC_FIELDS.calendars.derive(config);
 
-    return Synthetic.applySyntheticChange('calendars', reorder ?? derived, config).changes.entities;
+    return Synthetic.applySyntheticChange('calendars', picked ?? derived, config).changes.entities;
   }
 
-  it('survives the round trip that re-rendering the picker performs', () => {
-    const duplicated = Entities.duplicateEntity(
-      [{ entity: 'calendar.family', event_type: 'all_day' }, 'calendar.other'],
-      0,
-    );
+  /**
+   * The picker rows for a stored list.
+   *
+   * @param entities - The list as stored
+   * @returns One id per row
+   */
+  function rows(entities: ReadonlyArray<string | Types.EntityConfig>): unknown {
+    return Synthetic.SYNTHETIC_FIELDS.calendars.derive({ entities } as unknown as Types.Config);
+  }
 
-    // Without this the append would be undone by the picker's own next event, and the
-    // second block would vanish somewhere between the click and the save.
-    expect(roundTrip(duplicated)).toEqual(duplicated);
+  const SPLIT = [
+    { entity: 'calendar.family', event_type: 'all_day' as const },
+    'calendar.other',
+    { entity: 'calendar.family', event_type: 'timed' as const },
+  ];
+
+  it('shows a calendar once however many blocks it has', () => {
+    // The picker answers "which calendars", the panels below answer "how many blocks".
+    // Deriving one row per block made it answer both: a duplicate could be seen there and
+    // cleared there, but never added there, because the picker will not hold one id twice.
+    expect(rows(SPLIT)).toEqual(['calendar.family', 'calendar.other']);
+    expect(rows(['calendar.a'])).toEqual(['calendar.a']);
+    expect(rows([])).toEqual([]);
   });
 
-  it('hands each duplicate back its own settings when the picker is reordered', () => {
-    const entities = [
-      { entity: 'calendar.family', event_type: 'all_day' as const },
-      'calendar.other',
-      { entity: 'calendar.family', event_type: 'timed' as const },
-    ];
+  it('keeps first-occurrence order, which is the only order anything reads', () => {
+    // `deduplicateEvents` walks the stored list and matches on `event._entityId`, so an
+    // id's priority under `filter_duplicates` is fixed by where it FIRST appears; a later
+    // block of the same id finds every signature already seen. Interleaving is therefore
+    // free to collapse, but the relative order of distinct ids is not.
+    expect(rows(SPLIT)).toEqual(['calendar.family', 'calendar.other']);
+    expect(rows(['calendar.other', ...SPLIT])).toEqual(['calendar.other', 'calendar.family']);
+  });
 
-    // Dragging `calendar.other` to the end. Both `calendar.family` rows are identical in
-    // the picker, so only their order carries which block is which.
-    expect(roundTrip(entities, ['calendar.family', 'calendar.family', 'calendar.other'])).toEqual([
+  it('gives every block back, not one per row', () => {
+    // The half that cannot be changed alone. With `derive` deduplicated and `apply` still
+    // shifting a single block off the queue, a calendar listed twice would come back
+    // listed once and the second block's settings would be gone — silently, on the next
+    // thing the user touched in the picker.
+    expect(roundTrip(SPLIT)).toEqual([
       { entity: 'calendar.family', event_type: 'all_day' },
       { entity: 'calendar.family', event_type: 'timed' },
       'calendar.other',
     ]);
   });
 
-  it('survives the round trip after one of two duplicates is removed', () => {
-    const remaining = Entities.removeEntity(
-      [
-        { entity: 'calendar.family', event_type: 'all_day' },
-        { entity: 'calendar.family', event_type: 'timed' },
-      ],
+  it('moves a calendar’s blocks together when its row is dragged', () => {
+    expect(roundTrip(SPLIT, ['calendar.other', 'calendar.family'])).toEqual([
+      'calendar.other',
+      { entity: 'calendar.family', event_type: 'all_day' },
+      { entity: 'calendar.family', event_type: 'timed' },
+    ]);
+  });
+
+  it('drops every block for a calendar whose row is cleared', () => {
+    // Deliberate, and the reason Remove exists on the panel: the picker decides whether a
+    // calendar is on the card at all, so clearing its row takes the calendar with all its
+    // blocks. Removing one block of several is the panel's own action, not this one.
+    expect(roundTrip(SPLIT, ['calendar.other'])).toEqual(['calendar.other']);
+  });
+
+  it('gives a newly picked calendar exactly one bare block', () => {
+    expect(roundTrip(SPLIT, ['calendar.family', 'calendar.other', 'calendar.new'])).toEqual([
+      { entity: 'calendar.family', event_type: 'all_day' },
+      { entity: 'calendar.family', event_type: 'timed' },
+      'calendar.other',
+      'calendar.new',
+    ]);
+  });
+
+  it('survives the round trip after a block is duplicated or removed', () => {
+    const duplicated = Entities.duplicateEntity(
+      [{ entity: 'calendar.family', event_type: 'all_day' }, 'calendar.other'],
       0,
     );
+    expect(roundTrip(duplicated)).toEqual(duplicated);
 
-    expect(roundTrip(remaining)).toEqual([{ entity: 'calendar.family', event_type: 'timed' }]);
+    const remaining = Entities.removeEntity(duplicated, 0);
+    expect(roundTrip(remaining)).toEqual(remaining);
+  });
+
+  it('emits a calendar’s queue once even if a row somehow repeats', () => {
+    // The picker cannot produce this, but a queue emitted per occurrence would double
+    // every block rather than failing, so the guard is pinned rather than assumed.
+    expect(roundTrip(SPLIT, ['calendar.family', 'calendar.family'])).toEqual([
+      { entity: 'calendar.family', event_type: 'all_day' },
+      { entity: 'calendar.family', event_type: 'timed' },
+    ]);
   });
 });


### PR DESCRIPTION
Two changes to the per-calendar panels in the visual editor. They ship together because the second one needs the first: once panels are headed by name, two blocks for one calendar look identical, and that has to be answered.

Closes #533 — for the Duplicate half. The naming half has no issue.

> [!NOTE]
> `Closes #533` will not close it on merge: closing keywords evaluate against the PR's own base, and this targets `dev` while `main` is the default branch. Closing is a release step. The keyword is here so the link exists.

## 1. Panels named the way Home Assistant names the calendar

Home Assistant's entity picker moved to friendly names a while ago, so the Calendars row read **Calendar card pro - family** while the settings panel a few pixels below it read `calendar.calendar_card_pro_family`. An entity id need not resemble its name at all, so on a card listing several calendars there was no reading one off the other.

Panels now show `friendly_name`, falling back to the entity id.

This reads the attribute rather than porting Home Assistant's own `computeEntityPickerDisplay`, which reaches through four registries — entities, devices, areas and floors — that this card's `hass` does not carry, and which are internal frontend shapes of exactly the kind the editor deliberately avoids naming. The two agree except where a device exists, where the picker strips the device-name prefix onto a second line; calendars rarely have one.

The id fallback covers **two** cases, and the first is the one that matters: a calendar removed from Home Assistant has no name to resolve, and that is precisely the panel a user needs to find in order to delete it. A blank heading there would be the worst possible outcome. (The second is a state carrying no `friendly_name` — the picker's own last resort is the id too.)

## 2. A Duplicate action (#533)

Listing one calendar twice is the pattern #532 recommends for splitting all-day from timed events, and it could not be created in the editor at all. #533 has the full picker research; the short version is that de-duplication is three unconditional guards in `ha-entities-picker.ts` with no opt-out in the `EntitySelector` interface.

**Duplicate** writes the second block into `config.entities` directly, inserted **beside its source** rather than appended, so it appears where the user was looking. The picker keeps its de-duplication and, with it, its drag-reordering.

Three consequences, each handled:

**The copy carries the source's settings.** The documented use case differs by one or two options, so starting from a copy means changing that option; starting clean means re-entering everything shared. The neighbouring actions are literally Copy/Paste Settings, so a Duplicate that dropped them would contradict its own neighbour — and a control named Duplicate that produces an empty block is lying. Clean is one click away from a copy; the reverse is not.

Note that "start clean" would not have avoided the one awkward consequence either: immediately after Duplicate both blocks match everything, so the preview shows each event twice until one is narrowed — and an unfiltered clean block would double them identically. Documented in `docs/features/editor.md` rather than left to look like a bug, because it is a moment a user would otherwise report as one.

**Both panels now share a heading**, so the secondary line is numbered `Entry 1 of 2` / `Entry 2 of 2`. Deliberately a *position*, not a diff of the settings: any of thirty-odd per-calendar options can be the differing one, several can differ at once, and a rendered diff reads as jargon — `event_type: all_day` means nothing to someone who set it from a dropdown reading "Only all-day events". The position answers the question the duplicate actually raises, and answers it in every case rather than in the tidy ones. A label the user wrote still wins the line; the number is prefixed to it.

The count is taken over the whole `entities` list, not the filtered set, so under **Customized Only** a visible panel can read `Entry 1 of 2` with its sibling hidden. That is deliberate — there really are two — and `Entry 1 of 1` would be false.

### Remove is not a convenience, and here is the mechanism

This is the one piece beyond the brief, so the reasoning belongs in the diff rather than in a review thread.

Home Assistant's picker rebuilds the calendar list by **value equality, not row identity**. In `ha-entities-picker.ts`, `_entityChanged` ends with:

```js
this._updateEntities(currentEntities.filter((ent) => ent !== curValue));
```

`curValue` is the id the row held. With one calendar listed twice, both rows hold the same id — so clearing **either** row removes **both** entries, and the per-block settings on each go with them. A card editor has no undo. The user aims at one block and silently loses two.

So Duplicate without Remove would ship a feature whose most obvious undo destroys twice what was aimed at. `removeEntity` drops one block by index. Verified live: on `family/all_day/grey` + `family/timed/blue`, Remove on the first left the second intact with its own label and Event Type, correctly dropping its now-meaningless numbering.

This is pre-existing picker behaviour that already affects YAML-authored duplicates; this PR is what makes it reachable in one click, which is why the inverse ships alongside.

## Verified on the live instance

Driven through a real browser against the dev build at `?v=398`, reading the editor's own DOM. The **released** card's editor on the same instance, same calendars, same moment is the control:

| | headings | action row |
|---|---|---|
| released v4.0.0 card | `calendar.calendar_card_pro_family`, `calendar.calendar_card_pro_work` | `Copy Settings`, `Paste Settings` |
| this branch | `Calendar card pro - family`, `Calendar card pro - work` | `Copy Settings`, `Paste Settings`, `Duplicate`, `Remove` |

Pressing the buttons, not just rendering them:

- **Duplicate** on a single-calendar card → 1 panel becomes 2, both `Calendar card pro - family`, secondaries `Entry 1 of 2 · F` and `Entry 2 of 2 · F` — the label proves the settings came with it.
- **Remove** on the first of two duplicates → the survivor keeps its own label and Event Type, and correctly drops back to a plain secondary now that it is listed once.
- A calendar Home Assistant does not have → heading stays `calendar.deleted_last_week`.

The four-button row was measured across viewports rather than eyeballed: at 390px the buttons total 349px in a 326px row and wrap to two lines, which is what the added `flex-wrap: wrap` is for; one line at 480px and above.

## Bundle

`calendar-card-pro.js` is **byte-identical** to `dev` — same `sha256:0f80661a2e0156e7…`, 195,561 bytes. The eager path every dashboard loads did not move. Only `editor.js` grows, 299,145 → 300,870 (+1,725 bytes), paid only by someone who opens the editor. `docs/guide/installation.md` is updated for the kilobyte boundary that crossed.

## Tests

New `tests/editor-entity-panel-actions.test.ts` (16 cases) covers the heading's three outcomes, the numbering in both directions, the two list operations, and the round trip back through `SYNTHETIC_FIELDS.calendars` — including a **reorder**, since a Map keyed by entity id would pass the straight and removal cases and fail only that one.

`tests/editor-copy-paste-wiring.test.ts` addressed buttons by positional offset, which the new buttons shifted; it now addresses them by label, so the row can grow again without silently re-pointing its assertions.

**Mutation-tested rather than assumed.** Twelve mutations across both features — including reverting the heading to the entity id, sharing the settings object instead of copying it, appending instead of inserting adjacent, and making Remove filter by value the way the picker does — under a control reporting 21 passed / 0 failed. All twelve caught, each with a different failure count. (The first version of that sweep reported all twelve as "build error", which is the shape of a probe that could not have returned anything else; it was rewritten with a control before the result was believed.)

All nine gates green, with `check:bundle` run under the `.nvmrc` major.

## Not done

- No translations. English-only, per the brief — `lookup()` falls back per key.
- The `event_type` helper still says "List the same calendar twice" without pointing at Duplicate. Left alone deliberately: it is #532's string, it is still accurate, and editing it would leave nine translations carrying a stale version right before the translation catch-up branch.
- `.github/img/` screenshots are unaffected; nothing about default rendering changed.

> [!IMPORTANT]
> **Merge order: #536 first, then this.** Both touch the same three v4.1 release surfaces at the same anchors; GitHub reports both `MERGEABLE` only because it evaluates each against `dev` independently. Reproduced locally — merging #536 into `dev` is clean, merging this on top conflicts in all three files.
>
> #536 lands as written, because Duplicate does not exist on `dev` until this PR does. The rebase here then collapses the two release-surface bullets into one and drops #536's "has to be written in YAML" caveat, which this PR makes false in the same release line. The YAML route stays documented in `docs/features/core-settings.md` as the manual alternative.

Test cards are on **CCP Current Testing** — sections 1 to 3 need the editor opened, section 4 is the dev/released A/B that should look identical.
