### PR TITLE
docs(release): track #251 as half-served, and say why the list must mark those

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -793,6 +793,15 @@ vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements.
    this way to _Related Issues_ in `docs/RELEASE_NOTES.md`, so the next person auditing
    the same release does not have to rediscover it.
 
+   **A half-served issue goes in that list too, marked so it is not closed.** The list is
+   read at release time _as a close-list_, so the two mistakes it can produce are opposite
+   and both silent: an issue left out is forgotten, and an issue left in is closed on a
+   request the release only partly answered. Neither is visible afterwards, because a
+   wrongly-closed issue looks exactly like a correctly-closed one. Write **do not close**
+   in the entry and say which half shipped — #251 asked for all-day _and_ multi-day
+   filtering and got the first, and would otherwise have been closed by anyone working
+   the list mechanically.
+
 `hacs.json` pins the distributed filename to `calendar-card-pro.js` — do not rename it.
 HACS downloads every asset attached to a release, so it gets the editor without being told
 about it; `filename` only selects which asset becomes the Lovelace resource.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -78,6 +78,7 @@ That is eleven editor languages in total, counting US English in code and Britis
 ## Related Issues
 
 - [#132](https://github.com/alexpfau/calendar-card-pro/issues/132) - Filter based on all-day events by @syst3x
+- [#251](https://github.com/alexpfau/calendar-card-pro/issues/251) - Blocklist based on the duration of events by @tommi1968 — **half-served, do not close.** `event_type: timed` answers the all-day half; the multi-day half needs a span axis the card cannot yet express, because it holds three disagreeing answers to what counts as multi-day. The reporter has been asked which behavior they want for an event running 23:30 to 00:30 and has not yet replied
 - [#163](https://github.com/alexpfau/calendar-card-pro/issues/163) - All-day events that should disappear during the day by @Stefan765
 - [#186](https://github.com/alexpfau/calendar-card-pro/issues/186) - Hide or display location based on a regex expression by @mrtag23, with the two-block pattern suggested by @sebatze
 - [#188](https://github.com/alexpfau/calendar-card-pro/issues/188) - Use a calendar entity's own attributes to configure it by @shmuelie — both halves now: the color in #314, and the icon here


### PR DESCRIPTION
Two related fixes to the release bookkeeping, found by auditing v4.1's `## Related Issues` list against the open backlog.

## #251 was missing from the list

[#251](https://github.com/alexpfau/calendar-card-pro/issues/251) asked for filtering on event duration — specifically that "appointments over several days **or** all-day appointments should not be displayed."

`event_type: timed` answers the all-day half. The multi-day half does not ship, because the card holds three disagreeing answers to what counts as multi-day (documented in `AGENTS.md`), and the span axis was deliberately deferred until it picks one.

So the issue is half-served, and appeared **nowhere** in the release notes. At release it would have gone unnoticed and stayed open with no record that v4.1 partly answered it — the same class of miss that left six resolved requests open at v4.0.0.

It is now listed, with an explicit **do not close** marker and a note on which half shipped. The reporter was asked in-thread which behavior they want for an event running 23:30 to 00:30 and has not yet replied; that answer is what unblocks the remaining half.

## The list has two opposite failure modes and documented neither

`AGENTS.md` already says to comment and leave a half-served issue open, and to add anything found this way to Related Issues. What it did not say is that those two instructions interact badly.

The list is read at release time **as a close-list**. So:

- an issue left **out** is forgotten;
- an issue left **in** is closed, on a request the release only partly answered.

Both are silent, and the second is worse, because a wrongly-closed issue is indistinguishable from a correctly-closed one after the fact — there is no artifact to audit against. Following the existing instruction to add half-served issues to the list, without also marking them, actively causes the second failure.

Step 7 of the release process now says to mark them, with #251 as the worked example.

## Gates

`format`, `check:format`, `check:docs`, `docs:build` all green. Docs-only, no `src/` files touched.
