### PR TITLE
docs(release): give v4.1.0 an opening that states the per-calendar story

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -4,6 +4,8 @@ title: Release Notes
 
 # Calendar Card Pro v4.1.0
 
+**Per-calendar filtering and styling, and an editor that can list one calendar twice so each copy answers differently.** A calendar used to be one thing: you added it, and it contributed all of its events, styled one way. This release takes that apart. Filter a calendar on its location or its description, keep only its all-day events or only its timed ones, retire all-day events partway through the day, show a calendar on weekdays alone — each of those is set per calendar, so listing the same calendar twice gives you two blocks that filter and style themselves independently. The editor's new **Duplicate** button builds the second block for you. The card also takes the color and icon Home Assistant already holds for a calendar, so anything you have themed once is themed here too.
+
 ## 🎉 New Features
 
 ### 🎨 Follow the Colors and Icons Home Assistant Holds


### PR DESCRIPTION
v4.1.0 was the only release in this file with **no opening paragraph** — the heading ran straight into `## 🎉 New Features` and then nine features with nothing tying them together.

**This is a draft in your voice. Rewrite it freely; I am proposing the shape, not the words.**

## The gap

Every other release opens by saying what it is about:

- **v3.5.0** (105 words) — "…This release is mostly about fitting the card to the dashboard around it…"
- **v3.6.0** (89 words) — "**A documentation site of its own, and six fixes for defects that made the card look broken rather than merely wrong.**…"
- **v4.0.0** (363 words) — header image, "**This is a big one.** 🎉", then the story of #14.

v4.1.0 had none, so a reader met nine features — inherited colors, event types, expiring all-day events, weekday filtering, a Teams icon, location filtering, editor sub-headings, Duplicate, translations — with no signal that they are one thing. They read as scattered when they are not.

## The story the release actually has

A calendar used to be one thing: you added it, and it contributed all of its events, styled one way. Nine features later, one calendar can be several — and the through-line is that **the options deciding what a calendar contributes are all per calendar now**, with **Duplicate** as the thing that makes them usable.

Verified against `EntityConfig` in `src/config/types.ts` rather than asserted — `filter_field`, `event_type`, `days_of_week`, `allday_expires_at`, plus `label`, `label_type`, `accent_color`, `label_icon_color` and `show_location` are all per-calendar. The intro claims nothing that is not on that interface.

## Deliberate omissions

The Teams icon, the editor sub-headings and the translations are **not** mentioned. The first is automatic rather than per-calendar, and the other two are not features a user chooses. Naming all nine would have produced the list the intro exists to replace. They keep their own sections.

## Length

135 words, between v3.5.0's 105 and v4.0.0's 363. Longer than v3.6.0's 89, which suits a release with nine features rather than two.

## Not touched

Both "What's New" surfaces, which are release-PR only per `AGENTS.md`.

`format`, `check:format`, `check:docs`, `docs:build` green. Swept for British spellings; clean.
