### PR TITLE
docs(agents): record the hand-written entity whitelist that silently drops new options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1074,6 +1074,33 @@ Both controls are load-bearing. Without `days_to_show` the harness might be dete
 nothing at all; without `show_location` a zero is indistinguishable from a probe that never
 ran.
 
+### A new per-calendar option must be added to a hand-written whitelist
+
+🚨 **`normalizeEntities` in `config.ts` projects each entity through a hand-written field
+list, and an option missing from it is dropped before it reaches anything.** Normalization
+runs in `setConfig`, so the key never lands in `_matchedConfig` and the option is inert no
+matter how carefully the rest of it was wired — types, editor schema, translations,
+transform and docs can all be correct and complete.
+
+It is silent by construction. Nothing in the editor can see it, because the editor writes
+the key correctly; nothing in the types can see it, because the type declares it; and
+`tsc` cannot see it, because omitting an optional property from an object literal is legal.
+Three per-calendar options were written this way in one PR, with every other layer correct,
+and were caught only by the test below.
+
+**The file already documents the hazard, one function below the one that has it.**
+`serializeEntities` sits twenty lines further down and its docblock reads: _"Being
+field-agnostic is the point. A hand-written field list would silently stop covering the
+next per-calendar option somebody adds."_ That is exactly true, and it protects only
+itself — the projection above it was written the other way, so the two disagree about
+which fields exist and only one of them says so.
+
+What catches it is a test that **reconciles the whitelist against `EntityConfig`** rather
+than walking either one, which is the same _pin the whole table by value_ discipline as the
+`Object.keys(TABLE)` trap above; `tests/entity-config-reprocess.test.ts` does this. Blanking
+one line of the projection fails that test plus every behavioural test for the dropped
+option, which is the falsifier to run when adding one.
+
 ### The card holds three disagreeing answers to "is this multi-day?"
 
 For a **timed** event running 23:30 to 00:30:


### PR DESCRIPTION
Records a silent failure mode found while building #153/#212 — one that every other layer of the codebase was powerless to catch, and that the file containing it already documents one function further down.

## What happened

`normalizeEntities` in `src/config/config.ts` projects each entity through a **hand-written field list**. The three new `replace_*` options were absent from it, so they were dropped in `setConfig` and never reached `_matchedConfig`. The options were completely inert while types, editor schema, translations, the transform module and the docs were all correct.

Nothing available could catch it:

- the **editor** writes the key correctly, so it sees nothing wrong;
- the **types** declare the key, so they see nothing wrong;
- **`tsc`** cannot see it, because omitting an optional property from an object literal is legal.

## The part worth recording

`serializeEntities` sits **twenty lines below** the projection that had the bug, and its docblock reads:

> Being field-agnostic is the point. A hand-written field list would silently stop covering the next per-calendar option somebody adds.

That is precisely the failure that occurred, correctly predicted, in the same file — and it protects only itself. The two functions disagree about which fields exist, and only one of them says so.

A hazard documented next to the code that has it is worse than an undocumented one, because reading the file leaves you believing it is handled.

## What catches it

A test that **reconciles the whitelist against `EntityConfig`** rather than walking either one — the same "pin the whole table by value" discipline `AGENTS.md` already prescribes for the `Object.keys(TABLE)` trap. `tests/entity-config-reprocess.test.ts` does exactly this and is what found it.

Verified rather than assumed: blanking a single line of the projection fails that reconciliation test **plus five behavioral tests** for the dropped option. That falsifier is in the new section so the next person can run it.

## Placement

New subsection under _Event classification and cache invalidation_, beside _Render-time and processing-time options invalidate differently_. Both are hazards of adding a per-calendar option; that one is about an option taking effect late, this one about it never taking effect at all.

`check:format`, `check:docs`, `docs:build` green. Documentation only, no `src/` or `tests/` files touched.
