### PR TITLE
docs(release): add event_type to the v4.1 release surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Swap `calendar.family` for one of your own `calendar.*` entities and you have a 
 ### Latest Release: v4.1
 
 - 🎨 **Follow Home Assistant's Calendar Colors**: Set `accent_color` to `home-assistant` and each calendar takes [the color Home Assistant already holds for it](https://calendar-card-pro.alexpfau.com/features/core-settings), so it looks the same on every card — whether you picked that color by hand or Google Calendar imported it
+- 🗂️ **Show All-Day and Timed Events Separately**: [`event_type`](https://calendar-card-pro.alexpfau.com/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, and its all-day and timed events get a color each
 
 ### v4.0
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -12,8 +12,21 @@ title: Release Notes
 
 The color has to exist in Home Assistant first, and most do not yet: Google Calendar is the only integration that sets one, and only when it is first added, so calendars from before Home Assistant 2026.2 have none — re-adding the integration will not create them. Set those by hand under **Settings → Devices & Services → Entities**; any calendar still without one falls back to the card's own color rather than losing it. Requires Home Assistant 2026.2 (#314)
 
+### 🗂️ Show All-Day and Timed Events Separately
+
+**A calendar can now show only its all-day events, only its timed ones, or both in colors you can tell apart.** The new `event_type` option takes `all`, `timed` or `all_day`, and works card-wide or per calendar. Because `timed` and `all_day` are exact complements, listing the same calendar twice — once each way, with a different `accent_color` on each block — splits it into two colors without showing anything twice or losing anything.
+
+It names the kind of event, not how long one lasts: a dinner running from 23:30 to 00:30 is `timed`, however many dates it touches. The two-block pattern has to be written in YAML, because Home Assistant's calendar picker will not offer the same calendar twice; the editor reads and edits it correctly once it exists. (#132)
+
+### ⚙️ Editor Settings Grouped Under Sub-Headings
+
+**The panels that decide what the card shows now group their settings under sub-headings, and both order them the same way.** Which events appear comes first, then how events spanning several days are handled, then what each row carries — the order the card itself works in. The per-calendar panel still opens with its label and colors, because those name the calendar you are editing rather than configure it.
+
+Until now the two panels ordered the same settings differently, and neither said what a run of settings was for.
+
 ## Related Issues
 
+- [#132](https://github.com/alexpfau/calendar-card-pro/issues/132) - Filter based on all-day events by @syst3x
 - [#314](https://github.com/alexpfau/calendar-card-pro/issues/314) - Use color from entity registry by @karwosts, who also contributed the upstream Home Assistant support
 
 ---

--- a/docs/guide/whats-new.md
+++ b/docs/guide/whats-new.md
@@ -9,6 +9,8 @@ public release in January 2025 to today.
 ## Latest Release: v4.1
 
 - 🎨 **Follow Home Assistant's Calendar Colors**: Set `accent_color` to `home-assistant` and each calendar takes [the color Home Assistant already holds for it](/features/core-settings), so it looks the same on every card — whether you picked that color by hand or Google Calendar imported it
+- 🗂️ **Show All-Day and Timed Events Separately**: [`event_type`](/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, and its all-day and timed events get a color each
+- ⚙️ **Clearer Editor Layout**: The panels deciding what the card shows now group their settings under sub-headings, and both order them the same way
 
 ## v4.0
 


### PR DESCRIPTION
Adds the `event_type` feature from #532 to the v4.1.0 release surfaces. Documentation only.

#531 moved the v4.1 notes to being written as features land rather than at release time, so a feature merging without its entry is a gap nothing later sweeps up. `event_type` merged in #532 and was missing from all three surfaces.

## What went where

`docs/RELEASE_NOTES.md` gets two themed entries under v4.1.0's New Features, and #132 in Related Issues, credited to its reporter.

The first covers `event_type` itself — what it does, that `timed` and `all_day` are exact complements so listing a calendar twice splits it into two colors without duplicating or dropping anything, that it names the kind of event rather than its length, and that the two-block pattern needs YAML because Home Assistant's picker will not offer the same calendar twice.

The second covers the editor grouping, because the panels deciding what the card shows now carry sub-headings and share one order. That changes what every existing user sees when they open the editor, which is the test the house style sets for whether an internal change earns a mention.

`docs/guide/whats-new.md` gets both as bullets, with root-relative links.

`README.md` gets only the `event_type` bullet, with absolute links. The editor grouping is left out there deliberately — that list is a highlights reel capped at eight, and a layout improvement does not earn a slot against the features that will follow in this line. The archive keeps it either way.

## Verified

`check:format`, `check:docs` and `docs:build` all pass. The docs gate's counts moved from 143 to 144 internal links and 66 to 67 absolute site links, confirming the new links resolve to real headings rather than being skipped. Release surfaces still agree on v4.0.0, since the version has not been bumped yet.

One correction worth recording: the reporter credit on #132 was checked against the issue rather than assumed.
