### PR TITLE
feat(events): show an age or anniversary count from a YEAR marker

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -30,6 +30,14 @@ The time is read against the last day an event covers, so a three-day trip clear
 
 It judges the day a row actually lands on rather than the day the event began, which is what lets it work on holidays spanning weeks. Pair it with [`split_multiday_events`](/features/multi-day-events) on a calendar of long events — that turns a fortnight's holiday into a row per day, each judged on its own, which is the Monday-to-Friday view the request was for. Column view already splits by default. (#225)
 
+### 🎂 Ages on Birthdays, and Counts on Anniversaries
+
+**Your birthday events can show the person's age, the way Apple's Calendar does.** Apple builds that calendar out of Contacts, which is why it cannot be shared and why Home Assistant has never been able to show it — the card does the same job on the calendar you already have. Write `YEAR=1986` in a birthday event's description and the card draws **Alex Pfau Geburtstag (40)**.
+
+Because a birthday is stored as an event that repeats every year, each occurrence already knows its own year, so the age is a subtraction and updates itself forever — `(40)` this year, `(41)` next, with nothing to change. The card never needs the full date of birth and never has to work out whether the day has passed yet. The same marker counts anniversaries: a wedding in 2015 shows `(11)` in 2026.
+
+`YEAR:1966` works too, in any capitalization, and the marker is removed from the description before the card draws it — so a description holding nothing but the year shows nothing at all. There is no option to set: a four-digit year written that precisely is not something a calendar produces by accident. Spaces around the separator are the one thing that does not work, and deliberately, since that is what tells `YEAR=1986` apart from a sentence like `Academic Year: 2025`. See [Birthday Ages & Anniversary Counts](/features/event-content#birthday-ages-anniversary-counts) (#124)
+
 ### 💬 A Teams Icon on Your Teams Meetings
 
 **Your online meetings now show the Teams logo instead of a map pin, and there is nothing to set up.** The card recognises the location text Teams writes into an event — including its translations, so `Microsoft Teams-Besprechung` and `Réunion Microsoft Teams` are recognised alongside the English wording — as well as a `teams.microsoft.com` join link stored there in place of a phrase. Meetings that are actually somewhere keep the map pin.
@@ -78,6 +86,7 @@ That is eleven editor languages in total, counting US English in code and Britis
 ## Related Issues
 
 - [#132](https://github.com/alexpfau/calendar-card-pro/issues/132) - Filter based on all-day events by @syst3x
+- [#124](https://github.com/alexpfau/calendar-card-pro/issues/124) - Display age / anniversary by @RK62, who proposed the `YEAR:1966` marker and was already storing the year in the description; supported by @mheidinger, @pyxis1 — who was running a second card solely for this — and @peterdausm
 - [#163](https://github.com/alexpfau/calendar-card-pro/issues/163) - All-day events that should disappear during the day by @Stefan765
 - [#186](https://github.com/alexpfau/calendar-card-pro/issues/186) - Hide or display location based on a regex expression by @mrtag23, with the two-block pattern suggested by @sebatze
 - [#188](https://github.com/alexpfau/calendar-card-pro/issues/188) - Use a calendar entity's own attributes to configure it by @shmuelie — both halves now: the color in #314, and the icon here

--- a/docs/features/event-content.md
+++ b/docs/features/event-content.md
@@ -1,6 +1,6 @@
 # Event Content & Display
 
-These options control what each event actually shows — its title, times, location, description, countdown and progress — and how the card behaves on days that have no events at all.
+These options control what each event actually shows — its title, times, location, description, countdown and progress — and how the card behaves on days that have no events at all. It is also where [birthday ages and anniversary counts](/features/event-content#birthday-ages-anniversary-counts) live, which need no configuration at all.
 
 ## 📅 Calendar Events Display
 
@@ -163,6 +163,57 @@ entities:
   - entity: calendar.personal
     show_description: false # Hide descriptions for personal events
 ```
+
+## 🎂 Birthday Ages & Anniversary Counts
+
+Apple's Calendar app writes the person's age into every birthday, but it builds that calendar out of Contacts, so it cannot be shared or subscribed to and Home Assistant never sees it. This is the part of it the card can do on your own calendars: note the year in the event, and the card works out the rest.
+
+Put **`YEAR=1986`** anywhere in the event's description and the card appends the age to the title:
+
+```yaml
+# Nothing to configure — the marker in the event does the work
+Alex Pfau Geburtstag  →  Alex Pfau Geburtstag (40)
+```
+
+The event you already have is the one that carries it. Birthdays are normally stored as an event that repeats every year, and each occurrence carries its own year, so the number is a subtraction and nothing else — the 2026 occurrence of a 1986 birthday is `(40)`, and the 2027 one is `(41)` without anyone touching the card again. It never needs the full date of birth, and it never has to work out whether the day has passed yet this year, because the event **is** the birthday.
+
+The same marker counts anniversaries, because it is the same subtraction. A wedding in 2015 shows `(11)` in 2026. The number stands on its own without saying what it counts, which is what lets one marker serve both.
+
+### Writing the Marker
+
+`YEAR=1986` and `YEAR:1966` both work, in any capitalization, anywhere in the description — on a line of its own, or at the end of a sentence you already wrote.
+
+Two rules matter, and both exist to keep the card from finding a marker in a description that never meant to carry one:
+
+- **No spaces around the `=` or the `:`.** `YEAR=1986` counts; `YEAR = 1986` does not. This is what separates a marker from ordinary writing — a sentence such as `Academic Year: 2025` puts a space after its colon, and without this rule the card would read that as a birth year and start numbering a school calendar.
+- **The marker stands as its own word.** `Born YEAR=1966` counts; `BIRTHYEAR=1966` does not, and neither does a `?year=1986` sitting inside a link.
+
+The year is always four digits, so `YEAR=198` and `YEAR=19866` are both ignored.
+
+| You write             | The card shows |
+| --------------------- | -------------- |
+| `YEAR=1986`           | `(40)` in 2026 |
+| `YEAR:1966`           | `(60)` in 2026 |
+| `Geboren YEAR=1966`   | `(60)` in 2026 |
+| `YEAR = 1986`         | nothing        |
+| `Academic Year: 2025` | nothing        |
+| `BIRTHYEAR=1966`      | nothing        |
+
+::: tip Nothing Showing Up?
+The card only ever counts **upward**. A year that matches the event's own year, or one still in the future, shows nothing at all rather than `(0)` or a negative number — so a `YEAR=2026` on an event in 2026 looks exactly like a marker that was not recognized. Check the year first, then the spacing around the separator.
+:::
+
+### What the Description Shows
+
+The marker is instruction to the card, not something to read, so it never appears on your card. With `show_description: true`, a description of `Geboren YEAR=1966 in Berlin` is drawn as **Geboren in Berlin**, and a description containing nothing but the marker leaves no description line at all — which is the tidiest way to use it, since the year is metadata rather than something you wanted to read.
+
+Filtering is the deliberate exception. [`blocklist` and `allowlist`](/features/core-settings) read the event exactly as your calendar delivered it, so a `filter_field: description` pattern still sees the raw `YEAR=1986`. That is what makes it possible to filter a birthday calendar on its markers.
+
+::: info Always On, and How to Turn It Off
+There is no option for this. A four-digit year written this precisely is not something a calendar produces by accident, so an option would be one more setting for everybody in exchange for a case that does not really happen — and the way back is simply to write the year differently: `Born in 1986`, or `YEAR - 1986`, are both invisible to the card.
+
+One thing worth knowing on a narrow card: the number sits at the end of the title, so it is the first thing to be cut when `title_max_lines` truncates a long one.
+:::
 
 ## ✂️ Limiting Lines Per Field
 

--- a/src/utils/event-age.ts
+++ b/src/utils/event-age.ts
@@ -1,0 +1,165 @@
+/**
+ * The `YEAR=` marker: an age or anniversary count read out of an event's description.
+ *
+ * A yearly recurring birthday event carries its own year in every occurrence, so the
+ * arithmetic is a subtraction and nothing else — `age = eventYear - markerYear`. There is
+ * no need for the full birth date and no "has it happened yet this year" branch, because
+ * the event *is* the birthday. That is also what makes the result self-updating: nothing
+ * has to be reconfigured as the years pass.
+ *
+ * The count is rendered as a bracketed number appended to the title, which is deliberately
+ * language-neutral. `Alex Pfau Geburtstag (40)` needs no date formatting, no
+ * pluralization and no translated string, so all 35 languages get it on the day it ships.
+ * It is also why one implementation serves anniversaries as well as birthdays: a bracketed
+ * number does not claim to be an age, so the card never has to know which it is looking at.
+ *
+ * Deliberately pure — no DOM and no Lit, in the same spirit as `start-date.ts`. HTML
+ * stripping happens in the caller, which already does it for the displayed description.
+ */
+
+/**
+ * The marker, and every boundary in it is load-bearing.
+ *
+ * - **No whitespace around the separator.** This is the discriminator that makes the
+ *   false-positive claim actually true, and the reason is `Academic Year: 2025` — a
+ *   plausible timetable description that a `\s*` grammar reads as a marker and turns into
+ *   `(1)` on every event in the calendar half of the year. Prose puts a space after a
+ *   colon; a marker does not. The cost is that a tidy `YEAR = 1986` is not recognized,
+ *   which is a self-correctable miss against an unexplained corruption a subscribed-feed
+ *   user cannot fix at all.
+ * - **Start-of-string or whitespace on the left**, so the marker stands as its own token.
+ *   This is what rejects `FISCALYEAR=2024` and, more usefully, the query string in a
+ *   ticketing link — `https://example.com/?year=2024&…` is otherwise a clean match.
+ * - **Exactly four digits, not followed by a word character**, so `YEAR=19866` does not
+ *   quietly yield 1986.
+ * - **Case-insensitive, and both separators.** `YEAR:1966` and `YEAR=1986` each have a
+ *   real proponent on #124, and supporting both costs one character.
+ */
+const MARKER = /(?:^|\s)year[:=](\d{4})(?!\w)/i;
+
+/** The same pattern, global, for removing every occurrence rather than reading the first. */
+const MARKER_GLOBAL = new RegExp(MARKER.source, 'gi');
+
+/**
+ * The cheapest test that can rule a description out, used to avoid stripping HTML from
+ * every event's description on every render when almost none carries a marker.
+ *
+ * 🚨 This must not be able to produce a false negative, which holds only because HTML
+ * stripping cannot *introduce* the letters `year` — tags and entities surround text, they
+ * do not spell it. The two inputs that would defeat it are a description entity-encoding
+ * the letters themselves (`&#89;EAR=1986`) or a tag inside the word (`Y<b>EAR</b>=1986`).
+ * Neither is something a calendar produces.
+ *
+ * @param rawDescription Description exactly as the calendar delivered it
+ * @returns Whether the description is worth stripping and scanning
+ */
+export function mayCarryAgeMarker(rawDescription: string): boolean {
+  return rawDescription.length > 0 && /year/i.test(rawDescription);
+}
+
+/**
+ * Read the year out of a marker.
+ *
+ * Expects text with HTML already stripped, because that is what the user typed and sees.
+ * Google Calendar's description editor emits `&nbsp;`, so `Geboren&nbsp;YEAR=1966` has no
+ * ordinary space in front of the marker until entities are decoded — and `\s` does match
+ * U+00A0 once they are.
+ *
+ * @param plainDescription Description with tags removed and entities decoded
+ * @returns The four-digit year, or null when the description carries no marker
+ */
+export function readMarkerYear(plainDescription: string): number | null {
+  const match = MARKER.exec(plainDescription);
+  if (!match) return null;
+
+  return Number(match[1]);
+}
+
+/**
+ * Remove every marker from a description, and tidy what removing it leaves behind.
+ *
+ * The leading whitespace is part of the match, so `Geboren YEAR=1966 in Berlin` closes up
+ * to `Geboren in Berlin` rather than leaving a double space. A marker on its own line
+ * leaves an empty line, which the newline collapse removes; a marker that was the *whole*
+ * description leaves nothing at all, and the description block is rendered behind a
+ * truthiness guard, so that row simply loses its description rather than showing an empty
+ * one.
+ *
+ * Applied whenever the marker is recognized, whether or not a count is shown. The marker
+ * is card syntax rather than content, and showing the raw syntax with no number beside it
+ * is the worst of the available outcomes.
+ *
+ * The horizontal-whitespace collapse is what stops `Geboren  YEAR=1966  in Berlin` from
+ * closing up to three spaces: the left boundary consumes exactly one whitespace character
+ * and the right side none, so a doubled separator loses one space of four rather than two.
+ * It is a post-pass rather than a wider match because consuming the trailing run would
+ * eat the boundary the *next* marker needs, and `a YEAR=1900 YEAR=1901 b` would then strip
+ * only the first. It deliberately runs over the whole description rather than the seam,
+ * which needs a lookbehind to locate — nothing in `src/` uses one, and a lookbehind is a
+ * parse-time syntax error on an engine that lacks it, so the whole bundle would fail to
+ * load rather than this one feature. The over-reach costs nothing either way: `.description`
+ * sets no `white-space`, so the browser already collapses these runs before anyone sees
+ * them, and the pass only runs on a description that carried a marker at all.
+ *
+ * @param plainDescription Description with tags removed and entities decoded
+ * @returns The description without its marker
+ */
+export function stripAgeMarker(plainDescription: string): string {
+  return plainDescription
+    .replace(MARKER_GLOBAL, '')
+    .replace(/[^\S\n]{2,}/g, ' ')
+    .replace(/[^\S\n]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * The count to show for one occurrence, or null when there is nothing to show.
+ *
+ * Suppressing anything below 1 is the guard that earns its place, and it does more work
+ * than a plausibility range on the year would. The false positives that actually occur
+ * cluster at *recent* years — a feed stamping the current year into every description —
+ * which any plausible range admits and which this reduces to a no-op. A future-dated
+ * marker likewise vanishes rather than rendering a negative number.
+ *
+ * There is no upper bound. An age above 150 is implausible for a person and perfectly
+ * ordinary for an anniversary, and the four-digit rule already rejects the malformed input
+ * an upper bound would be aimed at.
+ *
+ * @param eventYear Calendar year of this occurrence, in the viewer's own time zone
+ * @param markerYear Year read from the marker
+ * @returns The count, or null when it would be zero or negative
+ */
+export function resolveAgeCount(eventYear: number, markerYear: number): number | null {
+  const count = eventYear - markerYear;
+
+  return count >= 1 ? count : null;
+}
+
+/**
+ * Append the count to a title.
+ *
+ * Appending rather than prefixing is not a matter of taste. `groupEventsByDay` sorts
+ * same-time all-day events by `summary.localeCompare`, and that sort runs *after* the
+ * display copies are built — so it reads whatever this writes. A suffix sits past the
+ * character two titles differ at and leaves the order untouched; a prefix would silently
+ * reorder every birthday list on the card. The summary comparison is the last link of a
+ * chain that tries entity index first, so it only ever fires within one calendar at one
+ * all-day start; two genuinely identical titles then order by count, which is harmless.
+ *
+ * 🚨 If a `title_replace` option is ever built (#153), it runs **before** this. A user's
+ * replacement pattern should see the title the calendar delivered, not one the card has
+ * already decorated — otherwise an end-anchored pattern has to tolerate a suffix its
+ * author never wrote. And a privacy option that blanks a title to something like "Busy"
+ * (#212) must suppress the count rather than have one appended to it, or the card
+ * announces that the hidden event is a birthday.
+ *
+ * @param summary Title as the calendar delivered it
+ * @param count Count to show
+ * @returns The title with the count appended
+ */
+export function appendAgeCount(summary: string, count: number): string {
+  const trimmed = summary.trim();
+
+  return trimmed.length > 0 ? `${summary} (${count})` : `(${count})`;
+}

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -5,6 +5,7 @@
 
 import * as EntityColors from './entity-colors';
 import * as EntityIcons from './entity-icons';
+import * as EventAge from './event-age';
 import * as FormatUtils from './format';
 import * as Helpers from './helpers';
 import * as Logger from './logger';
@@ -569,18 +570,52 @@ export function groupEventsByDay(
         };
       }
 
+      const showDescription =
+        getEntitySetting(event._entityId, 'show_description', config, event) ??
+        config.show_description;
+
+      // 🚨 Read the marker off the **raw** event and write the result into the display
+      // copy. The `description` a few lines down is `''` whenever `show_description` is
+      // off — which is the default — so scanning the display copy would leave the feature
+      // doing nothing for the very people who asked for it: someone who hides
+      // descriptions is exactly the person who does not want a bare `YEAR=1986` on their
+      // card. Reading raw and writing display is the correct asymmetry.
+      //
+      // Stripping HTML *before* matching is not the same thing as reading the display
+      // copy, and it is required: Google Calendar's description editor emits `&nbsp;`, so
+      // `Geboren&nbsp;YEAR=1966` has no ordinary space in front of the marker until
+      // entities are decoded. The prefilter keeps that off the hot path — almost no
+      // description mentions "year" at all, and one regex test is cheaper than building a
+      // detached textarea per event per render.
+      const rawDescription = event.description || '';
+      const mayCarryMarker = EventAge.mayCarryAgeMarker(rawDescription);
+
+      const plainDescription =
+        showDescription || mayCarryMarker ? FormatUtils.stripHtmlTags(rawDescription) : '';
+
+      const markerYear = mayCarryMarker ? EventAge.readMarkerYear(plainDescription) : null;
+
+      // The occurrence's own year, not the day the row lands on. With
+      // `split_multiday_events: false` an ongoing event's display date is clamped to the
+      // window start, which moves every day — so reading the display date would make the
+      // count change from one day to the next while the card just sits there.
+      const ageCount =
+        markerYear === null ? null : EventAge.resolveAgeCount(startDate.getFullYear(), markerYear);
+
+      const summary = event.summary || '';
+
       eventsByDay[eventDateKey].events.push({
-        summary: event.summary || '',
+        summary: ageCount === null ? summary : EventAge.appendAgeCount(summary, ageCount),
         location:
           (getEntitySetting(event._entityId, 'show_location', config, event) ??
           config.show_location)
             ? FormatUtils.formatLocation(event.location || '', config.remove_location_country)
             : '',
-        description:
-          (getEntitySetting(event._entityId, 'show_description', config, event) ??
-          config.show_description)
-            ? FormatUtils.stripHtmlTags(event.description || '')
-            : '',
+        description: showDescription
+          ? markerYear === null
+            ? plainDescription
+            : EventAge.stripAgeMarker(plainDescription)
+          : '',
         start: event.start,
         end: event.end,
         _entityId: event._entityId,

--- a/tests/age-marker.dst.test.ts
+++ b/tests/age-marker.dst.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The age of a birthday that falls on January 1.
+ *
+ * The count is `eventYear - markerYear`, so the year the card reads off an occurrence is
+ * the whole of the arithmetic. A one-*day* error in that reading is invisible for 364 days
+ * of the year and is a one-**year** error on the 365th, which is exactly the day this file
+ * is about: a birthday on January 1 renders `(39)` instead of `(40)` for everyone in the
+ * Americas if the date is parsed as UTC midnight rather than local midnight.
+ *
+ * This file is excluded from the `unit` project and run three times instead — under
+ * `Europe/Berlin`, `Australia/Sydney` and `America/New_York` (see `vitest.config.mjs`).
+ * Only the third can see the defect. Berlin and Sydney are both *ahead* of UTC, so UTC
+ * midnight on January 1 is still January 1 locally in both and the wrong parse lands on
+ * the right year anyway; New York is behind it, where the same instant is December 31 of
+ * the previous year. AGENTS.md records the same asymmetry for `all-day-parse.dst.test.ts`,
+ * and this is the case where its cost is a whole year rather than a row on the wrong day.
+ *
+ * Falsified rather than assumed: replacing `FormatUtils.parseAllDayDate` with
+ * `new Date(...)` at the all-day branch of `groupEventsByDay` fails the all-day cases here
+ * under `America/New_York` and leaves both other zones green.
+ *
+ * The timed case is the opposite assertion. A timed event near midnight genuinely does
+ * fall in different years in different zones, and that is correct — the count has to agree
+ * with the date drawn next to it. So it is pinned against the day the card actually
+ * grouped the event under rather than against a fixed number, which is the only form of
+ * the assertion that can hold in all three zones and still say something.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as EventUtils from '../src/utils/events';
+
+/**
+ * New Year's Eve, midday UTC.
+ *
+ * Late enough that it is already December 31 in New York and not yet January 1 in Sydney,
+ * so "today" is the same calendar day in all three zones and the January 1 event is one
+ * day ahead in each. Both fixtures start after it, so neither is filtered out as past.
+ */
+const FROZEN_NOW = new Date('2025-12-31T12:00:00.000Z');
+
+/** A yearly recurring birthday on January 1 — the shape a calendar produces for one. */
+const ALL_DAY_BIRTHDAY: Types.CalendarEventData = {
+  start: { date: '2026-01-01' },
+  end: { date: '2026-01-02' },
+  summary: 'Alex Geburtstag',
+  description: 'YEAR=1986',
+  _entityId: 'calendar.personal',
+};
+
+/**
+ * The same birthday stored as a timed event just after midnight UTC.
+ *
+ * 04:00–04:30 UTC is 05:00 on January 1 in Berlin, 15:00 on January 1 in Sydney, and
+ * 23:00 on December 31 in New York — so the three zones disagree about which year this
+ * occurrence falls in, which is the point. Both ends sit inside the same local day in
+ * every zone, so nothing here is incidentally multi-day.
+ */
+const TIMED_BIRTHDAY: Types.CalendarEventData = {
+  start: { dateTime: '2026-01-01T04:00:00.000Z' },
+  end: { dateTime: '2026-01-01T04:30:00.000Z' },
+  summary: 'Alex Geburtstag',
+  description: 'YEAR=1986',
+  _entityId: 'calendar.personal',
+};
+
+/** The day bucket carrying an event, and the event as the card will draw it. */
+function grouped(event: Types.CalendarEventData): { year: number; summary: string } {
+  const config = buildConfig({ days_to_show: 3 });
+  const days = EventUtils.groupEventsByDay([event], config, true, 'en');
+
+  const carriesBirthday = (candidate: Types.CalendarEventData): boolean =>
+    (candidate.summary ?? '').startsWith('Alex Geburtstag');
+
+  const day = days.find((candidate) => candidate.events.some(carriesBirthday));
+
+  expect(day).toBeDefined();
+  const entry = day!.events.find(carriesBirthday);
+  expect(entry).toBeDefined();
+
+  return { year: new Date(day!.timestamp).getFullYear(), summary: entry!.summary ?? '' };
+}
+
+describe('a January 1 birthday across time zones', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Sanity: everything below is vacuous under UTC, which has no DST transitions and no
+  // offset to be on the wrong side of. If this file is ever run in the `unit` project by
+  // accident, this fails rather than silently proving nothing.
+  it('runs under a zone that observes DST', () => {
+    const janOffset = new Date(2025, 0, 1).getTimezoneOffset();
+    const julOffset = new Date(2025, 6, 1).getTimezoneOffset();
+    expect(janOffset).not.toBe(julOffset);
+  });
+
+  // 🚨 The assertion the file exists for. An all-day date is a date, not an instant, so it
+  // means January 1 wherever it is read — and the count must therefore be the same number
+  // in every zone. A zone-dependent answer here *is* the failure.
+  it('shows the same age everywhere', () => {
+    expect(grouped(ALL_DAY_BIRTHDAY).summary).toBe('Alex Geburtstag (40)');
+  });
+
+  it('lands on January 1 of the year it names', () => {
+    expect(grouped(ALL_DAY_BIRTHDAY).year).toBe(2026);
+  });
+
+  // The timed half. The year genuinely differs by zone here, so the invariant is
+  // agreement rather than a constant: whatever date the card put beside the event, the
+  // count is measured from that same year.
+  it('counts from the year of the day it is drawn under', () => {
+    const { year, summary } = grouped(TIMED_BIRTHDAY);
+
+    expect(summary).toBe(`Alex Geburtstag (${year - 1986})`);
+  });
+
+  // And the two really do disagree, which is what stops the assertion above from being
+  // satisfiable by an implementation that ignores the zone altogether.
+  it('is the same occurrence in a different year than the all-day form', () => {
+    const allDayYear = grouped(ALL_DAY_BIRTHDAY).year;
+    const timedYear = grouped(TIMED_BIRTHDAY).year;
+
+    // Behind UTC, the timed event has not reached January yet; ahead of it, it has.
+    const expected = new Date('2026-01-01T04:00:00.000Z').getFullYear();
+    expect(timedYear).toBe(expected);
+    expect(allDayYear).toBe(2026);
+  });
+});

--- a/tests/age-marker.test.ts
+++ b/tests/age-marker.test.ts
@@ -1,0 +1,334 @@
+/**
+ * The `YEAR=` age marker, end to end.
+ *
+ * Two things about this feature make a naive test file prove nothing, and both shaped
+ * what is below.
+ *
+ * **The read side and the write side are different objects.** The marker is read off the
+ * raw event and the count is written into the display copy `groupEventsByDay` builds. A
+ * test that seeds `description` and then reads `description` back would pass against an
+ * implementation that scanned the display copy — which is broken for every user on the
+ * default config, because `show_description` defaults to `false` and the display copy's
+ * description is `''` in that case. The default-config assertions below are therefore the
+ * load-bearing ones, and `show_description: true` is the *variation*, not the baseline.
+ *
+ * **The grammar's value is in what it rejects.** An accept-only table cannot distinguish
+ * the intended pattern from `/\d{4}/`, so every accepted form here is paired with a
+ * near-miss that must not match, and `Academic Year: 2025` is the fixture the grammar
+ * exists for: it is a plausible timetable description that a whitespace-tolerant
+ * separator turns into `(1)` on every event in the calendar half of the year.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as EventAge from '../src/utils/event-age';
+import * as EventUtils from '../src/utils/events';
+
+/** The instant every test here runs at: a plain mid-week day in 2026, well clear of any
+ * year boundary, so the year read from an event is never in question for the wrong reason.
+ * The January-1 case that *is* about the boundary lives in `age-marker.dst.test.ts`. */
+const FROZEN_NOW = new Date('2026-06-17T10:00:00.000Z');
+
+/** An all-day birthday on the frozen day, which is the shape every calendar produces for
+ * a yearly recurring birthday. */
+function birthday(
+  description: string,
+  summary = 'Alex Geburtstag',
+  date = '2026-06-17',
+): Types.CalendarEventData {
+  const end = new Date(`${date}T00:00:00.000Z`);
+  end.setUTCDate(end.getUTCDate() + 1);
+
+  return {
+    start: { date },
+    end: { date: end.toISOString().slice(0, 10) },
+    summary,
+    description,
+    _entityId: 'calendar.personal',
+  };
+}
+
+/** The single display-copy event `groupEventsByDay` produces for one raw event. */
+function displayed(
+  event: Types.CalendarEventData,
+  overrides: Partial<Types.Config> = {},
+): Types.CalendarEventData {
+  const config = buildConfig({ days_to_show: 7, ...overrides });
+  const events = EventUtils.groupEventsByDay([event], config, true, 'en').flatMap(
+    (day) => day.events,
+  );
+
+  expect(events).toHaveLength(1);
+  return events[0];
+}
+
+describe('the YEAR marker grammar', () => {
+  // Every one of these is a form somebody could reasonably type. The colon and the equals
+  // sign each have a proponent on #124, so both are accepted rather than one being chosen.
+  it.each([
+    { description: 'YEAR=1986', year: 1986, why: 'the documented form' },
+    { description: 'YEAR:1966', year: 1966, why: 'the form the reporter proposed' },
+    { description: 'year=1986', year: 1986, why: 'lowercase' },
+    { description: 'Year:1966', year: 1966, why: 'title case' },
+    { description: 'Geboren YEAR=1966', year: 1966, why: 'after other text' },
+    { description: 'Ralf\nYEAR=1966', year: 1966, why: 'on its own line' },
+    { description: 'YEAR=1966\nRalf', year: 1966, why: 'on the first line' },
+    { description: 'YEAR=1966.', year: 1966, why: 'followed by a full stop' },
+    { description: 'YEAR=1966, Berlin', year: 1966, why: 'followed by a comma' },
+    { description: 'Geboren\u00a0YEAR=1966', year: 1966, why: 'after a decoded &nbsp;' },
+    { description: 'Wedding YEAR=2015', year: 2015, why: 'an anniversary, same grammar' },
+  ])('reads $year from $why', ({ description, year }) => {
+    expect(EventAge.readMarkerYear(description)).toBe(year);
+  });
+
+  // The half that carries the weight. Each of these is a *near* miss — text that a looser
+  // grammar would accept — rather than something obviously unrelated.
+  it.each([
+    { description: 'Academic Year: 2025', why: 'prose puts a space after its colon' },
+    { description: 'YEAR = 1986', why: 'spaces around the separator are the prose form' },
+    { description: 'https://example.com/?year=2024&t=1', why: 'a query string in a link' },
+    { description: 'FISCALYEAR=2024', why: 'the marker must stand as its own token' },
+    { description: 'BIRTHYEAR=1966', why: 'likewise, however reasonable it looks' },
+    { description: 'YEAR=19866', why: 'more than four digits is not a year' },
+    { description: 'YEAR=198', why: 'fewer than four digits is not a year either' },
+    { description: 'YEAR=1966_x', why: 'a word character follows the digits' },
+    { description: '(YEAR=1966)', why: 'a bracket is not whitespace' },
+    { description: 'The year 1986 was a good one', why: 'no separator at all' },
+    { description: 'Born in 1966', why: 'a bare year is not a marker' },
+    { description: '', why: 'nothing at all' },
+  ])('rejects $description, because $why', ({ description }) => {
+    expect(EventAge.readMarkerYear(description)).toBeNull();
+  });
+
+  it('takes the first marker when a description carries two', () => {
+    expect(EventAge.readMarkerYear('YEAR=1966 and YEAR=1970')).toBe(1966);
+  });
+
+  // The prefilter must never be able to hide a marker the grammar would have read. This
+  // reconciles the two against each other rather than testing the prefilter's own idea of
+  // itself: any accepted form has to survive it.
+  it.each([
+    'YEAR=1986',
+    'Geboren YEAR=1966',
+    'year:1966',
+    '<p>YEAR=1986</p>',
+    'Geboren\u00a0YEAR=1966',
+  ])('lets %s past the prefilter', (description) => {
+    expect(EventAge.mayCarryAgeMarker(description)).toBe(true);
+  });
+
+  it.each(['', 'Dinner with the team', 'Born in 1966'])('spends nothing on %s', (description) => {
+    expect(EventAge.mayCarryAgeMarker(description)).toBe(false);
+  });
+});
+
+describe('the count itself', () => {
+  it('subtracts, because the event is the birthday', () => {
+    expect(EventAge.resolveAgeCount(2026, 1986)).toBe(40);
+  });
+
+  it('serves an anniversary with the same subtraction', () => {
+    expect(EventAge.resolveAgeCount(2026, 2015)).toBe(11);
+  });
+
+  // The guard that does the work a plausibility range on the year would not: a feed
+  // stamping the current year into every description becomes a no-op rather than
+  // appending `(0)` to every title on the card.
+  it('shows nothing when the marker names the event`s own year', () => {
+    expect(EventAge.resolveAgeCount(2026, 2026)).toBeNull();
+  });
+
+  it('shows nothing rather than a negative number for a future year', () => {
+    expect(EventAge.resolveAgeCount(2026, 2030)).toBeNull();
+  });
+
+  // No upper bound: implausible for a person, ordinary for an anniversary.
+  it('does not cap a long anniversary', () => {
+    expect(EventAge.resolveAgeCount(2026, 1526)).toBe(500);
+  });
+});
+
+describe('appending the count to a title', () => {
+  it('appends in brackets', () => {
+    expect(EventAge.appendAgeCount('Alex Geburtstag', 40)).toBe('Alex Geburtstag (40)');
+  });
+
+  it('drops the leading space when there is no title to append to', () => {
+    expect(EventAge.appendAgeCount('', 40)).toBe('(40)');
+    expect(EventAge.appendAgeCount('   ', 40)).toBe('(40)');
+  });
+
+  it('appends after a title that already ends in a bracketed number', () => {
+    // Honest rather than pretty. Suppressing the count here would silently drop it, which
+    // is the worse of the two outcomes.
+    expect(EventAge.appendAgeCount('Standup (2)', 40)).toBe('Standup (2) (40)');
+  });
+});
+
+describe('stripping the marker out of a description', () => {
+  // Exact output strings, not `not.toContain('YEAR')`. Every artifact this strip can
+  // produce is a whitespace one, and a containment assertion is blind to all of them.
+  it.each([
+    { before: 'Geboren YEAR=1966 in Berlin', after: 'Geboren in Berlin' },
+    { before: 'YEAR=1966 Geboren', after: 'Geboren' },
+    { before: 'Geboren  YEAR=1966  in Berlin', after: 'Geboren in Berlin' },
+    { before: 'YEAR=1966', after: '' },
+    { before: 'a YEAR=1900 YEAR=1901 b', after: 'a b' },
+    { before: 'Line1\nYEAR=1966\nLine2', after: 'Line1\nLine2' },
+  ])('turns $before into $after', ({ before, after }) => {
+    expect(EventAge.stripAgeMarker(before)).toBe(after);
+  });
+
+  // The doubled-separator case above is the one a single-character left boundary gets
+  // wrong: it consumes one space of four and leaves three. Pinned separately so the
+  // reason survives if the table is ever reshuffled.
+  it('does not leave a run of spaces where the marker was', () => {
+    expect(EventAge.stripAgeMarker('Geboren  YEAR=1966  in Berlin')).not.toMatch(/ {2}/);
+  });
+
+  it('keeps the line structure of a multi-line description', () => {
+    expect(EventAge.stripAgeMarker('Agenda\nCake\nYEAR=1966\nPresents')).toBe(
+      'Agenda\nCake\nPresents',
+    );
+  });
+
+  it('leaves a description that only looks like a marker alone', () => {
+    expect(EventAge.stripAgeMarker('Academic Year: 2025')).toBe('Academic Year: 2025');
+  });
+});
+
+describe('an event on the card', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // 🚨 Default config, which means `show_description: false`. This is the assertion that
+  // fails against an implementation reading the display copy instead of the raw event,
+  // and it is the configuration almost every card is on.
+  it('shows the age with descriptions turned off', () => {
+    expect(displayed(birthday('YEAR=1986')).summary).toBe('Alex Geburtstag (40)');
+  });
+
+  it('still shows no description, having read one', () => {
+    expect(displayed(birthday('YEAR=1986')).description).toBe('');
+  });
+
+  it('shows the age with descriptions turned on', () => {
+    const event = displayed(birthday('YEAR=1986'), { show_description: true });
+    expect(event.summary).toBe('Alex Geburtstag (40)');
+  });
+
+  // The leak: the marker is card syntax, so it must not survive into the drawn text.
+  it('keeps the marker out of the description it draws', () => {
+    const event = displayed(birthday('Geboren YEAR=1986 in Berlin'), { show_description: true });
+    expect(event.description).toBe('Geboren in Berlin');
+    expect(event.description).not.toContain('YEAR');
+  });
+
+  it('draws no description at all when the marker was the whole of it', () => {
+    // Not an edge case: the marker is metadata, so a description containing nothing but
+    // the marker is the natural way to write one. `leaves.ts` renders the description
+    // block behind a truthiness guard, so an empty string is the difference between no
+    // description row and an empty one.
+    expect(displayed(birthday('YEAR=1986'), { show_description: true }).description).toBe('');
+  });
+
+  it('reads a marker wrapped in the HTML a rich-text calendar produces', () => {
+    expect(displayed(birthday('<p>Geboren <b>YEAR=1986</b></p>')).summary).toBe(
+      'Alex Geburtstag (40)',
+    );
+  });
+
+  // The fixture that must not match, at the level that matters — the whole pipeline, not
+  // just the regex.
+  it('leaves a timetable description alone', () => {
+    const event = displayed(birthday('Academic Year: 2025'), { show_description: true });
+    expect(event.summary).toBe('Alex Geburtstag');
+    expect(event.description).toBe('Academic Year: 2025');
+  });
+
+  it('leaves an event with no description alone', () => {
+    const event = displayed({ ...birthday(''), description: undefined });
+    expect(event.summary).toBe('Alex Geburtstag');
+  });
+
+  // Recognized but suppressed. The marker still goes, because showing raw card syntax
+  // with no number beside it is the worst of the available outcomes.
+  it('removes a marker whose count is suppressed', () => {
+    const event = displayed(birthday('YEAR=2026'), { show_description: true });
+    expect(event.summary).toBe('Alex Geburtstag');
+    expect(event.description).toBe('');
+  });
+
+  it('does not touch the raw event it was handed', () => {
+    // The transform belongs to the display copy. Writing it back would persist into
+    // `this.events` and the cache, and compound on every render.
+    const raw = birthday('YEAR=1986');
+    displayed(raw);
+    expect(raw.summary).toBe('Alex Geburtstag');
+    expect(raw.description).toBe('YEAR=1986');
+  });
+
+  it('is stable across repeated renders', () => {
+    const raw = birthday('YEAR=1986');
+    expect(displayed(raw).summary).toBe('Alex Geburtstag (40)');
+    expect(displayed(raw).summary).toBe('Alex Geburtstag (40)');
+  });
+});
+
+describe('the sort the count is appended before', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // `groupEventsByDay` sorts same-time all-day events by `summary.localeCompare`, and that
+  // sort runs *after* the display copies are built — so it reads whatever the count wrote.
+  // A suffix sits past the character two titles differ at; a prefix would reorder the list.
+  it('keeps birthdays in title order', () => {
+    const config = buildConfig({ days_to_show: 7 });
+    const events = EventUtils.groupEventsByDay(
+      [
+        birthday('YEAR=1996', 'Zoe Geburtstag'),
+        birthday('YEAR=1986', 'Alex Geburtstag'),
+        birthday('YEAR=1976', 'Mia Geburtstag'),
+      ],
+      config,
+      true,
+      'en',
+    ).flatMap((day) => day.events);
+
+    expect(events.map((event) => event.summary)).toEqual([
+      'Alex Geburtstag (40)',
+      'Mia Geburtstag (50)',
+      'Zoe Geburtstag (30)',
+    ]);
+  });
+
+  // The one case where the suffix does decide the order, and it is harmless: the summary
+  // comparison is the last link of a chain that tries entity index first, so it only fires
+  // within one calendar at one all-day start, and two people sharing a title is the only
+  // way to reach it.
+  it('orders two identical titles by their count', () => {
+    const config = buildConfig({ days_to_show: 7 });
+    const events = EventUtils.groupEventsByDay(
+      [birthday('YEAR=1976', 'Geburtstag'), birthday('YEAR=1986', 'Geburtstag')],
+      config,
+      true,
+      'en',
+    ).flatMap((day) => day.events);
+
+    expect(events.map((event) => event.summary)).toEqual(['Geburtstag (40)', 'Geburtstag (50)']);
+  });
+});


### PR DESCRIPTION
Closes the gap behind #124 — and behind the much larger stream of "please support the Apple birthday calendar" requests, which are impossible to serve directly because Apple synthesizes that calendar from Contacts and it cannot be shared or subscribed to.

Write `YEAR=1986` in a birthday event's description and the card draws **Alex Pfau Geburtstag (40)**. No configuration.

## Why this is small

Three properties, deliberately preserved:

- **The arithmetic is exact.** The event *is* the birthday, so `age = eventYear − markerYear`. No date of birth, no "has it happened yet this year" branch. Each occurrence of a yearly recurring event carries its own year, so it self-updates forever.
- **It is language-neutral.** ` (40)` needs no date formatting, no pluralization and no translated string. All 35 languages get it on the day it ships.
- **Anniversaries are free.** A bracketed number does not claim to be an age, so one implementation covers both and the card never has to know which it is looking at.

## The two findings that shaped it

**Read raw, write display.** `show_description` defaults to `false`, and in that case the display copy's `description` is `''` — the raw text is never copied across. A marker scan against the display copy would therefore do nothing for the default user, who is *precisely* the person who does not want a bare `YEAR=1986` on their card. The marker is read off `event.description` on the raw event; the count is written into the display copy in `groupEventsByDay`. Writing back into `this.events` would persist into the cache and compound the suffix on every render.

**Append, don't prefix — and that is load-bearing, not cosmetic.** `groupEventsByDay` sorts same-time all-day events by `summary.localeCompare` (`events.ts:636`), and that sort runs *after* the display copies are built, so it reads whatever this writes. A suffix sits past the character two titles differ at and leaves the order untouched. **A prefix would silently reorder every birthday list on the card.**

## Grammar, and what it rejects

```
/(?:^|\s)year[:=](\d{4})(?!\w)/i
```

Both `YEAR=1986` and `YEAR:1966` — the maintainer's form and the reporter's — in any capitalization.

Two boundaries carry the false-positive argument:

| Rejected | Why it matters |
| --- | --- |
| `Academic Year: 2025` | The reason whitespace around the separator is not allowed. A plausible timetable description that a tolerant grammar turns into `(1)` on every event in the calendar half of the year. |
| `https://example.com/?year=2024` | The reason the marker must stand as its own token. |
| `FISCALYEAR=2024`, `BIRTHYEAR=1966` | Same boundary. |
| `YEAR = 1986` | The documented cost. A self-correctable miss, against an unexplained corruption a subscribed-feed user cannot fix. |

**A plausibility range on the year would add nothing**, and this is the one place I'd expect a reviewer to disagree. The false positives that actually occur cluster at *recent* years — a feed stamping the current year — which any plausible range admits; a range only rejects input nothing produces. **Suppressing counts below 1 does the work instead**, reducing that exact case to a no-op. A future-dated marker vanishes rather than rendering a negative.

HTML is stripped before matching, behind a cheap `/year/i` prefilter. Google Calendar's description editor emits `&nbsp;`, so `Geboren&nbsp;YEAR=1966` has no ordinary space in front of the marker until entities are decoded — and `\s` does match U+00A0 once they are.

## The description leak

The marker is stripped from the drawn description whenever it is recognized, count shown or not — showing raw card syntax with no number beside it is the worst available outcome. A description containing nothing but the marker leaves no description block at all, since `leaves.ts:547` renders it behind a truthiness guard.

**Filtering deliberately still sees the marker.** `filterSubject` reads the raw event by design (its docblock says why), so `filter_field: description` can still match on markers. Confirmed, not assumed.

## Verification

**The DST test is proven, not asserted.** Planting `new Date(event.start.date)` in place of `parseAllDayDate` at `events.ts:543`:

| Zone | Result |
| --- | --- |
| `Europe/Berlin` | 5 passed |
| `Australia/Sydney` | 5 passed |
| **`America/New_York`** | **3 failed**, 2 passed — `Alex Geburtstag (39)` where `(40)` was expected |

Across the whole suite that mistake fails **3 of 2,722 tests, all three of them in this PR's new file**. Without it, a one-year error on every January 1 birthday throughout the Americas ships silently. Berlin and Sydney are ahead of UTC and cannot see it.

Also pinned: a must-not-match fixture at pipeline level, the default-config path (`show_description: false`), stability across repeated renders, non-mutation of the raw event, and sort order.

All nine gates green: `tsc --noEmit`, `lint`, `check:format`, `test` (2722 passed), `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle` — the last also re-run under Node 22.23.2 per `.nvmrc`, since its oracle is zlib-version-sensitive.

## Ordering, for whoever builds `title_replace`

Recorded as a comment at `appendAgeCount` rather than only here, so it is found at the site:

- **#153 `title_replace` runs first**, age appended last. A user's replacement pattern should see the title the calendar delivered, not one the card has already decorated — otherwise an end-anchored pattern has to tolerate a suffix its author never wrote.
- **#212 (hide details) must suppress the count**, not have one appended. Appending an age to a title blanked to "Busy" announces that the hidden event is a birthday.

## Notes for the maintainer

- **`Closes #124` deliberately omitted.** A closing keyword on a `dev`-based commit fires at release as a bare state change, where step 7 of the release process wants a comment naming the version and deep-linking the docs. It is in the v4.1.0 **Related Issues** list instead, crediting @RK62 (who proposed the marker first, and was already storing the year in the description) plus @mheidinger, @pyxis1 and @peterdausm.
- **Gate gap found, not fixed here:** `check:docs` does **not** validate same-page `#fragment` links — only path-qualified ones. Verified by breaking an anchor and watching it exit 0 with an unchanged link count. I worked around it by writing the in-page link root-absolute, which moved the resolved count 163 → 164 and put it under the gate. Left for AGENTS.md rather than edited in, since a sibling session is editing that file right now.
- Both **What's New** surfaces untouched, per the release-PR-only rule.
- Screenshots under `.github/img/` are unaffected: the card renders identically unless an event carries a marker.

Targets `dev`.