### PR TITLE
docs(core-settings): document hiding a location that is a meeting URL

### DIFF
--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -328,6 +328,34 @@ Teams meetings need no allowlist to get their icon; that happens on its own. Thi
 is for when you want the two halves styled differently, or want a specific icon on the
 half that is _not_ a Teams call.
 
+### Hiding a Location That Is Really a Meeting URL
+
+Online meetings tend to put a long join URL where a room name should be, and one of those
+across a card is enough to unbalance every row around it. You usually still want the
+event — just not that line of text under it.
+
+`show_location` is a per-calendar option, so the partition above solves this too. Split
+the calendar on the pattern and turn the location off on the half that carries the URL:
+
+```yaml
+entities:
+  - entity: calendar.work
+    filter_field: location
+    allowlist: 'zoom\.us|teams\.microsoft\.com|meet\.google\.com'
+    show_location: false
+  - entity: calendar.work
+    filter_field: location
+    blocklist: 'zoom\.us|teams\.microsoft\.com|meet\.google\.com'
+```
+
+The online meetings keep their title, their time and their icon and lose only the URL.
+Every other event on the same calendar still shows its room, because the second block
+never had the option set.
+
+Swap `show_location` for `show_description` to do the same to a description, or set both
+if the URL appears twice. And if you would rather those events were gone altogether,
+delete the first block — a lone `blocklist` filters them out instead of quieting them.
+
 ### Separating All-Day From Timed Events
 
 The `event_type` option decides which class of event a calendar contributes. It takes three


### PR DESCRIPTION
Closes the code half of #186 as already-shipped, and fills the documentation gap that hid it.

## What #186 asked for

> Hide or display location based on a regex expression

The reporter offered three mechanisms — hide on match, replace the value, or a "hide location if URL" boolean. The want behind all three is that a long Zoom URL sitting in the location field is ugly.

**The hide half already ships.** `show_location` is on `EntityConfig` (`src/config/types.ts:296`) and is read per-entity at render (`src/utils/events.ts:575`), so the same partition pattern already documented for Teams solves it:

```yaml
entities:
  - entity: calendar.work
    filter_field: location
    allowlist: 'zoom\.us'
    show_location: false
  - entity: calendar.work
    filter_field: location
    blocklist: 'zoom\.us'
```

## Verified live, not just read

Built the dev bundle, deployed it, and rendered a Zoom fixture alongside events with ordinary room locations. The matching events render title and time with **no location row**; every other event keeps its location. That is the behavior this section now documents.

## Why it needed writing down

`show_location: false` did not appear once in `core-settings.md`. Finding this required knowing the option was per-calendar _and_ thinking to combine it with a filter partition — two facts documented separately and never joined. A reporter asking for the feature is evidence the composition was not discoverable.

## What is not here

The reporter's third option — _replace_ the location with a friendlier string — still has no answer. That belongs to `epic:text-transform` and is deliberately not built speculatively; if hiding turns out not to be enough, it earns its keys then.

## Gates

`format`, `check:format`, `check:docs`, `docs:build` all green. Docs-only change, no `src/` files touched.
