### PR TITLE
feat: retire a calendar's all-day events, and keep one to weekdays

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Swap `calendar.family` for one of your own `calendar.*` entities and you have a 
 
 - 🎨 **Follow Home Assistant's Calendar Colors**: Set `accent_color` to `home-assistant` and each calendar takes [the color Home Assistant already holds for it](https://calendar-card-pro.alexpfau.com/features/core-settings), so it looks the same on every card — whether you picked that color by hand or Google Calendar imported it
 - 🗂️ **Split One Calendar by Event Type**: [`event_type`](https://calendar-card-pro.alexpfau.com/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, for a color on each, and [**Duplicate** in the editor](https://calendar-card-pro.alexpfau.com/features/editor#per-calendar-panels-actions) builds it for you
+- 🔍 **Two New Per-Calendar Filters**: [`allday_expires_at`](https://calendar-card-pro.alexpfau.com/features/core-settings#retiring-all-day-events-during-the-day) gives one calendar's all-day events the end time they lack, so a bin collection stops sitting on the card until midnight, and [`days_of_week`](https://calendar-card-pro.alexpfau.com/features/core-settings#showing-a-calendar-on-weekdays-only) keeps a single calendar to weekdays or weekends while every other one keeps its weekend
 
 ### v4.0
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -18,6 +18,18 @@ The color has to exist in Home Assistant first, and most do not yet: Google Cale
 
 It names the kind of event, not how long one lasts: a dinner running from 23:30 to 00:30 is `timed`, however many dates it touches. The two blocks are built with **Duplicate** on the calendar's own panel in the visual editor — see below. (#132)
 
+### 🗑️ All-Day Events That Clear Partway Through the Day
+
+**A bin that was emptied this morning no longer sits on your card until midnight.** All-day events have no end time, only an end date, so the card cannot tell one is over until the day itself is — which is right for a birthday and wrong for a waste-collection feed published by a council you cannot edit. The new per-calendar `allday_expires_at` gives that one calendar the end time it lacks: set `'10:00'` and its all-day events count as past from mid-morning, while your birthdays and holidays stay up all day.
+
+The time is read against the last day an event covers, so a three-day trip clears on the morning it ends rather than the morning it began. Nothing schedules a redraw at the time you name, so the row goes on the card's next refresh rather than exactly on the minute. (#163)
+
+### 📅 A Calendar That Only Shows on Weekdays
+
+**One calendar can stop at Friday while the rest of the card keeps its weekend.** A school-holidays calendar whose entries run through the weekend has always dragged those weekend days onto the card with it, and narrowing the card's date window is no answer — the window belongs to the card, so it would take the weekend away from every calendar at once. The new per-calendar `days_of_week` takes `weekdays` or `weekends` and settles it for that calendar alone.
+
+It judges the day a row actually lands on rather than the day the event began, which is what lets it work on holidays spanning weeks. Pair it with [`split_multiday_events`](/features/multi-day-events) on a calendar of long events — that turns a fortnight's holiday into a row per day, each judged on its own, which is the Monday-to-Friday view the request was for. Column view already splits by default. (#225)
+
 ### ⚙️ Editor Settings Grouped Under Sub-Headings
 
 **The panels that decide what the card shows now group their settings under sub-headings, and both order them the same way.** Which events appear comes first, then how events spanning several days are handled, then what each row carries — the order the card itself works in. The per-calendar panel still opens with its label and colors, because those name the calendar you are editing rather than configure it.
@@ -39,6 +51,8 @@ Both panels for one calendar carry the same heading, because they name the same 
 ## Related Issues
 
 - [#132](https://github.com/alexpfau/calendar-card-pro/issues/132) - Filter based on all-day events by @syst3x
+- [#163](https://github.com/alexpfau/calendar-card-pro/issues/163) - All-day events that should disappear during the day by @Stefan765
+- [#225](https://github.com/alexpfau/calendar-card-pro/issues/225) - Show only Monday to Friday entries for some calendars by @nytram-md
 - [#314](https://github.com/alexpfau/calendar-card-pro/issues/314) - Use color from entity registry by @karwosts, who also contributed the upstream Home Assistant support
 - [#533](https://github.com/alexpfau/calendar-card-pro/issues/533) - Duplicate a calendar block from the visual editor by @alexpfau
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -20,7 +20,7 @@ It names the kind of event, not how long one lasts: a dinner running from 23:30 
 
 ### 🗑️ All-Day Events That Clear Partway Through the Day
 
-**A bin that was emptied this morning no longer sits on your card until midnight.** All-day events have no end time, only an end date, so the card cannot tell one is over until the day itself is — which is right for a birthday and wrong for a waste-collection feed published by a council you cannot edit. The new per-calendar `allday_expires_at` gives that one calendar the end time it lacks: set `'10:00'` and its all-day events count as past from mid-morning, while your birthdays and holidays stay up all day.
+**A bin that was emptied this morning no longer sits on your card until midnight.** All-day events have no end time, only an end date, so the card retires one at midnight after the last day it covers — right for a birthday, wrong for a waste-collection feed published by a council you cannot edit. The new per-calendar `allday_expires_at` moves that moment earlier within the final day: set `'10:00'` and this one calendar's all-day events count as past from mid-morning, while your birthdays and holidays stay up all day.
 
 The time is read against the last day an event covers, so a three-day trip clears on the morning it ends rather than the morning it began. Nothing schedules a redraw at the time you name, so the row goes on the card's next refresh rather than exactly on the minute. (#163)
 
@@ -46,6 +46,8 @@ Both panels for one calendar carry the same heading, because they name the same 
 
 ## 🐛 Bug Fixes
 
+- **Finished All-Day Events Stayed on the Card** - With `show_past_events: false`, a timed event vanished when it ended but an all-day one never did: an all-day event has no end _time_, only an end _date_, so the card had nothing to compare against and exempted them all. Any card whose window reached backwards therefore kept showing all-day events from days that were over — `start_date: 'today-7'`, or `start_of_week` read on a Thursday, which the start-date docs actively recommend pairing with past events hidden. All-day events are now past at midnight after the last day they cover, so a finished one goes and today's stays up all day. If you use a backward-looking window, expect finished all-day entries to disappear from it
+- **The Editor Called `show_past_events` "Show Today's Past Events"** - It shows every past event inside the card's configured window, not only today's, so on a card starting a week back the label described a fraction of what the switch did. Corrected in English and in all nine translated editor languages
 - **A Calendar's Panel Named It Differently From the Picker Directly Above It** - Home Assistant's entity picker moved to friendly names some time ago, so the Calendars row read _Calendar card pro - family_ while the settings panel a few pixels below it read `calendar.calendar_card_pro_family`. An entity id need not resemble its name at all, which left no reliable way to tell which panel belonged to which row on a card listing several calendars. Panels are now headed with the same name Home Assistant shows. A calendar that has been removed from Home Assistant keeps its entity id, since that is the only thing left identifying it
 
 ## Related Issues

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -20,24 +20,24 @@ entities:
 
 ### Available Options for Entity Configuration Objects
 
-| Option                   | Type    | Default                  | Description                                                                                                                                                                                                          |
-| ------------------------ | ------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity`                 | string  | —                        | **Required.** The calendar entity ID                                                                                                                                                                                 |
-| `label`                  | string  | `-`                      | Calendar label displayed before event titles. Supports text/emoji, MDI icons (`mdi:icon-name`), or images (`/local/image.jpg`)                                                                                       |
-| `label_type`             | string  | derived from `label`     | Forces how `label` is read: `none`, `text`, `icon` or `image`. Only needed when the value alone would be read as the wrong kind                                                                                      |
-| `color`                  | string  | `event_color`            | Custom color for event titles from this calendar                                                                                                                                                                     |
-| `accent_color`           | string  | `accent_color`           | Custom color for the vertical line and event background (when `event_background_opacity` is >0). Accepts `home-assistant` to follow this calendar's Home Assistant color                                             |
-| `label_icon_color`       | string  | `-`                      | Custom color for label icons (only applies to `mdi:` and other icon labels)                                                                                                                                          |
-| `show_time`              | boolean | `show_time`              | Whether to show event times for this calendar (overrides global `show_time` option)                                                                                                                                  |
-| `show_location`          | boolean | `show_location`          | Whether to show event locations for this calendar (overrides global `show_location` option)                                                                                                                          |
-| `show_description`       | boolean | `show_description`       | Whether to show event descriptions for this calendar (overrides global `show_description` option)                                                                                                                    |
-| `compact_events_to_show` | number  | `compact_events_to_show` | Maximum number of events to show from this calendar (works with global `compact_events_to_show`)                                                                                                                     |
-| `blocklist`              | string  | `-`                      | RegExp pattern to specify events to exclude (e.g., "Private\|Conference")                                                                                                                                            |
-| `allowlist`              | string  | `-`                      | RegExp pattern to specify events to include (e.g., "Birthday\|Anniversary")                                                                                                                                          |
-| `split_multiday_events`  | boolean | `split_multiday_events`  | Whether multi-day events from this calendar span each day they cover (overrides global `split_multiday_events`)                                                                                                      |
-| `event_type`             | string  | `event_type`             | Which class of this calendar's events to keep — `all`, `timed` for events with a clock time, or `all_day` for all-day ones (overrides global `event_type`)                                                           |
-| `allday_expires_at`      | string  | `-`                      | Time of day, as `HH:MM`, at which this calendar's all-day events start counting as past, read against the last day each one covers. Unset they last until midnight. Only applies while `show_past_events` is `false` |
-| `days_of_week`           | string  | `-`                      | Restricts this calendar to `weekdays` (Monday to Friday) or `weekends` (Saturday and Sunday), judged on the day each row lands on. Unset, every day qualifies                                                        |
+| Option                   | Type    | Default                  | Description                                                                                                                                                                                                           |
+| ------------------------ | ------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `entity`                 | string  | —                        | **Required.** The calendar entity ID                                                                                                                                                                                  |
+| `label`                  | string  | `-`                      | Calendar label displayed before event titles. Supports text/emoji, MDI icons (`mdi:icon-name`), or images (`/local/image.jpg`)                                                                                        |
+| `label_type`             | string  | derived from `label`     | Forces how `label` is read: `none`, `text`, `icon` or `image`. Only needed when the value alone would be read as the wrong kind                                                                                       |
+| `color`                  | string  | `event_color`            | Custom color for event titles from this calendar                                                                                                                                                                      |
+| `accent_color`           | string  | `accent_color`           | Custom color for the vertical line and event background (when `event_background_opacity` is >0). Accepts `home-assistant` to follow this calendar's Home Assistant color                                              |
+| `label_icon_color`       | string  | `-`                      | Custom color for label icons (only applies to `mdi:` and other icon labels)                                                                                                                                           |
+| `show_time`              | boolean | `show_time`              | Whether to show event times for this calendar (overrides global `show_time` option)                                                                                                                                   |
+| `show_location`          | boolean | `show_location`          | Whether to show event locations for this calendar (overrides global `show_location` option)                                                                                                                           |
+| `show_description`       | boolean | `show_description`       | Whether to show event descriptions for this calendar (overrides global `show_description` option)                                                                                                                     |
+| `compact_events_to_show` | number  | `compact_events_to_show` | Maximum number of events to show from this calendar (works with global `compact_events_to_show`)                                                                                                                      |
+| `blocklist`              | string  | `-`                      | RegExp pattern to specify events to exclude (e.g., "Private\|Conference")                                                                                                                                             |
+| `allowlist`              | string  | `-`                      | RegExp pattern to specify events to include (e.g., "Birthday\|Anniversary")                                                                                                                                           |
+| `split_multiday_events`  | boolean | `split_multiday_events`  | Whether multi-day events from this calendar span each day they cover (overrides global `split_multiday_events`)                                                                                                       |
+| `event_type`             | string  | `event_type`             | Which class of this calendar's events to keep — `all`, `timed` for events with a clock time, or `all_day` for all-day ones (overrides global `event_type`)                                                            |
+| `allday_expires_at`      | string  | midnight                 | Time of day, as `HH:MM`, at which this calendar's all-day events start counting as past, read against the last day each one covers. Unset, they last until midnight. Only applies while `show_past_events` is `false` |
+| `days_of_week`           | string  | `-`                      | Restricts this calendar to `weekdays` (Monday to Friday) or `weekends` (Saturday and Sunday), judged on the day each row lands on. Unset, every day qualifies                                                         |
 
 This structure gives you granular control over how information from different calendars is displayed.
 
@@ -230,14 +230,14 @@ two-week one is. For how the card handles events spanning several days, see
 
 ### Retiring All-Day Events During the Day
 
-An all-day event has no end time, only an end date, so the card cannot tell that it is
-over until the day itself is. That is usually right — a birthday is a birthday all day —
-but it is wrong for a feed that describes something happening at a particular hour. A
-waste-collection calendar is the common case: the bin is emptied in the morning and its
-entry sits on the card until midnight.
+An all-day event has no end time, only an end date, so the card treats one as past at
+**midnight after the last day it covers**. That is usually right — a birthday is a birthday
+all day — but it is wrong for a feed describing something that happens at a particular
+hour. A waste-collection calendar is the common case: the bin is emptied in the morning and
+its entry sits on the card until midnight.
 
-`allday_expires_at` gives that calendar's all-day events the end time they lack. It takes
-a time of day, and from that time onward the card treats the event as past:
+`allday_expires_at` moves that moment earlier within the final day. It takes a time of day,
+and from that time onward the card treats the event as past:
 
 ```yaml
 entities:
@@ -252,6 +252,9 @@ your birthdays want opposite answers, and only the calendar itself knows which.
 The time is read against the **last** day the event covers, so a holiday running Monday to
 Wednesday retires on Wednesday morning rather than Monday's. Split the calendar with
 `split_multiday_events: true` and each day retires on its own morning instead.
+
+Leaving the option out keeps the default, midnight — the option changes _when_ within the
+final day, never _whether_.
 
 ::: warning It Only Applies While Past Events Are Hidden
 `allday_expires_at` decides _when_ an all-day event becomes past. Whether past events are

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -20,22 +20,24 @@ entities:
 
 ### Available Options for Entity Configuration Objects
 
-| Option                   | Type    | Default                  | Description                                                                                                                                                              |
-| ------------------------ | ------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `entity`                 | string  | —                        | **Required.** The calendar entity ID                                                                                                                                     |
-| `label`                  | string  | `-`                      | Calendar label displayed before event titles. Supports text/emoji, MDI icons (`mdi:icon-name`), or images (`/local/image.jpg`)                                           |
-| `label_type`             | string  | derived from `label`     | Forces how `label` is read: `none`, `text`, `icon` or `image`. Only needed when the value alone would be read as the wrong kind                                          |
-| `color`                  | string  | `event_color`            | Custom color for event titles from this calendar                                                                                                                         |
-| `accent_color`           | string  | `accent_color`           | Custom color for the vertical line and event background (when `event_background_opacity` is >0). Accepts `home-assistant` to follow this calendar's Home Assistant color |
-| `label_icon_color`       | string  | `-`                      | Custom color for label icons (only applies to `mdi:` and other icon labels)                                                                                              |
-| `show_time`              | boolean | `show_time`              | Whether to show event times for this calendar (overrides global `show_time` option)                                                                                      |
-| `show_location`          | boolean | `show_location`          | Whether to show event locations for this calendar (overrides global `show_location` option)                                                                              |
-| `show_description`       | boolean | `show_description`       | Whether to show event descriptions for this calendar (overrides global `show_description` option)                                                                        |
-| `compact_events_to_show` | number  | `compact_events_to_show` | Maximum number of events to show from this calendar (works with global `compact_events_to_show`)                                                                         |
-| `blocklist`              | string  | `-`                      | RegExp pattern to specify events to exclude (e.g., "Private\|Conference")                                                                                                |
-| `allowlist`              | string  | `-`                      | RegExp pattern to specify events to include (e.g., "Birthday\|Anniversary")                                                                                              |
-| `split_multiday_events`  | boolean | `split_multiday_events`  | Whether multi-day events from this calendar span each day they cover (overrides global `split_multiday_events`)                                                          |
-| `event_type`             | string  | `event_type`             | Which class of this calendar's events to keep — `all`, `timed` for events with a clock time, or `all_day` for all-day ones (overrides global `event_type`)               |
+| Option                   | Type    | Default                  | Description                                                                                                                                                                                                          |
+| ------------------------ | ------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `entity`                 | string  | —                        | **Required.** The calendar entity ID                                                                                                                                                                                 |
+| `label`                  | string  | `-`                      | Calendar label displayed before event titles. Supports text/emoji, MDI icons (`mdi:icon-name`), or images (`/local/image.jpg`)                                                                                       |
+| `label_type`             | string  | derived from `label`     | Forces how `label` is read: `none`, `text`, `icon` or `image`. Only needed when the value alone would be read as the wrong kind                                                                                      |
+| `color`                  | string  | `event_color`            | Custom color for event titles from this calendar                                                                                                                                                                     |
+| `accent_color`           | string  | `accent_color`           | Custom color for the vertical line and event background (when `event_background_opacity` is >0). Accepts `home-assistant` to follow this calendar's Home Assistant color                                             |
+| `label_icon_color`       | string  | `-`                      | Custom color for label icons (only applies to `mdi:` and other icon labels)                                                                                                                                          |
+| `show_time`              | boolean | `show_time`              | Whether to show event times for this calendar (overrides global `show_time` option)                                                                                                                                  |
+| `show_location`          | boolean | `show_location`          | Whether to show event locations for this calendar (overrides global `show_location` option)                                                                                                                          |
+| `show_description`       | boolean | `show_description`       | Whether to show event descriptions for this calendar (overrides global `show_description` option)                                                                                                                    |
+| `compact_events_to_show` | number  | `compact_events_to_show` | Maximum number of events to show from this calendar (works with global `compact_events_to_show`)                                                                                                                     |
+| `blocklist`              | string  | `-`                      | RegExp pattern to specify events to exclude (e.g., "Private\|Conference")                                                                                                                                            |
+| `allowlist`              | string  | `-`                      | RegExp pattern to specify events to include (e.g., "Birthday\|Anniversary")                                                                                                                                          |
+| `split_multiday_events`  | boolean | `split_multiday_events`  | Whether multi-day events from this calendar span each day they cover (overrides global `split_multiday_events`)                                                                                                      |
+| `event_type`             | string  | `event_type`             | Which class of this calendar's events to keep — `all`, `timed` for events with a clock time, or `all_day` for all-day ones (overrides global `event_type`)                                                           |
+| `allday_expires_at`      | string  | `-`                      | Time of day, as `HH:MM`, at which this calendar's all-day events start counting as past, read against the last day each one covers. Unset they last until midnight. Only applies while `show_past_events` is `false` |
+| `days_of_week`           | string  | `-`                      | Restricts this calendar to `weekdays` (Monday to Friday) or `weekends` (Saturday and Sunday), judged on the day each row lands on. Unset, every day qualifies                                                        |
 
 This structure gives you granular control over how information from different calendars is displayed.
 
@@ -225,6 +227,94 @@ one option that differs. The two panels are numbered so you can tell them apart,
 two-week one is. For how the card handles events spanning several days, see
 [Multi-Day Events](/features/multi-day-events).
 :::
+
+### Retiring All-Day Events During the Day
+
+An all-day event has no end time, only an end date, so the card cannot tell that it is
+over until the day itself is. That is usually right — a birthday is a birthday all day —
+but it is wrong for a feed that describes something happening at a particular hour. A
+waste-collection calendar is the common case: the bin is emptied in the morning and its
+entry sits on the card until midnight.
+
+`allday_expires_at` gives that calendar's all-day events the end time they lack. It takes
+a time of day, and from that time onward the card treats the event as past:
+
+```yaml
+entities:
+  - entity: calendar.waste_collection
+    allday_expires_at: '10:00' # gone from mid-morning, once the truck has been
+  - calendar.family # unaffected — birthdays stay up all day
+```
+
+It is per calendar and has no card-wide counterpart, which is the point: your bin feed and
+your birthdays want opposite answers, and only the calendar itself knows which.
+
+The time is read against the **last** day the event covers, so a holiday running Monday to
+Wednesday retires on Wednesday morning rather than Monday's. Split the calendar with
+`split_multiday_events: true` and each day retires on its own morning instead.
+
+::: warning It Only Applies While Past Events Are Hidden
+`allday_expires_at` decides _when_ an all-day event becomes past. Whether past events are
+drawn at all is [`show_past_events`](/reference/configuration#core-settings), which
+defaults to `false`. With `show_past_events: true` the card is being asked to show what is
+over, so this option has nothing left to do and the event stays.
+:::
+
+::: tip It Takes Effect on the Next Refresh, Not on the Minute
+The card has one timer, the refresh interval, and nothing schedules a redraw at the time
+you name here. An event retires on the first render after its moment passes — which may be
+the refresh, a dashboard reload, or any edit that redraws the card. Expect the row to go
+within the refresh interval of the time you set, not exactly on it.
+:::
+
+### Showing a Calendar on Weekdays Only
+
+`days_of_week` restricts one calendar to weekdays or to weekends. It takes `weekdays` for
+Monday to Friday and `weekends` for Saturday and Sunday; leave it out and every day
+qualifies, which is the default.
+
+```yaml
+entities:
+  - entity: calendar.school_holidays
+    days_of_week: weekdays # term dates matter on school days
+    split_multiday_events: true # judge each day of the holiday on its own
+  - calendar.family # keeps its weekend events
+```
+
+Like `event_type`, the two values are exact opposites, so listing one calendar twice — once
+each way — divides it between two blocks that can carry their own labels and colors,
+without losing an event or showing one twice.
+
+::: warning Pair This With `split_multiday_events` on a Calendar of Long Events
+The example above sets both, and on a holidays calendar it needs to. `days_of_week` judges
+the day a row **lands on**, and an event spanning several days is drawn as a single row on
+the first of them unless you split it. So a fortnight's holiday beginning on a Saturday is
+one Saturday row, and `weekdays` hides the whole fortnight rather than showing you its
+weekdays.
+
+With `split_multiday_events: true` that same holiday becomes a row per day, each judged
+separately, and you get the Monday-to-Friday view you asked for. Column view already
+defaults the option to `true`, so this pairing only needs stating for list view.
+:::
+
+::: tip It Filters the Day a Row Lands On, Not the Day It Started
+The same rule explains an event already running when the card's window opens: it is drawn
+on the window's **first day**, whichever weekday that is, so that is the day the filter
+judges — not the date the event began. A calendar of single-day entries never notices the
+distinction, since the two dates are the same.
+:::
+
+::: warning A Day the Filter Empties Follows `show_empty_days`
+Filtering runs before the card pads out its window, so a Saturday whose only entry this
+calendar supplied becomes an empty day like any other. With
+[`show_empty_days`](/reference/configuration#core-settings) off — the default in list view
+— that day is left out entirely and a later one takes its place. With it on, as column
+view defaults to, the day still appears carrying the usual _No upcoming events_ notice.
+:::
+
+Weekend means Saturday and Sunday. That is the same definition the
+[weekend colors](/features/layout-appearance#week-numbers-visual-separators) use, so a day
+this option treats as a weekend is a day the card already colors as one.
 
 ### Filtering Duplicate Events
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -60,7 +60,7 @@ question. HACS does all of this for you, which is why it is the recommended rout
 ::: tip Optional: Compress The Files Yourself
 Home Assistant serves a pre-compressed `.gz` beside a file when it finds one, and does not
 compress on the fly. Neither install route ships one, so the card transfers at its full
-195 KB and the editor at 301 KB — once per version, then the browser caches both.
+196 KB and the editor at 302 KB — once per version, then the browser caches both.
 
 If you want the smaller transfer, create the companions yourself and keep them beside the
 originals:
@@ -69,7 +69,7 @@ originals:
 gzip -9 -k calendar-card-pro.js editor.js
 ```
 
-That brings the card to 58 KB and the editor to 83 KB, give or take a few hundred bytes
+That brings the card to 60 KB and the editor to 85 KB, give or take a few hundred bytes
 depending on which `gzip` build you have. Delete the `.gz` files whenever you
 update, or regenerate them — Home Assistant will serve a stale `.gz` in preference to a
 newer `.js`.

--- a/docs/guide/whats-new.md
+++ b/docs/guide/whats-new.md
@@ -11,7 +11,8 @@ public release in January 2025 to today.
 - 🎨 **Follow Home Assistant's Calendar Colors**: Set `accent_color` to `home-assistant` and each calendar takes [the color Home Assistant already holds for it](/features/core-settings), so it looks the same on every card — whether you picked that color by hand or Google Calendar imported it
 - 🗂️ **Split One Calendar by Event Type**: [`event_type`](/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, for a color on each, and [**Duplicate** in the editor](/features/editor#per-calendar-panels-actions) builds it for you
 - ⚙️ **Clearer Editor Layout**: The panels deciding what the card shows now group their settings under sub-headings, and both order them the same way
-- 🗑️ **All-Day Events That Clear During the Day**: [`allday_expires_at`](/features/core-settings#retiring-all-day-events-during-the-day) gives one calendar's all-day events the end time they lack, so a bin emptied this morning stops sitting on the card until midnight
+- 🗑️ **All-Day Events That Clear During the Day**: [`allday_expires_at`](/features/core-settings#retiring-all-day-events-during-the-day) moves the moment one calendar's all-day events count as past earlier into the final day, so a bin emptied this morning stops sitting on the card until midnight
+- 🐛 **Finished All-Day Events Stayed on the Card**: with past events hidden, an all-day event that had already ended kept its row on any card whose window reached backwards, while timed events beside it were correctly gone
 - 📅 **A Calendar on Weekdays Only**: [`days_of_week`](/features/core-settings#showing-a-calendar-on-weekdays-only) takes `weekdays` or `weekends` for a single calendar, judged on the day each row lands on, while every other calendar keeps its weekend
 
 ## v4.0

--- a/docs/guide/whats-new.md
+++ b/docs/guide/whats-new.md
@@ -11,6 +11,8 @@ public release in January 2025 to today.
 - 🎨 **Follow Home Assistant's Calendar Colors**: Set `accent_color` to `home-assistant` and each calendar takes [the color Home Assistant already holds for it](/features/core-settings), so it looks the same on every card — whether you picked that color by hand or Google Calendar imported it
 - 🗂️ **Split One Calendar by Event Type**: [`event_type`](/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, for a color on each, and [**Duplicate** in the editor](/features/editor#per-calendar-panels-actions) builds it for you
 - ⚙️ **Clearer Editor Layout**: The panels deciding what the card shows now group their settings under sub-headings, and both order them the same way
+- 🗑️ **All-Day Events That Clear During the Day**: [`allday_expires_at`](/features/core-settings#retiring-all-day-events-during-the-day) gives one calendar's all-day events the end time they lack, so a bin emptied this morning stops sitting on the card until midnight
+- 📅 **A Calendar on Weekdays Only**: [`days_of_week`](/features/core-settings#showing-a-calendar-on-weekdays-only) takes `weekdays` or `weekends` for a single calendar, judged on the day each row lands on, while every other calendar keeps its weekend
 
 ## v4.0
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -68,7 +68,8 @@ the card-wide settings for that one calendar:
 
 `entity` · `label` · `label_type` · `color` · `accent_color` · `label_icon_color` ·
 `show_time` · `show_location` · `show_description` · `compact_events_to_show` ·
-`blocklist` · `allowlist` · `split_multiday_events` · `event_type`
+`blocklist` · `allowlist` · `split_multiday_events` · `event_type` ·
+`allday_expires_at` · `days_of_week`
 
 **→ [Entity configuration options](/features/core-settings#available-options-for-entity-configuration-objects)** — full table, with filtering examples.
 **→ [Choosing how a label is read](/features/core-settings#choosing-how-a-label-is-read)** — when `label_type` is needed, and when it is not.

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -19,6 +19,17 @@ const CONSTANTS_TS = join(ROOT, 'src/config/constants.ts');
 const TYPES_TS = join(ROOT, 'src/config/types.ts');
 const DOCS_DIR = join(ROOT, 'docs');
 const REFERENCE_DOC = join(DOCS_DIR, 'reference/configuration.md');
+
+/**
+ * The second table an option's values can be documented in.
+ *
+ * Per-calendar options that have no card-wide counterpart never reach the reference
+ * tables — those describe the card, and the per-entity section there is a bullet list
+ * pointing here. So this page carries the only row `days_of_week` has, and check 21 has
+ * to read both or an enumerated option documented only here goes unchecked while the
+ * gate reports a clean run.
+ */
+const ENTITY_OPTIONS_DOC = join(DOCS_DIR, 'features/core-settings.md');
 const VITEPRESS_CONFIG = join(DOCS_DIR, '.vitepress/config.mts');
 const STYLES_TS = join(ROOT, 'src/rendering/styles.ts');
 const THEMING_DOC = join(DOCS_DIR, 'features/theming.md');
@@ -1845,21 +1856,26 @@ function readEnumOptions() {
  * which is how a reader learns an option cannot do something it can.
  */
 function checkEnumValues(enums) {
-  const lines = readFileSync(REFERENCE_DOC, 'utf8').split('\n');
+  const sources = [REFERENCE_DOC, ENTITY_OPTIONS_DOC].map((file) => ({
+    file,
+    lines: readFileSync(file, 'utf8').split('\n'),
+  }));
   let described = 0;
 
   for (const [field, values] of enums) {
-    const rows = lines.filter((line) =>
-      new RegExp(`^\\|\\s*\`(?:[a-z0-9_]+ → )?${field}\``).test(line),
+    const found = sources.flatMap(({ file, lines }) =>
+      lines
+        .filter((line) => new RegExp(`^\\|\\s*\`(?:[a-z0-9_]+ → )?${field}\``).test(line))
+        .map((row) => ({ file, row })),
     );
     // Check 2 already requires every option to be documented somewhere.
-    if (!rows.length) continue;
+    if (!found.length) continue;
     described++;
-    for (const row of rows) {
+    for (const { file, row } of found) {
       const missing = values.filter((value) => !new RegExp(`\\b${value}\\b`).test(row));
       if (missing.length) {
         error(
-          `${relative(ROOT, REFERENCE_DOC)}: the \`${field}\` row never mentions ` +
+          `${relative(ROOT, file)}: the \`${field}\` row never mentions ` +
             `${missing.map((v) => `\`${v}\``).join(', ')}, so a reader cannot discover ` +
             `${missing.length > 1 ? 'those values' : 'that value'}. The type accepts ` +
             `${values.map((v) => `\`${v}\``).join(' | ')}.`,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -569,6 +569,8 @@ export function normalizeEntities(
         allowlist?: string;
         split_multiday_events?: boolean;
         event_type?: Types.EventType;
+        days_of_week?: Types.DaysOfWeekFilter;
+        allday_expires_at?: string;
       }
   >,
 ): Array<Types.EntityConfig> {
@@ -604,6 +606,8 @@ export function normalizeEntities(
           allowlist: item.allowlist,
           split_multiday_events: item.split_multiday_events,
           event_type: item.event_type,
+          days_of_week: item.days_of_week,
+          allday_expires_at: item.allday_expires_at,
         };
       }
       return null;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -285,10 +285,11 @@ export interface EntityConfig {
   /**
    * Clock time at which this calendar's all-day events start counting as past, `HH:MM`.
    *
-   * All-day events are exempt from expiry by construction — the `show_past_events` test
-   * compares an end *instant*, and an all-day event has none — so without this they sit on
-   * the card until midnight. Unset keeps that. Read only while `show_past_events` is
-   * `false`; it decides *when* an all-day event becomes past, not whether past events show.
+   * An all-day event has no end *instant*, only an end date, so the `show_past_events` test
+   * cannot be applied to it directly. It is therefore past at **midnight after its last
+   * day**, and this option moves that instant earlier within the final day. Unset keeps
+   * midnight. Read only while `show_past_events` is `false`; it decides *when* an all-day
+   * event becomes past, not whether past events show.
    */
   allday_expires_at?: string;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -144,6 +144,26 @@ export type EffectiveView = 'list' | 'column';
  */
 export type EventType = 'all' | 'timed' | 'all_day';
 
+/**
+ * Which days of the week a calendar's events are allowed to land on.
+ *
+ * A **display-date** axis, not an event-property one. `event_type` above asks what an
+ * event *is*; this asks where a row *lands*, which is why it is resolved after multi-day
+ * splitting and after the window clamp rather than from the event's own start date. A
+ * three-week holiday already in progress shows on the window's first day whatever weekday
+ * that is, so reading the start date would answer about a day the card is not drawing.
+ *
+ * Weekend means Saturday and Sunday — {@link isWeekendDate} in `utils/format.ts` is the
+ * single definition, shared with the weekend day-header colors so the two cannot disagree.
+ *
+ * 🚨 There is deliberately no `all` member, unlike `EventType`. This option is
+ * per-calendar only, so it has no card-level value to override and an explicit `all` would
+ * mean exactly what the absent key already means — two dropdown entries with one behavior
+ * and, inevitably, one label between them. Absent is the unfiltered state; the editor
+ * spells that `inherit`, the way it spells `show_week_numbers`' absent value `none`.
+ */
+export type DaysOfWeekFilter = 'weekdays' | 'weekends';
+
 /** What column view does when even its narrowest permitted layout will not fit. */
 export type ColumnMinDaysFallback = 'list' | 'cramp';
 
@@ -261,6 +281,16 @@ export interface EntityConfig {
   allowlist?: string;
   split_multiday_events?: boolean;
   event_type?: EventType;
+  days_of_week?: DaysOfWeekFilter;
+  /**
+   * Clock time at which this calendar's all-day events start counting as past, `HH:MM`.
+   *
+   * All-day events are exempt from expiry by construction — the `show_past_events` test
+   * compares an end *instant*, and an all-day event has none — so without this they sit on
+   * the card until midnight. Unset keeps that. Read only while `show_past_events` is
+   * `false`; it decides *when* an all-day event becomes past, not whether past events show.
+   */
+  allday_expires_at?: string;
 }
 
 /** Weather position-specific styling configuration. */

--- a/src/rendering/column.ts
+++ b/src/rendering/column.ts
@@ -16,6 +16,7 @@ import * as Leaves from './leaves';
 import * as Presentation from './presentation';
 import * as Types from '../config/types';
 import * as ViewConfig from '../config/view';
+import * as FormatUtils from '../utils/format';
 
 //-----------------------------------------------------------------------------
 // DAY BOUNDARIES
@@ -215,7 +216,7 @@ function renderDayColumn(
 ): TemplateResult {
   const dayDate = new Date(day.timestamp);
   const { isToday, isTomorrow } = Leaves.classifyDay(day.timestamp);
-  const isWeekendDay = Leaves.isWeekendDate(dayDate);
+  const isWeekendDay = FormatUtils.isWeekendDate(dayDate);
 
   const weatherContent = Leaves.renderDateWeather(dayDate, config, weatherForecasts);
 

--- a/src/rendering/editor/schemas/entity.ts
+++ b/src/rendering/editor/schemas/entity.ts
@@ -176,17 +176,29 @@ export function buildEntitySchema(ctx: SchemaCtx): HaFormSchema[] {
     row(text('color'), accentColorMode(ctx.language)),
     text('accent_color'),
 
-    // Predicates first, then the budget. `compact_events_to_show` decides how many of the
-    // survivors fit rather than whether any one of them qualifies, so it reads last — the
-    // order the card applies them in. The two render-time predicates sit after the two
-    // processing-time ones for the same reason, which is also why the pair of dropdowns is
-    // split by the pair of pattern fields rather than kept visually together.
+    // Ordered coarse-to-fine by **scope**, not by the order the card applies them in.
+    // Which days qualify at all → which class of event → when those events stop counting
+    // → which titles survive → how many of the survivors fit. An earlier draft used
+    // pipeline order, which put both new options after the pattern fields: defensible, and
+    // wrong for a reader, who is narrowing a set rather than tracing an implementation.
+    //
+    // `compact_events_to_show` stays last under either reading, because it is a budget
+    // rather than a predicate — it decides how many survivors fit, not whether any one of
+    // them qualifies.
+    //
+    // 🚨 A new option's **position inside its section is a decision, not a default**. Do
+    // not append it and treat placement as settled by having chosen the right category;
+    // say where it sits on this scale and why, as you would for its name and its default.
+    //
+    // The card-level group leads with `event_type` rather than diverging: it has no
+    // `days_of_week` or `allday_expires_at` to precede it, so it too opens with the
+    // coarsest option it actually carries.
     heading('heading_filters'),
+    inheritable(ctx.language, 'days_of_week'),
     inheritable(ctx.language, 'event_type'),
+    { name: 'allday_expires_at', selector: { text: { type: 'time' } } },
     text('blocklist'),
     text('allowlist'),
-    { name: 'allday_expires_at', selector: { text: { type: 'time' } } },
-    inheritable(ctx.language, 'days_of_week'),
     {
       name: 'compact_events_to_show',
       selector: { number: { min: 0, mode: 'box' } },

--- a/src/rendering/editor/schemas/entity.ts
+++ b/src/rendering/editor/schemas/entity.ts
@@ -176,19 +176,16 @@ export function buildEntitySchema(ctx: SchemaCtx): HaFormSchema[] {
     row(text('color'), accentColorMode(ctx.language)),
     text('accent_color'),
 
-    // Ordered coarse-to-fine by **scope**, not by the order the card applies them in.
-    // Which days qualify at all → which class of event → when those events stop counting
-    // → which titles survive → how many of the survivors fit. An earlier draft used
-    // pipeline order, which put both new options after the pattern fields: defensible, and
-    // wrong for a reader, who is narrowing a set rather than tracing an implementation.
+    // Ordered coarse-to-fine by **scope**, per _Where a new option goes is a decision, not
+    // a default_ in `AGENTS.md`: which days qualify at all → which class of event → when
+    // those events stop counting → which titles survive → how many of the survivors fit.
     //
-    // `compact_events_to_show` stays last under either reading, because it is a budget
-    // rather than a predicate — it decides how many survivors fit, not whether any one of
-    // them qualifies.
-    //
-    // 🚨 A new option's **position inside its section is a decision, not a default**. Do
-    // not append it and treat placement as settled by having chosen the right category;
-    // say where it sits on this scale and why, as you would for its name and its default.
+    // 🚨 Not pipeline order, which is what an earlier draft of this list used and which put
+    // both new options after the pattern fields. `days_of_week` is resolved *last* of these
+    // and belongs *first*, because it is the broadest question a reader asks; which options
+    // resolve at fetch time and which at render time is invisible to them and should stay
+    // that way. `compact_events_to_show` is last under either reading — it is a budget over
+    // the result set rather than a predicate over an event.
     //
     // The card-level group leads with `event_type` rather than diverging: it has no
     // `days_of_week` or `allday_expires_at` to precede it, so it too opens with the

--- a/src/rendering/editor/schemas/entity.ts
+++ b/src/rendering/editor/schemas/entity.ts
@@ -16,6 +16,7 @@ export const ENTITY_TRISTATE_VALUES: Readonly<Record<string, ReadonlyArray<strin
   show_description: [INHERIT, 'show', 'hide'],
   split_multiday_events: [INHERIT, 'split', 'whole'],
   event_type: [INHERIT, 'all', 'timed', 'all_day'],
+  days_of_week: [INHERIT, 'weekdays', 'weekends'],
 };
 
 /**
@@ -42,6 +43,10 @@ export const ENTITY_TRISTATE_STORED: Readonly<
   show_description: { [INHERIT]: undefined, show: true, hide: false },
   split_multiday_events: { [INHERIT]: undefined, split: true, whole: false },
   event_type: { [INHERIT]: undefined, all: 'all', timed: 'timed', all_day: 'all_day' },
+  // Its own mapping rather than a share of `event_type`'s, which is what the note above
+  // is for: both store `all`, and a shared table would then have to agree on `weekdays`
+  // and `all_day` too. Keyed per option, the two cannot collide however they are spelled.
+  days_of_week: { [INHERIT]: undefined, weekdays: 'weekdays', weekends: 'weekends' },
 };
 
 /**
@@ -173,11 +178,15 @@ export function buildEntitySchema(ctx: SchemaCtx): HaFormSchema[] {
 
     // Predicates first, then the budget. `compact_events_to_show` decides how many of the
     // survivors fit rather than whether any one of them qualifies, so it reads last — the
-    // order the card applies them in.
+    // order the card applies them in. The two render-time predicates sit after the two
+    // processing-time ones for the same reason, which is also why the pair of dropdowns is
+    // split by the pair of pattern fields rather than kept visually together.
     heading('heading_filters'),
     inheritable(ctx.language, 'event_type'),
     text('blocklist'),
     text('allowlist'),
+    { name: 'allday_expires_at', selector: { text: { type: 'time' } } },
+    inheritable(ctx.language, 'days_of_week'),
     {
       name: 'compact_events_to_show',
       selector: { number: { min: 0, mode: 'box' } },

--- a/src/rendering/editor/strings.ts
+++ b/src/rendering/editor/strings.ts
@@ -192,6 +192,20 @@ export const EDITOR_STRINGS: Readonly<Record<string, string>> = {
   'entity.allowlist.helper':
     'Show only events whose title contains one of these terms, separated by | . Left ' +
     'empty, every event is shown.',
+  'entity.allday_expires_at': 'All-Day Events Expire At',
+  'entity.allday_expires_at.helper':
+    'Time of day this calendar\u2019s all-day events stop counting as upcoming, on the ' +
+    'last day they cover. Left empty they last until midnight. Only applies while past ' +
+    'events are hidden, and takes effect on the card\u2019s next refresh rather than on ' +
+    'the minute.',
+  'entity.days_of_week': 'Days of the Week',
+  'entity.days_of_week.option.inherit.label': 'Every day',
+  'entity.days_of_week.option.weekdays.label': 'Monday to Friday only',
+  'entity.days_of_week.option.weekends.label': 'Saturday and Sunday only',
+  'entity.days_of_week.helper':
+    'Which days this calendar may put events on. A multi-day event keeps only the days ' +
+    'that qualify, so a holiday running through a weekend still shows on the weekdays ' +
+    'around it.',
 
   // --- Exceptions -----------------------------------------------------------
   //

--- a/src/rendering/editor/strings.ts
+++ b/src/rendering/editor/strings.ts
@@ -276,7 +276,7 @@ export const EDITOR_STRINGS: Readonly<Record<string, string>> = {
     'Rather than stopping mid-day at the event limit, show the rest of that day too.',
 
   content: 'What The Card Shows',
-  show_past_events: "Show Today's Past Events",
+  show_past_events: 'Show Past Events',
   show_empty_days: 'Show Empty Days',
   empty_day_text: 'Empty Day Text',
   'empty_day_text.helper': 'Replaces the translated default, and drops the check mark before it.',

--- a/src/rendering/editor/translations/de.json
+++ b/src/rendering/editor/translations/de.json
@@ -126,7 +126,7 @@
   "compact_events_complete_days": "Letzten Tag vollständig zeigen",
   "compact_events_complete_days.helper": "Statt am Terminlimit mitten im Tag aufzuhören, wird der Rest dieses Tages ebenfalls angezeigt.",
   "content": "Was die Karte zeigt",
-  "show_past_events": "Vergangene Termine von heute anzeigen",
+  "show_past_events": "Vergangene Termine anzeigen",
   "show_empty_days": "Leere Tage anzeigen",
   "empty_day_text": "Text für leere Tage",
   "empty_day_text.helper": "Ersetzt den übersetzten Standardtext und lässt das Häkchen davor weg.",

--- a/src/rendering/editor/translations/et.json
+++ b/src/rendering/editor/translations/et.json
@@ -126,7 +126,7 @@
   "compact_events_complete_days": "Lõpeta viimane päev",
   "compact_events_complete_days.helper": "Selle asemel et peatuda sündmuste piiri juures keset päeva, näita ka ülejäänud päeva.",
   "content": "Mida kaart näitab",
-  "show_past_events": "Näita tänaseid möödunud sündmusi",
+  "show_past_events": "Näita möödunud sündmusi",
   "show_empty_days": "Näita tühje päevi",
   "empty_day_text": "Tühja päeva tekst",
   "empty_day_text.helper": "Asendab tõlgitud vaikeväärtuse ja jätab ära selle ees oleva linnukese.",

--- a/src/rendering/editor/translations/it.json
+++ b/src/rendering/editor/translations/it.json
@@ -126,7 +126,7 @@
   "compact_events_complete_days": "Completa l'ultimo giorno",
   "compact_events_complete_days.helper": "Invece di fermarsi a metà giornata al raggiungimento del limite di eventi, mostra anche il resto di quel giorno.",
   "content": "Cosa mostra la scheda",
-  "show_past_events": "Mostra gli eventi passati di oggi",
+  "show_past_events": "Mostra gli eventi passati",
   "show_empty_days": "Mostra giorni vuoti",
   "empty_day_text": "Testo per i giorni vuoti",
   "empty_day_text.helper": "Sostituisce il testo predefinito tradotto e toglie il segno di spunta che lo precede.",

--- a/src/rendering/editor/translations/lt.json
+++ b/src/rendering/editor/translations/lt.json
@@ -126,7 +126,7 @@
   "compact_events_complete_days": "Užbaigti paskutinę dieną",
   "compact_events_complete_days.helper": "Užuot sustojus ties įvykių riba dienos viduryje, parodyti ir likusią tos dienos dalį.",
   "content": "Ką kortelė rodo",
-  "show_past_events": "Rodyti šiandienos praėjusius įvykius",
+  "show_past_events": "Rodyti praėjusius įvykius",
   "show_empty_days": "Rodyti tuščias dienas",
   "empty_day_text": "Tuščios dienos tekstas",
   "empty_day_text.helper": "Pakeičia išverstą numatytąjį tekstą ir panaikina prieš jį esančią varnelę.",

--- a/src/rendering/editor/translations/lv.json
+++ b/src/rendering/editor/translations/lv.json
@@ -126,7 +126,7 @@
   "compact_events_complete_days": "Pabeigt pēdējo dienu",
   "compact_events_complete_days.helper": "Tā vietā, lai apstātos pie notikumu ierobežojuma dienas vidū, parādīt arī atlikušo tās dienas daļu.",
   "content": "Ko karte rāda",
-  "show_past_events": "Rādīt šodienas pagājušos notikumus",
+  "show_past_events": "Rādīt pagājušos notikumus",
   "show_empty_days": "Rādīt tukšas dienas",
   "empty_day_text": "Tukšas dienas teksts",
   "empty_day_text.helper": "Aizstāj tulkoto noklusējuma tekstu un noņem ķeksīti tā priekšā.",

--- a/src/rendering/editor/translations/nb.json
+++ b/src/rendering/editor/translations/nb.json
@@ -126,7 +126,7 @@
   "compact_events_complete_days": "Gjør den siste dagen ferdig",
   "compact_events_complete_days.helper": "I stedet for å stoppe midt i en dag ved hendelsesgrensen, vis resten av den dagen også.",
   "content": "Hva kortet viser",
-  "show_past_events": "Vis dagens passerte hendelser",
+  "show_past_events": "Vis passerte hendelser",
   "show_empty_days": "Vis tomme dager",
   "empty_day_text": "Tekst for tomme dager",
   "empty_day_text.helper": "Erstatter den oversatte standardteksten, og fjerner haken foran den.",

--- a/src/rendering/editor/translations/pl.json
+++ b/src/rendering/editor/translations/pl.json
@@ -126,7 +126,7 @@
   "compact_events_complete_days": "Dokończ ostatni dzień",
   "compact_events_complete_days.helper": "Zamiast zatrzymywać się w środku dnia po osiągnięciu limitu wydarzeń, pokazuje też resztę tego dnia.",
   "content": "Co pokazuje karta",
-  "show_past_events": "Pokaż minione wydarzenia z dzisiaj",
+  "show_past_events": "Pokaż minione wydarzenia",
   "show_empty_days": "Pokaż puste dni",
   "empty_day_text": "Tekst pustego dnia",
   "empty_day_text.helper": "Zastępuje przetłumaczony tekst domyślny i usuwa poprzedzający go znak zaznaczenia.",

--- a/src/rendering/editor/translations/sk.json
+++ b/src/rendering/editor/translations/sk.json
@@ -126,7 +126,7 @@
   "compact_events_complete_days": "Dokončiť posledný deň",
   "compact_events_complete_days.helper": "Namiesto zastavenia uprostred dňa pri dosiahnutí limitu udalostí zobrazí aj zvyšok toho dňa.",
   "content": "Čo karta zobrazuje",
-  "show_past_events": "Zobraziť dnešné minulé udalosti",
+  "show_past_events": "Zobraziť minulé udalosti",
   "show_empty_days": "Zobraziť prázdne dni",
   "empty_day_text": "Text prázdneho dňa",
   "empty_day_text.helper": "Nahradí preložený predvolený text a odstráni značku začiarknutia pred ním.",

--- a/src/rendering/editor/translations/sv.json
+++ b/src/rendering/editor/translations/sv.json
@@ -126,7 +126,7 @@
   "compact_events_complete_days": "Visa dagen färdig",
   "compact_events_complete_days.helper": "I stället för att sluta mitt i en dag vid händelsegränsen, visa resten av den dagen också.",
   "content": "Vad kortet visar",
-  "show_past_events": "Visa dagens passerade händelser",
+  "show_past_events": "Visa passerade händelser",
   "show_empty_days": "Visa tomma dagar",
   "empty_day_text": "Text för tomma dagar",
   "empty_day_text.helper": "Ersätter den översatta standardtexten och tar bort bocken före den.",

--- a/src/rendering/leaves.ts
+++ b/src/rendering/leaves.ts
@@ -11,6 +11,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import * as Types from '../config/types';
 import * as Localize from '../translations/localize';
 import * as EventUtils from '../utils/events';
+import * as FormatUtils from '../utils/format';
 import * as Helpers from '../utils/helpers';
 import * as Weather from '../utils/weather';
 
@@ -78,17 +79,6 @@ export function renderDateWeather(
 }
 
 /**
- * Check whether a date falls on a weekend (Saturday or Sunday).
- *
- * @param date Date to check
- * @returns True when the date is a Saturday or Sunday
- */
-export function isWeekendDate(date: Date): boolean {
-  const day = date.getDay();
-  return day === 0 || day === 6; // 0 = Sunday, 6 = Saturday
-}
-
-/**
  * Classify a day's start-of-day timestamp as today and/or tomorrow.
  *
  * @param timestamp Start-of-day timestamp for the day
@@ -129,7 +119,7 @@ export function renderDateContent(
   isToday: boolean,
   weatherContent: TemplateResult | typeof nothing = nothing,
 ): TemplateResult {
-  const isWeekendDay = isWeekendDate(date);
+  const isWeekendDay = FormatUtils.isWeekendDate(date);
 
   let weekdayColor = config.weekday_color;
   let dayColor = config.day_color;

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -13,6 +13,7 @@ import * as Constants from '../config/constants';
 import * as Types from '../config/types';
 import * as ViewConfig from '../config/view';
 import * as Localize from '../translations/localize';
+import * as FormatUtils from '../utils/format';
 
 /**
  * Re-exported so the card can dispatch between views through a single import namespace. Keeping both renderers reachable as `Render.*` means the two call sites in the card's view dispatch read as a symmetrical pair rather than pulling from different modules.
@@ -347,7 +348,7 @@ export function renderDay(
   // Column view carries `weekend` on its day container, so list view does too — a card-mod
   // rule targeting weekends should not need to know which view is active. List view also
   // keeps it on `.date-column`, where it drives the built-in date-cell styling.
-  const isWeekendDay = Leaves.isWeekendDate(new Date(day.timestamp));
+  const isWeekendDay = FormatUtils.isWeekendDate(new Date(day.timestamp));
 
   let daySeparator: TemplateResult | typeof nothing = nothing;
 
@@ -485,7 +486,7 @@ function renderEvent(
   const presentation = Presentation.buildEventPresentation(event, config, language, hass);
 
   const dayDate = new Date(day.timestamp);
-  const isWeekendDay = Leaves.isWeekendDate(dayDate);
+  const isWeekendDay = FormatUtils.isWeekendDate(dayDate);
 
   const isFirst = index === 0;
   const isLast = index === day.events.length - 1;

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -214,6 +214,149 @@ function deduplicateEvents(
   return events.filter((event) => keep.has(event) || !seen.has(generateEventSignature(event)));
 }
 
+//-----------------------------------------------------------------------------
+// RENDER-TIME PER-CALENDAR FILTERS
+//-----------------------------------------------------------------------------
+//
+// Both of the filters below are read from the `_matchedConfig` stamp while events are
+// **grouped**, not while they are processed, which is what keeps them out of
+// `PROCESSING_TIME_KEYS`: nothing about them is baked into `this.events`, so an edit
+// reaches the screen on the next render. They are also per-calendar only, so the entity
+// list changes whenever either does and `serializeEntities` already forces a reprocess —
+// belt and braces, but the render-time read is the load-bearing half.
+//
+// They run **after** `processMultiDayEvents`, which is the opposite of where
+// `filterEventsByType` has to sit and for a related reason. Splitting rewrites the middle
+// days of a timed multi-day event as `start: { date }`, so a filter reading an event's
+// *class* must precede it. These two read an event's *day* instead, which only exists once
+// the splitter has decided how many days the event occupies.
+
+/**
+ * Which day a grouped event is drawn on.
+ *
+ * Extracted so the weekday filter and the grouping pass cannot disagree about it. The
+ * distinction matters most for an event already in progress when the window opens: it is
+ * clamped to the window's first day, so its row lands on a day its own `start` never
+ * names. Filtering on the start date would then hide — or fail to hide — the wrong row.
+ *
+ * The second and third tests are reached only when `startDate < referenceStart`, since the
+ * first returned otherwise; the original inline form repeated that as an explicit conjunct.
+ *
+ * @param startDate Event start, as the caller resolved it for its all-day-ness
+ * @param endDate Event end, likewise, with the all-day exclusive day already removed
+ * @param referenceStart Local midnight on the window's first day
+ * @returns The day the event's row belongs to
+ */
+function resolveDisplayDate(startDate: Date, endDate: Date, referenceStart: Date): Date {
+  if (startDate >= referenceStart) return startDate;
+  if (endDate.toDateString() === referenceStart.toDateString()) return referenceStart;
+  if (endDate > referenceStart) return referenceStart;
+
+  return startDate;
+}
+
+/** `HH:MM`, or `HH:MM:SS`. A single-digit hour is accepted; 24 and above is not. */
+const TIME_OF_DAY_PATTERN = /^(\d{1,2}):([0-5]\d)(?::([0-5]\d))?$/;
+
+/** Values already reported as unparseable, so one typo warns once rather than per event. */
+const reportedExpiryValues = new Set<string>();
+
+/**
+ * Read a wall-clock time of day out of a configured string.
+ *
+ * @param value Configured value, from a calendar's `allday_expires_at`
+ * @returns The time, or `null` when the value is absent or not a time
+ */
+function parseTimeOfDay(
+  value: unknown,
+): { hours: number; minutes: number; seconds: number } | null {
+  if (typeof value !== 'string') return null;
+
+  const match = TIME_OF_DAY_PATTERN.exec(value.trim());
+  if (!match) return null;
+
+  const hours = Number(match[1]);
+  if (hours > 23) return null;
+
+  return { hours, minutes: Number(match[2]), seconds: match[3] ? Number(match[3]) : 0 };
+}
+
+/**
+ * Whether an all-day event has passed the time of day its calendar retires it at.
+ *
+ * All-day events are exempt from expiry by construction: the test beside this one compares
+ * `endDate < now`, and an all-day event's end is a date rather than an instant, so it can
+ * only fall past once the calendar day itself has. `allday_expires_at` supplies the missing
+ * instant — the configured clock time on the event's **last** day, so a Monday-to-Wednesday
+ * holiday retires on Wednesday morning rather than on Monday's.
+ *
+ * An unparseable value expires nothing, on the same principle as `resolveEventType`: a typo
+ * should show too much, never too little. It is reported once per distinct value, because
+ * this runs per event and a silent typo is a support question nobody can answer.
+ *
+ * 🚨 Nothing schedules a render at the configured time. The card's only timer is the
+ * refresh interval, so an event retires on the first render after its moment passes.
+ *
+ * @param endDate Last day the event covers, at local midnight
+ * @param configured The calendar's `allday_expires_at`, unvalidated
+ * @param now Instant the card is rendering at
+ * @returns True when the event should count as past
+ */
+function allDayEventHasExpired(endDate: Date, configured: unknown, now: Date): boolean {
+  const time = parseTimeOfDay(configured);
+
+  if (!time) {
+    if (typeof configured === 'string' && configured.trim() !== '') {
+      const value = configured.trim();
+      if (!reportedExpiryValues.has(value)) {
+        reportedExpiryValues.add(value);
+        Logger.warn(`Invalid allday_expires_at value "${value}" — expected a time such as 10:00`);
+      }
+    }
+
+    return false;
+  }
+
+  const expiresAt = new Date(endDate);
+  expiresAt.setHours(time.hours, time.minutes, time.seconds, 0);
+
+  return now >= expiresAt;
+}
+
+/**
+ * Which days of the week one calendar may put a row on.
+ *
+ * Per-calendar only, and deliberately so. The request behind it (#225) is a school-holidays
+ * calendar whose entries run through the weekend, on a card that must keep showing every
+ * *other* calendar's weekend events — so a card-wide value would answer a question nobody
+ * asked, and narrowing the card's date window cannot express it at all.
+ *
+ * An unrecognized value filters nothing, so a typo shows too much rather than too little —
+ * the same principle `resolveEventType` follows, and the reason this returns `undefined`
+ * rather than throwing on a value the union does not name.
+ *
+ * @param entityConfig The calendar's own settings, where it has any
+ * @returns The days that calendar's events may land on, or `undefined` for every day
+ */
+function resolveDaysOfWeek(
+  entityConfig: Types.EntityConfig | undefined,
+): Types.DaysOfWeekFilter | undefined {
+  const configured = entityConfig?.days_of_week;
+
+  return configured === 'weekdays' || configured === 'weekends' ? configured : undefined;
+}
+
+/**
+ * Whether a day satisfies one calendar's `days_of_week`.
+ *
+ * @param displayDate The day the row would land on
+ * @param filter The calendar's resolved filter
+ * @returns True when the row may stay
+ */
+function dayPassesWeekFilter(displayDate: Date, filter: Types.DaysOfWeekFilter): boolean {
+  return FormatUtils.isWeekendDate(displayDate) === (filter === 'weekends');
+}
+
 /**
  * Group events by display day.
  *
@@ -338,6 +481,31 @@ export function groupEventsByDay(
       if (!isAllDayEvent && endDate < now) {
         return false;
       }
+
+      // The all-day half of the same rule. Read here rather than beside the timed test
+      // above because it is per-calendar: `show_past_events` decides *whether* past events
+      // are shown, and this decides *when* one of this calendar's all-day events becomes
+      // past. With `show_past_events: true` there is nothing for it to do, which is why it
+      // sits inside this branch rather than beside it.
+      if (
+        isAllDayEvent &&
+        allDayEventHasExpired(
+          endDate,
+          getEntitySetting(event._entityId, 'allday_expires_at', config, event),
+          now,
+        )
+      ) {
+        return false;
+      }
+    }
+
+    const daysOfWeek = resolveDaysOfWeek(event._matchedConfig);
+
+    if (
+      daysOfWeek &&
+      !dayPassesWeekFilter(resolveDisplayDate(startDate, endDate, referenceStart), daysOfWeek)
+    ) {
+      return false;
     }
 
     return true;
@@ -368,17 +536,7 @@ export function groupEventsByDay(
 
       if (!startDate || !endDate) return;
 
-      let displayDate: Date;
-
-      if (startDate >= referenceStart) {
-        displayDate = startDate;
-      } else if (endDate.toDateString() === referenceStart.toDateString()) {
-        displayDate = referenceStart;
-      } else if (startDate < referenceStart && endDate > referenceStart) {
-        displayDate = referenceStart;
-      } else {
-        displayDate = startDate;
-      }
+      const displayDate = resolveDisplayDate(startDate, endDate, referenceStart);
 
       const eventDateKey = FormatUtils.getLocalDateKey(displayDate);
       const translations = Localize.getTranslations(language);

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -282,27 +282,39 @@ function parseTimeOfDay(
 }
 
 /**
- * Whether an all-day event has passed the time of day its calendar retires it at.
+ * The instant an all-day event stops counting as upcoming.
  *
- * All-day events are exempt from expiry by construction: the test beside this one compares
- * `endDate < now`, and an all-day event's end is a date rather than an instant, so it can
- * only fall past once the calendar day itself has. `allday_expires_at` supplies the missing
- * instant — the configured clock time on the event's **last** day, so a Monday-to-Wednesday
- * holiday retires on Wednesday morning rather than on Monday's.
+ * 🚨 The **default matters as much as the option**, and supplying it is what closes the
+ * older defect this function also fixes. An all-day event has no end instant — its end is a
+ * date — so the timed test beside this one could not be applied to it: `endDate` is local
+ * midnight *at the start* of the last day, so from 00:00:01 onward every all-day event
+ * happening **today** would have read as past. The card therefore exempted all-day events
+ * from expiry altogether, which is right for today and wrong for every day before it. With
+ * `show_past_events: false` and a window reaching backwards — `start_date: 'today-7'`, or
+ * `start_of_week` mid-week — a finished all-day event kept its row while every timed event
+ * beside it was correctly hidden.
  *
- * An unparseable value expires nothing, on the same principle as `resolveEventType`: a typo
- * should show too much, never too little. It is reported once per distinct value, because
- * this runs per event and a silent typo is a support question nobody can answer.
+ * Supplying the missing instant fixes both at once. An all-day event is past at **midnight
+ * after its last day**, so today's survives the whole day and last Saturday's does not, and
+ * `allday_expires_at` moves that instant earlier *within* the final day. The option and the
+ * default are then one rule at two settings rather than two mechanisms.
  *
- * 🚨 Nothing schedules a render at the configured time. The card's only timer is the
+ * The last day is the event's own, not today's, so a Monday-to-Wednesday holiday retires on
+ * Wednesday night rather than on Monday's.
+ *
+ * An unparseable value falls back to midnight rather than to never, on the same principle
+ * as `resolveEventType`: a typo should leave the card behaving as though the option were
+ * absent. It is reported once per distinct value, because this runs per event and a silent
+ * typo is a support question nobody can answer.
+ *
+ * 🚨 Nothing schedules a render at the returned instant. The card's only timer is the
  * refresh interval, so an event retires on the first render after its moment passes.
  *
  * @param endDate Last day the event covers, at local midnight
  * @param configured The calendar's `allday_expires_at`, unvalidated
- * @param now Instant the card is rendering at
- * @returns True when the event should count as past
+ * @returns The local instant from which the event counts as past
  */
-function allDayEventHasExpired(endDate: Date, configured: unknown, now: Date): boolean {
+function allDayExpiryInstant(endDate: Date, configured: unknown): Date {
   const time = parseTimeOfDay(configured);
 
   if (!time) {
@@ -314,13 +326,19 @@ function allDayEventHasExpired(endDate: Date, configured: unknown, now: Date): b
       }
     }
 
-    return false;
+    // Midnight after the last day, built by adding a calendar day rather than by naming
+    // 24:00, so a DST transition on that night shifts it correctly.
+    const midnight = new Date(endDate);
+    midnight.setDate(midnight.getDate() + 1);
+    midnight.setHours(0, 0, 0, 0);
+
+    return midnight;
   }
 
   const expiresAt = new Date(endDate);
   expiresAt.setHours(time.hours, time.minutes, time.seconds, 0);
 
-  return now >= expiresAt;
+  return expiresAt;
 }
 
 /**
@@ -482,18 +500,17 @@ export function groupEventsByDay(
         return false;
       }
 
-      // The all-day half of the same rule. Read here rather than beside the timed test
-      // above because it is per-calendar: `show_past_events` decides *whether* past events
-      // are shown, and this decides *when* one of this calendar's all-day events becomes
-      // past. With `show_past_events: true` there is nothing for it to do, which is why it
-      // sits inside this branch rather than beside it.
+      // The all-day half of the same rule, and the half that needs an instant computed for
+      // it. `show_past_events` decides *whether* past events are shown; the expiry decides
+      // *when* an all-day event becomes past. With `show_past_events: true` there is
+      // nothing for either to do, which is why both sit inside this branch.
       if (
         isAllDayEvent &&
-        allDayEventHasExpired(
-          endDate,
-          getEntitySetting(event._entityId, 'allday_expires_at', config, event),
-          now,
-        )
+        now >=
+          allDayExpiryInstant(
+            endDate,
+            getEntitySetting(event._entityId, 'allday_expires_at', config, event),
+          )
       ) {
         return false;
       }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -262,6 +262,28 @@ export function getLocalDateKey(date: Date): string {
 }
 
 /**
+ * Check whether a date falls on a weekend.
+ *
+ * Saturday and Sunday, deliberately fixed rather than derived from the locale or from
+ * `first_day_of_week`. This is the card's **one** answer to the question, and it is read
+ * by two features that have to agree: the weekend day-header colors, and the per-calendar
+ * `days_of_week` filter. Were the filter locale-aware while the colors were not, a Friday
+ * in a Friday–Saturday weekend would be filtered as a weekend day and colored as a
+ * weekday — two visible answers to one question on the same row.
+ *
+ * Lives here rather than beside its first caller in `rendering/leaves.ts` for that reason:
+ * `leaves.ts` imports `utils/events.ts`, so the filter could not have reached it without
+ * a cycle, and a second copy is what this comment exists to prevent.
+ *
+ * @param date Date to check
+ * @returns True when the date is a Saturday or Sunday
+ */
+export function isWeekendDate(date: Date): boolean {
+  const day = date.getDay();
+  return day === 0 || day === 6; // 0 = Sunday, 6 = Saturday
+}
+
+/**
  * Count whole calendar days from one date to another.
  *
  * Both arguments are reduced to their local calendar date and differenced in

--- a/tests/allday-expiry.test.ts
+++ b/tests/allday-expiry.test.ts
@@ -1,12 +1,17 @@
 /**
  * `allday_expires_at` retires a calendar's all-day events partway through the day.
  *
- * All-day events are exempt from expiry **by construction**, which is the fact this option
- * exists to change. The past-events test compares `endDate < now`, and an all-day event's
- * end is a date rather than an instant, so it cannot fall past until the calendar day
- * itself has. The request behind it (#163) is a waste-collection feed published by a
- * council: its entries are all-day events, so the bin sits on the card until midnight,
- * hours after it was emptied, and the reporter cannot edit the feed.
+ * All-day events had no end **instant**, only an end date, so the past-events test —
+ * `endDate < now` — could not be applied to them and they were exempt from expiry
+ * altogether. `allday_expires_at` supplies that instant. The request behind it (#163) is a
+ * waste-collection feed published by a council: its entries are all-day events, so the bin
+ * sits on the card all day, hours after it was emptied, and the reporter cannot edit
+ * the feed.
+ *
+ * The option and its **default** are one rule at two settings, which is why the first
+ * describe block below tests the default rather than the option. An all-day event is past
+ * at midnight after its last day; `allday_expires_at` moves that instant earlier within the
+ * final day.
  *
  * Four properties are pinned here, and each one has been wrong in some draft:
  *
@@ -16,8 +21,8 @@
  *   past events are shown and this one decides *when* an event becomes past. Two
  *   independent visibility rules over the same events is a card nobody can predict.
  * - It leaves timed events alone, which already have an end instant and already expire.
- * - An unparseable value expires nothing, so a typo shows too much rather than emptying a
- *   calendar silently.
+ * - An unparseable value falls back to the default rather than to never, so a typo leaves
+ *   the card behaving as though the option were absent.
  *
  * The suite is built from `DEFAULT_CONFIG`, where the option is unset, so every case here
  * sets it deliberately — without that this option would be invisible to the whole suite.
@@ -91,6 +96,102 @@ function render(
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+/**
+ * The defect the option's **default** fixes, which is separate from the option itself.
+ *
+ * Reported during review of this branch. `show_past_events: false` hid every timed event
+ * that had ended and left finished **all-day** events on the card indefinitely, because
+ * all-day events were exempt from the past test by construction. From a user's point of
+ * view that is simply wrong: an event that finished last Saturday is past, whatever shape
+ * its dates take.
+ *
+ * It is invisible at the default `start_date`, which is why it shipped: the window filter
+ * requires `endDate >= referenceStart`, so with the window opening today a finished all-day
+ * event is dropped for being outside the window rather than for being past, and the two
+ * reasons cannot be told apart. Only a window reaching **backwards** separates them —
+ * `start_date: 'today-7'`, or `start_of_week` read mid-week, which the start-date docs
+ * actively recommend. Every case below therefore uses one, and the timed control proves the
+ * window itself is not what hides the event.
+ *
+ * The fix is the same instant `allday_expires_at` names, defaulted: an all-day event is
+ * past at midnight after its last day.
+ */
+describe('a finished all-day event is past, with no option set', () => {
+  /** Saturday 13 June, four days before the frozen Wednesday. */
+  const lastSaturday = (): Types.CalendarEventData[] => [
+    allDay('Disneyland', '2026-06-13', '2026-06-14'),
+  ];
+
+  /** A window reaching back a week, which is the only thing that exposes this. */
+  const BACKWARDS = { start_date: '2026-06-10', days_to_show: 12 } as Partial<Types.Config>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(AT_1100);
+  });
+
+  it('hides it', () => {
+    expect(render(lastSaturday(), {}, BACKWARDS)).toEqual([]);
+  });
+
+  /**
+   * The denominator, and the assertion that makes the one above mean something. The event
+   * is inside the window — it renders the moment past events are shown — so its absence is
+   * the past test doing its job rather than the window excluding it.
+   */
+  it('control: the same event is inside the window', () => {
+    expect(render(lastSaturday(), {}, { ...BACKWARDS, show_past_events: true })).toEqual([
+      'Disneyland',
+    ]);
+  });
+
+  /**
+   * The second control, and the one that states the inconsistency the report was about: a
+   * timed event on the same past day was already hidden. Before the fix these two answered
+   * differently, side by side, on the same card.
+   */
+  it('control: a timed event on that same day was already hidden', () => {
+    const timed: Types.CalendarEventData[] = [
+      {
+        summary: 'Timed',
+        start: { dateTime: '2026-06-13T09:00:00.000Z' },
+        end: { dateTime: '2026-06-13T10:00:00.000Z' },
+        _entityId: 'calendar.waste',
+      },
+    ];
+
+    expect(render(timed, {}, BACKWARDS)).toEqual([]);
+  });
+
+  /**
+   * The over-correction guard, and the reason the exemption existed in the first place.
+   * `endDate` for an all-day event is local midnight at the *start* of its last day, so a
+   * naive `endDate < now` retires today's event at 00:00:01. Midnight-after-the-last-day is
+   * what keeps it up all day.
+   */
+  it('keeps today\u2019s all-day event, late in the day', () => {
+    vi.setSystemTime(new Date('2026-06-17T23:30:00.000Z'));
+
+    expect(render([allDay('Today', TODAY, TOMORROW)], {}, BACKWARDS)).toEqual(['Today']);
+  });
+
+  /** And retires it the moment that midnight passes, rather than at some later point. */
+  it('retires it once midnight has passed', () => {
+    vi.setSystemTime(new Date('2026-06-18T00:00:00.000Z'));
+
+    expect(render([allDay('Today', TODAY, TOMORROW)], {}, BACKWARDS)).toEqual([]);
+  });
+
+  /** A multi-day event is judged on its last day, not its first. */
+  it('keeps a multi-day event that is still running', () => {
+    expect(render([allDay('Away', '2026-06-15', '2026-06-19')], {}, BACKWARDS)).toEqual(['Away']);
+  });
+
+  it('hides a multi-day event that finished yesterday', () => {
+    expect(render([allDay('Away', '2026-06-14', '2026-06-17')], {}, BACKWARDS)).toEqual([]);
+  });
 });
 
 describe('allday_expires_at: a single-day all-day event', () => {
@@ -287,12 +388,15 @@ describe('allday_expires_at: values it accepts and values it refuses', () => {
   });
 
   /**
-   * A typo shows too much, never too little — the principle `resolveEventType` follows.
-   * The alternative is a calendar that silently empties because someone wrote `10am`, with
-   * nothing on screen to say why.
+   * A typo falls back to the default — the principle `resolveEventType` follows, adapted to
+   * an option whose absent state is no longer "never". The card behaves as though the key
+   * were not there, rather than silently emptying a calendar because someone wrote `10am`.
+   *
+   * The fixture is today's event, so falling back to midnight leaves it showing; the
+   * default's own behaviour is pinned separately in the first describe block.
    */
   it.each(['10am', '24:00', '10:60', '10', 'morning', '', '1000'])(
-    '%s expires nothing',
+    '%s falls back to the default',
     (value) => {
       expect(render(bin(), { allday_expires_at: value })).toEqual(['Green bin']);
     },

--- a/tests/allday-expiry.test.ts
+++ b/tests/allday-expiry.test.ts
@@ -1,0 +1,307 @@
+/**
+ * `allday_expires_at` retires a calendar's all-day events partway through the day.
+ *
+ * All-day events are exempt from expiry **by construction**, which is the fact this option
+ * exists to change. The past-events test compares `endDate < now`, and an all-day event's
+ * end is a date rather than an instant, so it cannot fall past until the calendar day
+ * itself has. The request behind it (#163) is a waste-collection feed published by a
+ * council: its entries are all-day events, so the bin sits on the card until midnight,
+ * hours after it was emptied, and the reporter cannot edit the feed.
+ *
+ * Four properties are pinned here, and each one has been wrong in some draft:
+ *
+ * - It reads the event's **last** day, so a multi-day all-day event retires on the morning
+ *   it ends rather than the morning it began.
+ * - It does nothing while `show_past_events` is on, because that option decides *whether*
+ *   past events are shown and this one decides *when* an event becomes past. Two
+ *   independent visibility rules over the same events is a card nobody can predict.
+ * - It leaves timed events alone, which already have an end instant and already expire.
+ * - An unparseable value expires nothing, so a typo shows too much rather than emptying a
+ *   calendar silently.
+ *
+ * The suite is built from `DEFAULT_CONFIG`, where the option is unset, so every case here
+ * sets it deliberately — without that this option would be invisible to the whole suite.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import { groupEventsByDay } from '../src/utils/events';
+
+/** Wednesday 2026-06-17. Mid-week and mid-month, clear of every boundary the card draws. */
+const TODAY = '2026-06-17';
+const TOMORROW = '2026-06-18';
+const DAY_AFTER = '2026-06-19';
+
+/** Before a 10:00 expiry. */
+const AT_0900 = new Date('2026-06-17T09:00:00.000Z');
+
+/** After it, and still comfortably clear of midnight either side. */
+const AT_1100 = new Date('2026-06-17T11:00:00.000Z');
+
+/**
+ * An all-day event, with iCal's exclusive end.
+ *
+ * @param summary Event title
+ * @param start First day it covers
+ * @param endExclusive The day after the last day it covers
+ * @returns The event
+ */
+function allDay(summary: string, start: string, endExclusive: string): Types.CalendarEventData {
+  return {
+    summary,
+    start: { date: start },
+    end: { date: endExclusive },
+    _entityId: 'calendar.waste',
+  };
+}
+
+/**
+ * Group a fixture and return the real summaries that survived.
+ *
+ * Empty-day placeholders are dropped: a card the filter has emptied pads the window with
+ * *No upcoming events* notices, which are not events and would otherwise read as several.
+ *
+ * @param events Events to group
+ * @param entity The calendar's own settings
+ * @param overrides Card configuration beyond the defaults
+ * @returns The surviving summaries, in day order
+ */
+function render(
+  events: Types.CalendarEventData[],
+  entity: Partial<Types.EntityConfig>,
+  overrides: Partial<Types.Config> = {},
+): string[] {
+  const config = buildConfig({
+    entities: [{ entity: 'calendar.waste', ...entity }],
+    days_to_show: 5,
+    ...overrides,
+  } as Partial<Types.Config>);
+
+  const stamped = events.map((event) => ({
+    ...event,
+    _matchedConfig: { entity: 'calendar.waste', ...entity } as Types.EntityConfig,
+  }));
+
+  return groupEventsByDay(stamped, config, true, 'en')
+    .flatMap((day) => day.events)
+    .filter((event) => !event._isEmptyDay)
+    .map((event) => event.summary ?? '');
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('allday_expires_at: a single-day all-day event', () => {
+  const bin = () => [allDay('Green bin', TODAY, TOMORROW)];
+
+  describe('before the configured time', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(AT_0900);
+    });
+
+    it('is still showing', () => {
+      expect(render(bin(), { allday_expires_at: '10:00' })).toEqual(['Green bin']);
+    });
+  });
+
+  describe('after the configured time', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(AT_1100);
+    });
+
+    it('is gone', () => {
+      expect(render(bin(), { allday_expires_at: '10:00' })).toEqual([]);
+    });
+
+    /**
+     * The denominator for every expiry case. Today's all-day event is *never* dropped
+     * without this option, so an empty result above is the option working rather than the
+     * fixture falling outside the window.
+     */
+    it('control: unset, the same event survives the same instant', () => {
+      expect(render(bin(), {})).toEqual(['Green bin']);
+    });
+
+    /**
+     * The second denominator, and the one a "does it still show?" assertion cannot supply:
+     * an event that was never eligible for expiry proves the filter is reading the clock
+     * rather than dropping the calendar wholesale.
+     */
+    it("control: tomorrow's event is untouched", () => {
+      const both = [...bin(), allDay('Paper bin', TOMORROW, DAY_AFTER)];
+
+      expect(render(both, { allday_expires_at: '10:00' })).toEqual(['Paper bin']);
+    });
+
+    it('expires exactly at the configured minute, not a minute before', () => {
+      vi.setSystemTime(new Date('2026-06-17T09:59:59.999Z'));
+      expect(render(bin(), { allday_expires_at: '10:00' })).toEqual(['Green bin']);
+
+      vi.setSystemTime(new Date('2026-06-17T10:00:00.000Z'));
+      expect(render(bin(), { allday_expires_at: '10:00' })).toEqual([]);
+    });
+  });
+});
+
+describe('allday_expires_at: which day it reads', () => {
+  /**
+   * A three-day all-day event, on the morning of its **first** day, past the expiry time.
+   *
+   * The property under test is that expiry follows the event's last day, so this must
+   * still be showing. Reading the start date instead — the obvious simplification, since
+   * `startDate` is right there in the same scope — retires a three-day event on its first
+   * morning, and only a fixture spanning more than one day can tell the two apart.
+   */
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(AT_1100);
+  });
+
+  it('keeps a multi-day event until the morning of its last day', () => {
+    const trip = [allDay('Away', TODAY, '2026-06-20')];
+
+    expect(render(trip, { allday_expires_at: '10:00' })).toEqual(['Away']);
+  });
+
+  it('retires it once that last morning is past', () => {
+    vi.setSystemTime(new Date('2026-06-19T11:00:00.000Z'));
+
+    const trip = [allDay('Away', TODAY, '2026-06-20')];
+
+    expect(render(trip, { allday_expires_at: '10:00', split_multiday_events: false })).toEqual([]);
+  });
+
+  /**
+   * Split into per-day segments, each segment carries its own last day, so the days
+   * already past retire and the rest stay. This is the shape the waste feed actually
+   * takes once a collection spans a weekend.
+   */
+  it('retires split segments one day at a time', () => {
+    vi.setSystemTime(new Date('2026-06-18T11:00:00.000Z'));
+
+    const trip = [allDay('Away', TODAY, '2026-06-20')];
+    const kept = render(trip, { allday_expires_at: '10:00', split_multiday_events: true });
+
+    // 17th and 18th are past their 10:00; the 19th is not.
+    expect(kept).toEqual(['Away']);
+  });
+
+  it('control: unsplit and unfiltered, the same event shows across the window', () => {
+    vi.setSystemTime(new Date('2026-06-19T11:00:00.000Z'));
+
+    const trip = [allDay('Away', TODAY, '2026-06-20')];
+
+    expect(render(trip, { split_multiday_events: false })).toEqual(['Away']);
+  });
+});
+
+describe('allday_expires_at: what it deliberately does not touch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(AT_1100);
+  });
+
+  /**
+   * With past events shown, this option has nothing to do. It decides *when* an all-day
+   * event becomes past; `show_past_events` decides whether past events are drawn at all,
+   * and an option that hid events the card was explicitly asked to show would be a second
+   * visibility rule contradicting the first.
+   */
+  it('shows an expired event anyway when past events are shown', () => {
+    const bin = [allDay('Green bin', TODAY, TOMORROW)];
+
+    expect(render(bin, { allday_expires_at: '10:00' }, { show_past_events: true })).toEqual([
+      'Green bin',
+    ]);
+  });
+
+  /** Timed events have an end instant and already expire; this option is not for them. */
+  it('leaves a timed event to its own end time', () => {
+    const meeting: Types.CalendarEventData[] = [
+      {
+        summary: 'Standup',
+        start: { dateTime: `${TODAY}T13:00:00.000Z` },
+        end: { dateTime: `${TODAY}T14:00:00.000Z` },
+        _entityId: 'calendar.waste',
+      },
+    ];
+
+    // 13:00 is still ahead of the 11:00 clock, and a 10:00 all-day expiry must not reach it.
+    expect(render(meeting, { allday_expires_at: '10:00' })).toEqual(['Standup']);
+  });
+
+  /**
+   * Per-calendar, and only this calendar. The card's other calendars keep their all-day
+   * events, which is the whole reason the option is not card-level: a household calendar's
+   * birthdays should not vanish at 10:00 because the bin feed does.
+   */
+  it('leaves another calendar\u2019s all-day events alone', () => {
+    const config = buildConfig({
+      entities: [{ entity: 'calendar.waste', allday_expires_at: '10:00' }, 'calendar.family'],
+      days_to_show: 5,
+    } as Partial<Types.Config>);
+
+    const events: Types.CalendarEventData[] = [
+      {
+        ...allDay('Green bin', TODAY, TOMORROW),
+        _matchedConfig: {
+          entity: 'calendar.waste',
+          allday_expires_at: '10:00',
+        } as Types.EntityConfig,
+      },
+      {
+        summary: 'Birthday',
+        start: { date: TODAY },
+        end: { date: TOMORROW },
+        _entityId: 'calendar.family',
+        _matchedConfig: { entity: 'calendar.family' } as Types.EntityConfig,
+      },
+    ];
+
+    const rendered = groupEventsByDay(events, config, true, 'en')
+      .flatMap((day) => day.events)
+      .map((event) => event.summary);
+
+    expect(rendered).toEqual(['Birthday']);
+  });
+});
+
+describe('allday_expires_at: values it accepts and values it refuses', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(AT_1100);
+  });
+
+  const bin = () => [allDay('Green bin', TODAY, TOMORROW)];
+
+  it.each(['10:00', '10:00:00', ' 10:00 ', '9:30'])('%s expires the event', (value) => {
+    expect(render(bin(), { allday_expires_at: value })).toEqual([]);
+  });
+
+  it.each(['23:59', '11:01'])('%s has not come round yet at 11:00', (value) => {
+    expect(render(bin(), { allday_expires_at: value })).toEqual(['Green bin']);
+  });
+
+  /**
+   * A typo shows too much, never too little — the principle `resolveEventType` follows.
+   * The alternative is a calendar that silently empties because someone wrote `10am`, with
+   * nothing on screen to say why.
+   */
+  it.each(['10am', '24:00', '10:60', '10', 'morning', '', '1000'])(
+    '%s expires nothing',
+    (value) => {
+      expect(render(bin(), { allday_expires_at: value })).toEqual(['Green bin']);
+    },
+  );
+
+  it('midnight is a real value, not an absent one', () => {
+    // `00:00` is falsy as a time-of-day in every representation that stores it as a number,
+    // which is the shape of bug that would make it silently mean "unset". At 11:00 on the
+    // event's own day, midnight has passed, so it must expire.
+    expect(render(bin(), { allday_expires_at: '00:00' })).toEqual([]);
+  });
+});

--- a/tests/days-of-week-filter.test.ts
+++ b/tests/days-of-week-filter.test.ts
@@ -1,0 +1,450 @@
+/**
+ * `days_of_week` restricts one calendar to weekdays or to weekends.
+ *
+ * The request behind it (#225) is a school-holidays calendar whose entries run through the
+ * weekend, on a card that must keep showing every *other* calendar's weekend events. That
+ * is the whole reason the option is per-calendar and cannot be a narrower date window: the
+ * window belongs to the card, and narrowing it would take the weekend away from everyone.
+ *
+ * The property this file exists to pin is that the filter reads the **display date** — the
+ * day the row lands on — and not the event's own `start`. Those are the same date for an
+ * ordinary event and differ for a multi-day one in two distinct ways, so there are three
+ * cases and no two of them are covered by the same reasoning:
+ *
+ * 1. **Ordinary event.** Start and display date coincide; nothing distinguishes the two
+ *    readings, and this is the case a naive implementation gets right.
+ * 2. **Split multi-day event.** `split_multiday_events: true` turns one event into a
+ *    segment per day, each with its own start, so *reading the start already works* —
+ *    which is exactly why this case cannot substitute for the third.
+ * 3. **Unsplit multi-day event, clamped.** With `split_multiday_events: false` an event
+ *    that began before the window shows once, on the window's **first day**, because
+ *    `resolveDisplayDate` clamps it there. Its own start names a day the card is not
+ *    drawing — possibly weeks earlier, possibly a different weekday — so a start-date
+ *    reading hides the wrong row or fails to hide the right one.
+ *
+ * Case 3 is the falsifier. Rewriting the filter to read `startDate` leaves cases 1 and 2
+ * green and fails only that one, which is why it carries an explicit control asserting the
+ * two dates genuinely disagree rather than assuming the fixture arranged it.
+ *
+ * The suite is built from `DEFAULT_CONFIG`, where `days_of_week` is unset and every day
+ * qualifies, so every case here sets it deliberately — without that this option would be
+ * invisible to the whole suite.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import { groupEventsByDay } from '../src/utils/events';
+
+/**
+ * Monday 2026-06-15 at 09:00 UTC.
+ *
+ * A **Monday** deliberately: the window's first day is then a weekday, so a `weekdays`
+ * filter cannot pass merely by keeping everything the window opens on. Mid-June, mid-month
+ * and clear of any month or year boundary.
+ */
+const MONDAY = new Date('2026-06-15T09:00:00.000Z');
+
+/** The seven days from that Monday, so a fixture can name a weekday rather than a number. */
+const DATES = {
+  monday: '2026-06-15',
+  tuesday: '2026-06-16',
+  wednesday: '2026-06-17',
+  thursday: '2026-06-18',
+  friday: '2026-06-19',
+  saturday: '2026-06-20',
+  sunday: '2026-06-21',
+  nextMonday: '2026-06-22',
+  nextTuesday: '2026-06-23',
+} as const;
+
+/** An all-day event. Home Assistant returns these with `date`, and an exclusive end. */
+function allDay(summary: string, start: string, endExclusive: string): Types.CalendarEventData {
+  return {
+    summary,
+    start: { date: start },
+    end: { date: endExclusive },
+    _entityId: 'calendar.holidays',
+  };
+}
+
+/** A timed event at midday, so no fixture sits near a local midnight by accident. */
+function timed(summary: string, date: string): Types.CalendarEventData {
+  return {
+    summary,
+    start: { dateTime: `${date}T12:00:00.000Z` },
+    end: { dateTime: `${date}T13:00:00.000Z` },
+    _entityId: 'calendar.holidays',
+  };
+}
+
+/**
+ * Stamp each event with the calendar settings production would have stamped on it.
+ *
+ * `processEvents` writes `_matchedConfig` on the fetch path, and `groupEventsByDay` reads
+ * the stamp rather than re-deriving it — so a fixture that skips this is testing a code
+ * path the card never takes. Kept explicit rather than hidden in a helper default so that
+ * the stamp is visible in each case.
+ */
+function stamped(
+  events: Types.CalendarEventData[],
+  entity: Partial<Types.EntityConfig>,
+): Types.CalendarEventData[] {
+  return events.map((event) => ({
+    ...event,
+    _matchedConfig: { entity: 'calendar.holidays', ...entity } as Types.EntityConfig,
+  }));
+}
+
+/** The date key `groupEventsByDay` buckets a day under, read back off its timestamp. */
+function dateKeyOf(timestamp: number): string {
+  const date = new Date(timestamp);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(
+    date.getDate(),
+  ).padStart(2, '0')}`;
+}
+
+/**
+ * Group a fixture and return what survived, keyed by day.
+ *
+ * **Real events only.** A card the filter has emptied falls through to the empty-day
+ * padding and renders a *No upcoming events* placeholder on every day of the window, so a
+ * helper that read summaries indiscriminately would report nine events where the answer is
+ * none — and the two cases asserting that a calendar is filtered away entirely would both
+ * fail against correct behavior. Placeholders are reached through {@link placeholderDays}
+ * instead, which keeps "no events" and "an empty-day notice" distinguishable.
+ *
+ * @param events Events to group
+ * @param entity The calendar's own settings
+ * @param overrides Card configuration beyond the defaults
+ * @returns Each rendered day's date key mapped to the real summaries on it
+ */
+function render(
+  events: Types.CalendarEventData[],
+  entity: Partial<Types.EntityConfig>,
+  overrides: Partial<Types.Config> = {},
+): Record<string, string[]> {
+  const config = buildConfig({
+    entities: [{ entity: 'calendar.holidays', ...entity }],
+    days_to_show: 9,
+    ...overrides,
+  } as Partial<Types.Config>);
+
+  const days = groupEventsByDay(stamped(events, entity), config, true, 'en');
+
+  const result: Record<string, string[]> = {};
+  for (const day of days) {
+    result[dateKeyOf(day.timestamp)] = day.events
+      .filter((event) => !event._isEmptyDay)
+      .map((event) => event.summary ?? '');
+  }
+  return result;
+}
+
+/**
+ * The same grouping, reduced to the days carrying an empty-day placeholder and its text.
+ *
+ * @param events Events to group
+ * @param entity The calendar's own settings
+ * @param overrides Card configuration beyond the defaults
+ * @returns Each placeholder day's date key mapped to the notice it shows
+ */
+function placeholderDays(
+  events: Types.CalendarEventData[],
+  entity: Partial<Types.EntityConfig>,
+  overrides: Partial<Types.Config> = {},
+): Record<string, string> {
+  const config = buildConfig({
+    entities: [{ entity: 'calendar.holidays', ...entity }],
+    days_to_show: 9,
+    ...overrides,
+  } as Partial<Types.Config>);
+
+  const days = groupEventsByDay(stamped(events, entity), config, true, 'en');
+
+  const result: Record<string, string> = {};
+  for (const day of days) {
+    const placeholder = day.events.find((event) => event._isEmptyDay);
+    if (placeholder) result[dateKeyOf(day.timestamp)] = placeholder.summary ?? '';
+  }
+  return result;
+}
+
+/** Every real summary the card rendered, in day order, flattened. */
+function summaries(rendered: Record<string, string[]>): string[] {
+  return Object.keys(rendered)
+    .sort()
+    .flatMap((key) => rendered[key]);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(MONDAY);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('days_of_week: the ordinary case', () => {
+  const week = [
+    timed('Friday', DATES.friday),
+    timed('Saturday', DATES.saturday),
+    timed('Sunday', DATES.sunday),
+    timed('Monday', DATES.nextMonday),
+  ];
+
+  it('shows every day when the option is unset', () => {
+    expect(summaries(render(week, {}))).toEqual(['Friday', 'Saturday', 'Sunday', 'Monday']);
+  });
+
+  it('keeps only Monday to Friday under weekdays', () => {
+    expect(summaries(render(week, { days_of_week: 'weekdays' }))).toEqual(['Friday', 'Monday']);
+  });
+
+  it('keeps only Saturday and Sunday under weekends', () => {
+    expect(summaries(render(week, { days_of_week: 'weekends' }))).toEqual(['Saturday', 'Sunday']);
+  });
+
+  /**
+   * The two values are exact complements, which is what makes the same
+   * list-the-calendar-twice pattern `event_type` supports work for this option too: one
+   * block each way styles weekday and weekend entries differently without losing a row or
+   * showing one twice.
+   */
+  it('partitions the week between the two values', () => {
+    const weekdays = summaries(render(week, { days_of_week: 'weekdays' }));
+    const weekends = summaries(render(week, { days_of_week: 'weekends' }));
+
+    expect([...weekdays, ...weekends].sort()).toEqual(summaries(render(week, {})).sort());
+    expect(weekdays.filter((summary) => weekends.includes(summary))).toEqual([]);
+  });
+
+  /**
+   * The control that stops every assertion above from passing on a filter that simply
+   * drops this calendar. Without it, `[]` would satisfy "no weekend events".
+   */
+  it('control: an unfiltered calendar keeps its weekend events', () => {
+    expect(summaries(render(week, {}))).toContain('Saturday');
+  });
+});
+
+describe('days_of_week: a multi-day event, split', () => {
+  /** Friday through Monday, covering both weekend days. All-day, so the end is exclusive. */
+  const holiday = [allDay('Long weekend', DATES.friday, DATES.nextTuesday)];
+
+  it('keeps the weekday segments and drops the weekend ones', () => {
+    const rendered = render(holiday, { days_of_week: 'weekdays', split_multiday_events: true });
+
+    expect(Object.keys(rendered).sort()).toEqual([DATES.friday, DATES.nextMonday].sort());
+  });
+
+  it('keeps the weekend segments and drops the weekday ones', () => {
+    const rendered = render(holiday, { days_of_week: 'weekends', split_multiday_events: true });
+
+    expect(Object.keys(rendered).sort()).toEqual([DATES.saturday, DATES.sunday]);
+  });
+
+  /**
+   * The denominator. An unfiltered split covers all five days, so the two cases above are
+   * genuinely dropping segments rather than describing a fixture that never had them.
+   */
+  it('control: unfiltered, the same event covers every day it spans', () => {
+    const rendered = render(holiday, { split_multiday_events: true });
+
+    expect(Object.keys(rendered).sort()).toEqual(
+      [DATES.friday, DATES.saturday, DATES.sunday, DATES.nextMonday].sort(),
+    );
+  });
+});
+
+describe('days_of_week: a multi-day event left whole, clamped to the window', () => {
+  /**
+   * The case that separates a display-date filter from a start-date one — and the two
+   * fixtures below are chosen so that the two readings actually *disagree*, which is a
+   * property the fixture has to supply rather than one the scenario gives for free.
+   *
+   * An unsplit event already in progress renders **once**, on the window's first day,
+   * because `resolveDisplayDate` clamps it to `referenceStart`. So the readings diverge
+   * only when the event's own start and the window's first day fall on opposite sides of
+   * the weekday/weekend line. One fixture cannot arrange that for both windows, so there
+   * are two, one per direction:
+   *
+   * - `startedOnAWeekend` begins on a Saturday and is drawn on a Monday. Under `weekdays`
+   *   a display-date reading keeps it and a start-date reading drops it.
+   * - `startedOnAWeekday` begins on a Wednesday and is drawn on a Saturday, once the
+   *   window is moved. The same two readings swap verdicts.
+   *
+   * The first draft of this block used a Wednesday start with a Monday window — two
+   * weekdays — so both readings agreed and every assertion passed against a filter reading
+   * the wrong date. Mutating the source to `startDate` is what exposed it, and is the
+   * check to repeat before trusting any change here.
+   */
+  const startedOnAWeekend = [allDay('Summer holidays', '2026-06-13', '2026-07-01')];
+  const startedOnAWeekday = [allDay('Field trip', '2026-06-10', '2026-07-01')];
+
+  it('control: each fixture is drawn on a weekday it did not start on', () => {
+    // Saturday 13 June, drawn on Monday 15 June.
+    expect(new Date('2026-06-13T00:00:00Z').getUTCDay(), 'fixture starts on a Saturday').toBe(6);
+    expect(Object.keys(render(startedOnAWeekend, { split_multiday_events: false }))).toEqual([
+      DATES.monday,
+    ]);
+
+    // Wednesday 10 June, drawn on Saturday 20 June once the window moves.
+    expect(new Date('2026-06-10T00:00:00Z').getUTCDay(), 'fixture starts on a Wednesday').toBe(3);
+    expect(
+      Object.keys(
+        render(startedOnAWeekday, { split_multiday_events: false }, { start_date: DATES.saturday }),
+      ),
+    ).toEqual([DATES.saturday]);
+  });
+
+  it('keeps a weekend-starting event, because the day it is drawn on is a Monday', () => {
+    expect(
+      summaries(
+        render(startedOnAWeekend, { days_of_week: 'weekdays', split_multiday_events: false }),
+      ),
+    ).toEqual(['Summer holidays']);
+  });
+
+  it('drops that same event under weekends, though it started on one', () => {
+    expect(
+      summaries(
+        render(startedOnAWeekend, { days_of_week: 'weekends', split_multiday_events: false }),
+      ),
+    ).toEqual([]);
+  });
+
+  /**
+   * The mirror image, and the half a start-date reading gets wrong in the other direction:
+   * a weekday-starting event drawn on a Saturday must be kept by `weekends` and dropped by
+   * `weekdays` — the opposite verdict to the pair above, on an event whose start has not
+   * moved.
+   */
+  it('follows the window when the first day is a weekend', () => {
+    const saturdayWindow = { start_date: DATES.saturday };
+
+    expect(
+      summaries(
+        render(
+          startedOnAWeekday,
+          { days_of_week: 'weekends', split_multiday_events: false },
+          saturdayWindow,
+        ),
+      ),
+    ).toEqual(['Field trip']);
+
+    expect(
+      summaries(
+        render(
+          startedOnAWeekday,
+          { days_of_week: 'weekdays', split_multiday_events: false },
+          saturdayWindow,
+        ),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('days_of_week: what happens to the day that is left empty', () => {
+  /**
+   * Filtering happens before the empty-day padding, which is what makes this fall out
+   * rather than needing a rule of its own — and the two settings genuinely differ, so the
+   * behavior is worth pinning rather than describing.
+   */
+  const week = [timed('Saturday', DATES.saturday), timed('Monday', DATES.nextMonday)];
+
+  it('leaves the day out entirely when empty days are hidden', () => {
+    const rendered = render(week, { days_of_week: 'weekdays' }, { show_empty_days: false });
+
+    expect(Object.keys(rendered)).toEqual([DATES.nextMonday]);
+  });
+
+  it('shows the day with its empty text when empty days are shown', () => {
+    const rendered = render(week, { days_of_week: 'weekdays' }, { show_empty_days: true });
+
+    expect(Object.keys(rendered)).toContain(DATES.saturday);
+    expect(rendered[DATES.saturday], 'the filtered event came back').toEqual([]);
+  });
+
+  /**
+   * The placeholder is created after grouping and carries no `_matchedConfig`, so it is
+   * not itself subject to the filter — a Saturday emptied by `weekdays` still gets one,
+   * with the card's own notice on it rather than a blank row.
+   */
+  it('control: the placeholder is not filtered away in turn', () => {
+    const placeholders = placeholderDays(
+      week,
+      { days_of_week: 'weekdays' },
+      { show_empty_days: true },
+    );
+
+    expect(Object.keys(placeholders)).toContain(DATES.saturday);
+    expect(placeholders[DATES.saturday]).toBe('No upcoming events');
+  });
+
+  /**
+   * The denominator for both. Unfiltered, that Saturday carries a real event and no
+   * placeholder, so the two cases above describe a day the filter emptied rather than one
+   * that was empty all along.
+   */
+  it('control: unfiltered, the same Saturday carries an event and no placeholder', () => {
+    expect(render(week, {}, { show_empty_days: true })[DATES.saturday]).toEqual(['Saturday']);
+    expect(Object.keys(placeholderDays(week, {}, { show_empty_days: true }))).not.toContain(
+      DATES.saturday,
+    );
+  });
+});
+
+describe('days_of_week: it is one calendar\u2019s setting, not the card\u2019s', () => {
+  /**
+   * The request this option exists for. Two calendars, one filtered and one not, on the
+   * same card: the school calendar loses its weekend, the family calendar keeps it.
+   */
+  it('leaves other calendars alone', () => {
+    const config = buildConfig({
+      entities: [
+        { entity: 'calendar.holidays', days_of_week: 'weekdays' },
+        { entity: 'calendar.family' },
+      ],
+      days_to_show: 9,
+    } as Partial<Types.Config>);
+
+    const events: Types.CalendarEventData[] = [
+      {
+        ...timed('School Saturday', DATES.saturday),
+        _matchedConfig: {
+          entity: 'calendar.holidays',
+          days_of_week: 'weekdays',
+        } as Types.EntityConfig,
+      },
+      {
+        summary: 'Family Saturday',
+        start: { dateTime: `${DATES.saturday}T14:00:00.000Z` },
+        end: { dateTime: `${DATES.saturday}T15:00:00.000Z` },
+        _entityId: 'calendar.family',
+        _matchedConfig: { entity: 'calendar.family' } as Types.EntityConfig,
+      },
+    ];
+
+    const days = groupEventsByDay(events, config, true, 'en');
+    const rendered = days.flatMap((day) => day.events.map((event) => event.summary));
+
+    expect(rendered).toEqual(['Family Saturday']);
+  });
+});
+
+describe('days_of_week: a value the union does not name', () => {
+  /**
+   * A typo shows too much, never too little — the principle `resolveEventType` follows.
+   * The alternative is a calendar that silently empties because someone wrote `weekday`.
+   */
+  it.each(['weekday', 'all', '', 'WEEKDAYS'])('%s filters nothing', (value) => {
+    const week = [timed('Saturday', DATES.saturday), timed('Monday', DATES.nextMonday)];
+
+    expect(summaries(render(week, { days_of_week: value as Types.DaysOfWeekFilter }))).toEqual([
+      'Saturday',
+      'Monday',
+    ]);
+  });
+});

--- a/tests/editor-filter.test.ts
+++ b/tests/editor-filter.test.ts
@@ -824,11 +824,11 @@ describe('editor: the order of the two panels', () => {
       'accent_color_mode',
       'accent_color',
       '# heading_filters',
+      'days_of_week',
       'event_type',
+      'allday_expires_at',
       'blocklist',
       'allowlist',
-      'allday_expires_at',
-      'days_of_week',
       'compact_events_to_show',
       '# heading_multiday',
       'split_multiday_events',
@@ -887,14 +887,54 @@ describe('editor: the order of the two panels', () => {
 
     expect(content.filter((name) => shared.includes(name))).toEqual(shared);
 
-    // And the shared categories must start with the same key, since `event_type` is the
-    // one option both panels put under `heading_filters`.
-    const firstUnder = (schema: ReadonlyArray<HaFormSchema>, name: string) => {
+    /**
+     * The options a panel lists under one heading, in render order.
+     *
+     * @param schema - Panel or group schema
+     * @param name - Heading key to read under
+     * @returns The option names between that heading and the next one
+     */
+    const optionsUnder = (schema: ReadonlyArray<HaFormSchema>, name: string) => {
       const seq = sequence(schema);
-      return seq[seq.indexOf(`# ${name}`) + 1];
+      const from = seq.indexOf(`# ${name}`) + 1;
+      const rest = seq.slice(from);
+      const until = rest.findIndex((entry) => entry.startsWith('# '));
+
+      return (until === -1 ? rest : rest.slice(0, until)).filter(Boolean);
     };
 
-    expect(firstUnder(entitySchema(), 'heading_filters')).toBe('event_type');
-    expect(firstUnder(contentSchema(), 'heading_filters')).toBe('event_type');
+    // What the two panels put under `heading_filters`, pinned by value so a key joining or
+    // leaving either side is a deliberate edit rather than a silently smaller comparison.
+    const entityFilters = optionsUnder(entitySchema(), 'heading_filters');
+    const contentFilters = optionsUnder(contentSchema(), 'heading_filters');
+
+    expect(entityFilters).toEqual([
+      'days_of_week',
+      'event_type',
+      'allday_expires_at',
+      'blocklist',
+      'allowlist',
+      'compact_events_to_show',
+    ]);
+    expect(contentFilters).toEqual(['event_type', 'show_past_events', 'filter_duplicates']);
+
+    /**
+     * The invariant, stated over the options the two panels actually share.
+     *
+     * This replaces a "both panels start `heading_filters` with the same key" assertion,
+     * which was a **proxy** that held only while `event_type` was the sole shared option
+     * and every other key sat after it. The per-calendar panel now opens with
+     * `days_of_week`, which is per-calendar only — there is no card-level counterpart to
+     * disagree with — so the proxy went false without anything being wrong. Relative order
+     * over the intersection is the property that was actually meant.
+     *
+     * At one shared option this is trivially satisfied, which is why the set is pinned
+     * above: the assertion becomes real the moment a second key is shared, and cannot go
+     * quietly vacuous by one panel dropping a key in the meantime.
+     */
+    const sharedFilters = entityFilters.filter((name) => contentFilters.includes(name));
+
+    expect(sharedFilters).toEqual(['event_type']);
+    expect(contentFilters.filter((name) => sharedFilters.includes(name))).toEqual(sharedFilters);
   });
 });

--- a/tests/editor-filter.test.ts
+++ b/tests/editor-filter.test.ts
@@ -827,6 +827,8 @@ describe('editor: the order of the two panels', () => {
       'event_type',
       'blocklist',
       'allowlist',
+      'allday_expires_at',
+      'days_of_week',
       'compact_events_to_show',
       '# heading_multiday',
       'split_multiday_events',

--- a/tests/editor-schema.test.ts
+++ b/tests/editor-schema.test.ts
@@ -2702,11 +2702,13 @@ describe('editor: per-calendar settings', () => {
       [
         'accent_color',
         'accent_color_mode',
+        'allday_expires_at',
         'event_type',
         'allowlist',
         'blocklist',
         'color',
         'compact_events_to_show',
+        'days_of_week',
         'label',
         'label_icon_color',
         'label_type',
@@ -2831,6 +2833,7 @@ describe('editor: per-calendar settings', () => {
       show_description: ['inherit', 'show', 'hide'],
       split_multiday_events: ['inherit', 'split', 'whole'],
       event_type: ['inherit', 'all', 'timed', 'all_day'],
+      days_of_week: ['inherit', 'weekdays', 'weekends'],
     });
 
     expect(ENTITY_TRISTATE_STORED).toEqual({
@@ -2839,6 +2842,7 @@ describe('editor: per-calendar settings', () => {
       show_description: { inherit: undefined, show: true, hide: false },
       split_multiday_events: { inherit: undefined, split: true, whole: false },
       event_type: { inherit: undefined, all: 'all', timed: 'timed', all_day: 'all_day' },
+      days_of_week: { inherit: undefined, weekdays: 'weekdays', weekends: 'weekends' },
     });
 
     // Every offered value must be storable, and nothing may be storable that is not
@@ -4141,7 +4145,14 @@ describe('editor: exceptions for the union-typed options', () => {
  * A panel only offers what the configuration in front of it calls for, so the weather
  * and column dropdowns exist only once those features are configured.
  *
- * @returns Each dropdown's field name mapped to the values it offers
+ * Sub-forms are walked too, and their fields are keyed by path — `entity.days_of_week`
+ * rather than `days_of_week`. Without the prefix a per-calendar dropdown would overwrite
+ * the card-level one of the same name, silently swapping which surface each case below
+ * asserts about; `event_type` exists on both, and the per-calendar copy carries an extra
+ * `inherit`. Sub-forms went unwalked entirely until a per-calendar-only option needed
+ * checking, so `event_type` was passing on its card-level dropdown alone.
+ *
+ * @returns Each dropdown's field name, path-qualified for sub-forms, mapped to its values
  */
 function editorOptions(): Map<string, string[]> {
   const configs = [
@@ -4152,20 +4163,30 @@ function editorOptions(): Map<string, string[]> {
   ] as Types.Config[];
 
   const found = new Map<string, string[]>();
-  for (const config of configs) {
-    for (const panel of PANELS) {
-      const schema = panel.build({ view: config.view, config, language: 'en' });
-      for (const { node } of walkSchema(schema)) {
-        const options = (node as { selector?: { select?: { options?: unknown[] } } }).selector
-          ?.select?.options;
-        if (!node.name || !options) continue;
 
-        found.set(
-          node.name,
-          options.map((option) =>
-            typeof option === 'string' ? option : (option as SelectOption).value,
-          ),
-        );
+  const collect = (schema: ReadonlyArray<HaFormSchema>, prefix: string) => {
+    for (const { node } of walkSchema(schema)) {
+      const options = (node as { selector?: { select?: { options?: unknown[] } } }).selector?.select
+        ?.options;
+      if (!node.name || !options) continue;
+
+      found.set(
+        prefix + node.name,
+        options.map((option) =>
+          typeof option === 'string' ? option : (option as SelectOption).value,
+        ),
+      );
+    }
+  };
+
+  for (const config of configs) {
+    const ctx = { view: config.view, config, language: 'en' };
+
+    for (const panel of PANELS) {
+      collect(panel.build(ctx), '');
+
+      for (const subform of panel.subforms?.(ctx) ?? []) {
+        collect(subform.schema, `${subform.path.join('.')}.`);
       }
     }
   }
@@ -4189,6 +4210,11 @@ describe('editor: enumerated options offer their whole vocabulary', () => {
     // `inherit`, which is the absent key rather than a mode of its own, so the card-level
     // control is the one whose vocabulary must match the union exactly.
     event_type: { field: 'event_type' },
+    // Per-calendar only, so the only dropdown of this name is the one carrying `inherit`.
+    // Unlike `event_type` there is no card-level control to compare against, and unlike
+    // `event_type` the union has no `all`: absent *is* every day, and `inherit` is how a
+    // dropdown spells absent — the same accommodation `show_week_numbers` needs for `null`.
+    days_of_week: { field: 'entity.days_of_week', editorOnly: ['inherit'] },
   };
 
   /**

--- a/tests/entity-colors.test.ts
+++ b/tests/entity-colors.test.ts
@@ -560,6 +560,7 @@ describe('entity colours: every per-calendar dropdown round-trips', () => {
         .sort(),
     ).toEqual([
       'accent_color_mode',
+      'days_of_week',
       'event_type',
       'label_type',
       'show_description',

--- a/tests/entity-config-reprocess.test.ts
+++ b/tests/entity-config-reprocess.test.ts
@@ -65,6 +65,8 @@ const PER_CALENDAR_OPTIONS: ReadonlyArray<[string, unknown, unknown]> = [
   ['allowlist', 'standup', 'retro'],
   ['split_multiday_events', true, false],
   ['event_type', 'all_day', 'timed'],
+  ['days_of_week', 'weekdays', 'weekends'],
+  ['allday_expires_at', '10:00', '18:00'],
 ];
 
 /**

--- a/tests/local-day-filters.dst.test.ts
+++ b/tests/local-day-filters.dst.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Both per-calendar filters must read the **local** calendar, not UTC.
+ *
+ * This file is excluded from the `unit` project and run three times instead — under
+ * `Europe/Berlin`, `Australia/Sydney` and `America/New_York` (see `projects` in
+ * `vitest.config.mjs`). That is not redundancy. The rest of the suite pins `TZ=UTC`, which
+ * is the right default and is also exactly why it cannot see this: under UTC the local
+ * calendar and the UTC calendar are the same calendar, so an implementation reading either
+ * one passes every assertion in `days-of-week-filter.test.ts` and `allday-expiry.test.ts`.
+ *
+ * Two one-word edits are the whole risk, and each is the kind that reads as a tidy-up:
+ *
+ * - `getDay()` → `getUTCDay()` in `isWeekendDate`, which moves a Friday-evening event into
+ *   Saturday for everyone west of Greenwich and a Saturday-morning one into Friday for
+ *   everyone east of it.
+ * - `setHours()` → `setUTCHours()` in the expiry instant, which retires a 10:00 bin at
+ *   06:00 in New York and at noon in Berlin.
+ *
+ * Neither changes a single character of rendered output under UTC.
+ *
+ * **Why three zones and not one.** The two weekday fixtures below straddle a local
+ * midnight in opposite directions, and which of them disagrees with UTC depends on the
+ * sign of the offset: east of Greenwich it is the Saturday-morning event, west of it the
+ * Friday-evening one. Berlin and Sydney are both ahead of UTC and so exercise the same
+ * half; New York is the only one of the three that exercises the other. A control below
+ * asserts that at least one fixture genuinely disagrees with UTC, so the pair can never
+ * pass vacuously in a zone that happens to align.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import { groupEventsByDay } from '../src/utils/events';
+
+/** Friday 22:30 local, one hour long, so it does not cross a local midnight and split. */
+const LATE_FRIDAY = new Date(2026, 5, 19, 22, 30);
+
+/** Saturday 00:30 local, likewise. */
+const EARLY_SATURDAY = new Date(2026, 5, 20, 0, 30);
+
+/**
+ * Group one calendar's events and return the summaries that survived.
+ *
+ * @param events Events to group
+ * @param entity The calendar's own settings
+ * @param overrides Card configuration beyond the defaults
+ * @returns The surviving real summaries, placeholders excluded
+ */
+function render(
+  events: Types.CalendarEventData[],
+  entity: Partial<Types.EntityConfig>,
+  overrides: Partial<Types.Config> = {},
+): string[] {
+  const config = buildConfig({
+    entities: [{ entity: 'calendar.local', ...entity }],
+    days_to_show: 7,
+    ...overrides,
+  } as Partial<Types.Config>);
+
+  const stamped = events.map((event) => ({
+    ...event,
+    _matchedConfig: { entity: 'calendar.local', ...entity } as Types.EntityConfig,
+  }));
+
+  return groupEventsByDay(stamped, config, true, 'en')
+    .flatMap((day) => day.events)
+    .filter((event) => !event._isEmptyDay)
+    .map((event) => event.summary ?? '');
+}
+
+/**
+ * A one-hour timed event beginning at a local instant.
+ *
+ * Built from a local `Date` and serialized to an ISO instant, which is how a real feed
+ * delivers one: the wire format is absolute and the weekday is a question about where the
+ * user is standing.
+ *
+ * @param summary Event title
+ * @param localStart Local instant it begins at
+ * @returns The event
+ */
+function timedAt(summary: string, localStart: Date): Types.CalendarEventData {
+  const end = new Date(localStart.getTime() + 60 * 60 * 1000);
+
+  return {
+    summary,
+    start: { dateTime: localStart.toISOString() },
+    end: { dateTime: end.toISOString() },
+    _entityId: 'calendar.local',
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('the zone these tests need', () => {
+  /** Without this, a file silently run under UTC would prove nothing and still pass. */
+  it('observes DST', () => {
+    expect(new Date(2026, 0, 1).getTimezoneOffset()).not.toBe(
+      new Date(2026, 6, 1).getTimezoneOffset(),
+    );
+  });
+
+  /**
+   * The denominator for the weekday cases. If neither fixture disagreed with UTC, both
+   * readings would answer identically and the two assertions below would be decoration.
+   */
+  it('puts at least one weekday fixture on a different date in UTC', () => {
+    const disagreeing = [LATE_FRIDAY, EARLY_SATURDAY].filter(
+      (instant) => instant.getUTCDay() !== instant.getDay(),
+    );
+
+    expect(
+      disagreeing.length,
+      'no fixture discriminates local from UTC in this zone',
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe('days_of_week reads the local weekday', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Friday morning, local, so both fixtures are ahead of now and inside the window.
+    vi.setSystemTime(new Date(2026, 5, 19, 8, 0));
+  });
+
+  const both = () => [
+    timedAt('Friday evening', LATE_FRIDAY),
+    timedAt('Saturday morning', EARLY_SATURDAY),
+  ];
+
+  it('keeps the Friday-evening event under weekdays and drops the Saturday-morning one', () => {
+    expect(render(both(), { days_of_week: 'weekdays' })).toEqual(['Friday evening']);
+  });
+
+  it('does the exact opposite under weekends', () => {
+    expect(render(both(), { days_of_week: 'weekends' })).toEqual(['Saturday morning']);
+  });
+
+  it('control: unfiltered, this zone shows both', () => {
+    expect(render(both(), {}).sort()).toEqual(['Friday evening', 'Saturday morning']);
+  });
+});
+
+describe('allday_expires_at fires at the local clock time', () => {
+  /** An all-day event on Wednesday 17 June, expiring at 10:00. */
+  const bin = (): Types.CalendarEventData[] => [
+    {
+      summary: 'Green bin',
+      start: { date: '2026-06-17' },
+      end: { date: '2026-06-18' },
+      _entityId: 'calendar.local',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('is still showing one minute before 10:00 local', () => {
+    vi.setSystemTime(new Date(2026, 5, 17, 9, 59));
+
+    expect(render(bin(), { allday_expires_at: '10:00' })).toEqual(['Green bin']);
+  });
+
+  it('is gone one minute after 10:00 local', () => {
+    vi.setSystemTime(new Date(2026, 5, 17, 10, 1));
+
+    expect(render(bin(), { allday_expires_at: '10:00' })).toEqual([]);
+  });
+
+  /**
+   * The denominator. Without the option the same event survives both instants, so the pair
+   * above is the expiry working rather than the window excluding a fixture this zone
+   * happens to place elsewhere.
+   */
+  it('control: unset, it survives both instants', () => {
+    vi.setSystemTime(new Date(2026, 5, 17, 9, 59));
+    expect(render(bin(), {})).toEqual(['Green bin']);
+
+    vi.setSystemTime(new Date(2026, 5, 17, 10, 1));
+    expect(render(bin(), {})).toEqual(['Green bin']);
+  });
+
+  /**
+   * A UTC reading would put the expiry hours away from 10:00 local in every zone this file
+   * runs under, so this states the gap rather than leaving it to the two cases above to
+   * imply. Berlin and Sydney are ahead of UTC and would expire late; New York is behind and
+   * would expire early.
+   */
+  it('control: 10:00 local is not 10:00 UTC in this zone', () => {
+    const localTen = new Date(2026, 5, 17, 10, 0);
+
+    expect(
+      localTen.getUTCHours(),
+      'this zone is on UTC, so the pair above proves nothing',
+    ).not.toBe(10);
+  });
+});


### PR DESCRIPTION
Two per-calendar filters, plus a bug the review of this branch turned up in the same three lines.

Closes #163
Closes #225

## 🐛 A finished all-day event kept its row

Found by @alexpfau reviewing the test cards, and it is the change most existing users will notice.

With `show_past_events: false` a timed event disappears when it ends and an all-day one never did. An all-day event has no end *instant* — its end is a date, and `endDate` is local midnight at the **start** of the last day — so `endDate < now` would have retired *today's* event at 00:00:01, and the card avoided that by exempting all-day events from expiry altogether. Right for today, wrong for every day before it.

It is invisible at the default `start_date`, which is why it shipped: the window filter already requires `endDate >= referenceStart`, so a finished all-day event is dropped for being outside the window instead, and the two reasons cannot be told apart. Only a backward-looking window separates them — `start_date: 'today-7'`, or `start_of_week` read mid-week, which the start-date docs actively **recommend** pairing with past events hidden.

**Left: the released card. Right: this build. Identical YAML — the Saturday that finished five days ago is the whole defect.**

![Released card versus this build](https://github.com/user-attachments/assets/8babf6f5-fb26-440e-a4dd-5be53bf15fce)

The fix and the feature are now one rule at two settings: an all-day event is past at **midnight after its last day**, and `allday_expires_at` moves that instant earlier within the final day. Users with a backward-looking window will see finished all-day entries disappear; that is the point, and the release notes say so.

The whole suite stayed green across the fix — the same signal from the other side, that nothing covered it. Seven tests added, pinning the default rather than the option.

## 🏷️ The editor called `show_past_events` "Show Today's Past Events"

Also from review. It shows every past event inside the card's configured **window**, not only today's, so on a card starting a week back the label described a fraction of what the switch did. Now "Show Past Events", with the word for *today* removed from all nine translated editor languages — each a standalone modifier (`von heute`, `di oggi`, `dagens`, …) deletable without touching the grammar of the surviving words, so these are deletions rather than new translations. Worth a native-speaker glance on the translation branch.

## 🗑️ `allday_expires_at` — #163

The two filters are grouped because they are the same kind of thing in the same place: both are render-time, both read `_matchedConfig` in `groupEventsByDay`, and both run **after** multi-day splitting rather than before it.

With the default above corrected, an all-day event is past at midnight. Stefan765's waste-collection feed is published by a council he cannot edit, and midnight is still hours too late — the bin was emptied in the morning.

`allday_expires_at: '10:00'` moves that instant earlier within the final day. The time is read against the event's **last** day, so a three-day trip clears on the morning it ends. It is scoped to `show_past_events: false` because it decides *when* an event becomes past, not whether past events are drawn — two competing visibility rules over the same events would be unpredictable.

Nothing schedules a render at the configured time; the card's only timer is the refresh interval. Documented, not implied.


**Left: no option — Saturday 15 August still listed, five days after it happened. Right: `allday_expires_at: '10:00'` — the stale row is gone and the coming Saturday stays.**

![Before and after, all-day expiry](https://github.com/user-attachments/assets/df6dbe4f-185d-4ca0-93e0-85798ec66046)

## 📅 `days_of_week` — #225

Takes `weekdays` or `weekends` for a single calendar. nytram-md's school-holidays calendar spans whole holidays including weekends, on a card carrying other calendars whose weekend entries must stay — so narrowing the card's date window cannot express it.

It judges the **display date** — the day the row lands on — not the event's own start. An event already running when the window opens is clamped to the window's first day, so a start-date reading answers about a day the card is not drawing. That is the whole difficulty of this one.

There is deliberately **no `all` member**, unlike `EventType`. With no card-level value to override, an explicit `all` would mean exactly what the absent key means, leaving two dropdown entries sharing one behavior and, inevitably, one label between them.


**Unfiltered, then `weekdays`, then `weekends` — exact complements, six rows split three and three.**

![Weekday and weekend filtering](https://github.com/user-attachments/assets/ab0db191-4cfb-4307-8067-8e3269ad624c)

**The request itself: family restricted to weekdays (blue), personal untouched (pink). Sunday 23 keeps only the pink event — family's Spring Cleaning is filtered while the other calendar keeps its weekend.**

![One calendar filtered, one not](https://github.com/user-attachments/assets/64e09b71-d52b-41f0-a95f-1b46cea3ddef)

## Neither key is a `PROCESSING_TIME_KEYS` member

Confirmed rather than assumed. Both are read while events are **grouped**, not processed, so nothing is baked into `this.events` and an edit reaches the screen on the next render. Being per-calendar-only, `serializeEntities` also forces a reprocess whenever either changes — belt and braces, but the render-time read is the load-bearing half.

## Also here, because the work required it

- **`isWeekendDate` moves** from `rendering/leaves.ts` to `utils/format.ts`. The filter needed the card's existing definition of weekend; `leaves.ts` imports `utils/events.ts`, so reaching it in place meant a cycle, and a second copy would let the weekend colors and the weekend filter disagree about a Friday.
- **`resolveDisplayDate` extracted** from the grouping pass, so the filter and the renderer cannot drift on which day a row belongs to. Behavior-preserving — the DOM snapshots are untouched.
- **The editor's dropdown walker now walks sub-forms**, path-qualified. It walked panels only, so every per-calendar dropdown was unchecked and `event_type` was passing on its card-level copy alone.
- **`check-docs.mjs` check 21 now reads the per-entity table** in `core-settings.md` as well as the reference tables. Per-calendar-only options never reach the reference, so `days_of_week` was discovered by the parser and silently skipped — the enumerated-option count staying at 6 was the tell. It is 7 now, and planting a missing value fires it.
- **Transfer sizes updated**: +882 raw / +311 gzip-9 on the card, +977 / +281 on the editor, measured under the pinned Node 22.

**Blast radius of the gate change, checked rather than assumed.** Widening check 21 could in principle fail a PR that was green before it, so: at the time it landed there were **no other open PRs** — `gh pr list --state open` returned empty, and #537 had already merged at 20:41 UTC. Nobody's green run is invalidated and no rebase is owed. Had a PR been open and adding a per-calendar-only enumerated option, it would have needed a rebase and a re-run before merging.

## 🏷️ Editor ordering, and a habit rather than a fix

The filter section reads **Days of the Week → Event Type → All-Day Events Expire At → Blocklist → Allowlist → Compact Events to Show** — coarse-to-fine by **scope**, not by the order the card applies them in. I had appended both new options after the pattern fields, which optimizes for the pipeline rather than for a reader narrowing a set.

The general point, recorded on the schema itself: **a new option's position inside its section is a decision, not a default.** Raised on two consecutive PRs, so it is now a comment where the next person will hit it.

That change falsified one gate, and it was a proxy rather than the invariant: `orders every shared category the same way in both panels` asserted both panels start `heading_filters` with the same key — true only while `event_type` was the sole shared option. Replaced with relative order over the **intersection**, with both filter lists pinned by value beside it so the assertion becomes real when a second key is shared rather than staying quietly vacuous.

## 🧪 What only the live tab could catch

Section 3 of the test tab went empty, and my note blamed a deleted fixture. It was still there — **section 1's own bug fix removed it.** The fixture was an all-day event ending 18 August, the new midnight rule made it past, and `show_past_events: false` dropped it. The code was right and the cards were wrong.

**The unit tests are structurally incapable of seeing this.** They build events against a frozen clock, so a fixture is always exactly the age the test says it is; a fixture drifting into the past relative to a live instance is invisible to them. That is the argument for the live tab existing at all, and it is why both replacement fixtures now **recur** — a one-off "today" event would have drifted past at midnight and left three cards empty by morning.

## Verification

Six mutants run against the new tests; every one fails, and each is named in the test docblocks:

| mutant | caught by |
| --- | --- |
| weekday filter reads `startDate` | 3 tests, both directions |
| expiry reads the start day | the multi-day case |
| `now > expiresAt` instead of `>=` | the exact-minute case |
| parse accepts anything | 6 tests |
| expiry applies to timed events | the timed control |
| expiry ignores `show_past_events` | the scoping case |

The first fixture for the display-date case did **not** catch its own mutant — a Wednesday start drawn on a Monday means both readings agree. Replaced with fixtures that straddle the weekday line in each direction.

`tests/local-day-filters.dst.test.ts` pins the property neither UTC-pinned file can see: both filters read the **local** calendar. `getDay()` → `getUTCDay()` and `setHours` → `setUTCHours` are each invisible to the `unit` project and caught by all three zones.

All nine gates green. Live-verified on Home Assistant at `?v=400` — every card matched its predicted rows, the editor shows both fields in the intended order, and the new dropdown holds across all six ordered transitions.



