### PR TITLE
fix(check-docs): stop the summary claiming release surfaces agree on a failing run

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1590,7 +1590,7 @@ function report(counts) {
       `${counts.citations} line citations resolved, ` +
       `${counts.languages} language counts reconciled, ` +
       `${counts.readmeAnchors} README anchor links checked, ` +
-      `release surfaces agree on v${counts.version}.\n`,
+      `release surfaces checked against v${counts.version}.\n`,
   );
 
   if (errors.length) {


### PR DESCRIPTION
A one-clause fix to `check-docs.mjs`'s summary line, found while probing whether v4.1's release surfaces would pass the version gate on release day.

## What happens

`report()` prints its summary **unconditionally**, before the error list. So a failing run announces:

```
… 1 README anchor links checked, release surfaces agree on v4.2.0.

3 error(s):
  ✗ docs/RELEASE_NOTES.md has no "# Calendar Card Pro v4.2.0" section …
  ✗ docs/guide/whats-new.md has no "## v4.2" entry …
  ✗ README.md's What's New section does not mention v4.2 …
```

It states the surfaces agree, immediately above three errors saying they do not.

## Why that clause and no other

Every other clause on that line is a **count of what was inspected** — "94 defaults in code", "162 internal links resolved", "21 pages". Those stay truthful on a failing run, because a link that failed to resolve is not counted among the resolved ones.

The release clause was the only one asserting a **verdict**, and a verdict has no business on a line printed before the checks are evaluated. It now describes what was inspected, like its neighbours, and the verdict is left to the `Documentation does not match the code.` line that already exists for it.

## Why it matters beyond tidiness

The summary is the last line before the errors and the natural thing to grep for or to read off a tail. I hit this myself: probing the gate with a deliberately unsupported version, my first read of the output was the summary, which told me the surfaces agreed. They did not.

`AGENTS.md` devotes a section to checks that appear to establish something they have not. A summary that announces agreement on a failing run is that failure in its purest form — it is not a wrong check, it is a correct check with a misleading label, which is harder to notice precisely because the underlying logic is sound.

## Verified both directions

- **Fail case** — `package.json` set to a version with no surfaces: 3 errors, exit 1, and the summary now reads `release surfaces checked against v4.2.0`.
- **Pass case** — the real repository state: exit 0, wording reads correctly.
- Zero remaining occurrences of the old phrase anywhere in `AGENTS.md`, `docs/`, `scripts/`, `.github/`, `tests/` or the README, confirmed with a corrected count (the first attempt read `head`'s exit status through a pipe rather than grep's — the trap `AGENTS.md` documents).

## Also confirmed while here, needing no change

v4.1's three release surfaces — the `# Calendar Card Pro v4.1.0` notes section, the `## v4.1` archive entry, and the README's What's New — **already pass**. Bumping `package.json` at release time will not fail this gate. That had never been exercised, because the gate keys off the shipped version and `package.json` is still `4.0.0` until the release commit.

`format`, `check:format`, `check:docs`, `docs:build` green.
