### PR TITLE
fix(check-docs): validate same-page fragment links

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -757,15 +757,32 @@ function buildAnchorMap(docs) {
 function checkInternalLinks(docs) {
   const { published, anchors } = buildAnchorMap(docs);
 
-  const LINK = /\[[^\]]*\]\((\/[^)\s]*)\)|<a\s[^>]*href="(\/[^"]*)"/g;
+  // The `#…` alternatives are not decoration. A same-page fragment is the one link form
+  // nothing else validates: VitePress's dead-link check resolves it no more than this
+  // gate did, so a bare `[see below](#renamed-heading)` rotted silently through every
+  // build. Confirmed by planting one — `check:docs` and `docs:build` both exited 0.
+  const LINK = /\[[^\]]*\]\(((?:\/|#)[^)\s]*)\)|<a\s[^>]*href="((?:\/|#)[^"]*)"/g;
   let checked = 0;
 
   for (const file of published) {
     const text = readFileSync(file, 'utf8');
+
+    // The route this file publishes at, so a `#fragment` resolves against its own
+    // headings. Derived the same way buildAnchorMap does, so the two cannot disagree.
+    const ownRoute = (() => {
+      const r =
+        '/' +
+        relative(DOCS_DIR, file)
+          .replace(/\.md$/, '')
+          .replace(/\/index$/, '');
+      return r === '/index' ? '/' : r;
+    })();
+
     for (const m of text.matchAll(LINK)) {
       const target = m[1] ?? m[2];
-      const [rawPath, anchor] = target.split('#');
-      const path = rawPath.replace(/\/$/, '') || '/';
+      const samePage = target.startsWith('#');
+      const [rawPath, anchor] = samePage ? [ownRoute, target.slice(1)] : target.split('#');
+      const path = samePage ? rawPath : rawPath.replace(/\/$/, '') || '/';
       checked++;
 
       if (!anchors.has(path)) {
@@ -774,7 +791,8 @@ function checkInternalLinks(docs) {
       }
       if (anchor && !anchors.get(path).has(anchor)) {
         error(
-          `${relative(ROOT, file)} links to ${target}, but #${anchor} is not a heading on that page. ` +
+          `${relative(ROOT, file)} links to ${target}, but #${anchor} is not a heading ` +
+            `on ${samePage ? 'its own page' : 'that page'}. ` +
             "Note the site's slugify strips emoji and dots.",
         );
       }


### PR DESCRIPTION
`check:docs` validated a cross-page fragment (`/features/weather#anchor`) and was blind to a same-page one (`#anchor`). Found by the #124 session while writing its docs; verified here before fixing.

## The gap, measured

The `LINK` pattern required a target beginning with `/`:

```js
/\[[^\]]*\]\((\/[^)\s]*)\)|<a\s[^>]*href="(\/[^"]*)"/g
```

A same-page link starts with `#`, so it never matched — not validated, and not even counted.

| Link | `check:docs` | `docs:build` |
| --- | --- | --- |
| `/features/weather#does-not-exist` | **exit 1** | — |
| `#does-not-exist` | **exit 0** | **exit 0** |

The second row is the finding, and the `docs:build` column is why it matters: `AGENTS.md` records that the two checks are complementary, one catching what the other misses. For this link form **neither** fires. VitePress's `ignoreDeadLinks: false` resolves markdown links between pages, not fragments within one. So a `[see below](#renamed-heading)` broke on any heading rename and shipped silently — the same failure mode as the raw `<a href>` hole this function was extended to close once before, arriving from a third direction.

## The fix

Both alternatives now accept `/` **or** `#`, and a `#` target resolves against the page's own route, derived exactly as `buildAnchorMap` derives it so the two cannot disagree. The error message says "on its own page" rather than "on that page", since the old wording is confusing when the page is the current one.

## Verified in three directions

1. **Real corpus still passes** — exit 0, and the resolved-link count moves **165 → 176**. Eleven same-page links existed and were never checked; all eleven resolve, so this fixes a gate without a backlog to clear.
2. **Fail control** — a planted `#this-anchor-does-not-exist-xyzzy` now exits 1 and names the file and the anchor. Before the change the same plant exited 0.
3. **Pass control** — a *valid* same-page link to a real heading (`#calendar-events-display`, from an emoji heading, so it exercises the slugify path) exits 0. Without this, a fix that flagged every fragment would look identical to a working one.

The count moving is what separates "the pattern now matches" from "the pattern still misses them and the check is vacuous" — a fix that changed nothing would have left it at 165.

Also re-run under Node 22 per `.nvmrc`, since I am on a newer major.

`lint`, `check:format`, `check:docs`, `check:i18n`, `docs:build` green. One file changed.
