### PR TITLE
docs(guide): add the flagship story, and open the release notes on it

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -104,6 +104,7 @@ export default defineConfig({
         items: [
           { text: 'Installation', link: '/guide/installation' },
           { text: 'Usage', link: '/guide/usage' },
+          { text: 'One Calendar, Many Purposes', link: '/guide/one-calendar-many-purposes' },
           { text: "What's New", link: '/guide/whats-new' },
         ],
       },

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -4,7 +4,41 @@ title: Release Notes
 
 # Calendar Card Pro v4.1.0
 
-**Per-calendar filtering and styling, and an editor that can list one calendar twice so each copy answers differently.** A calendar used to be one thing: you added it, and it contributed all of its events, styled one way. This release takes that apart. Filter a calendar on its location or its description, keep only its all-day events or only its timed ones, retire all-day events partway through the day, show a calendar on weekdays alone — each of those is set per calendar, so listing the same calendar twice gives you two blocks that filter and style themselves independently. The editor's new **Duplicate** button builds the second block for you. The card also takes the color and icon Home Assistant already holds for a calendar, so anything you have themed once is themed here too.
+**Per-calendar filtering, rewriting and styling, and an editor that can list one calendar twice so each copy answers differently.** A calendar used to be one thing: you added it, and it contributed all of its events, styled one way. This release takes that apart.
+
+Here is what that buys you, in one config — a hallway tablet the whole household walks past:
+
+```yaml
+entities:
+  # 🎂 Birthdays — the name and the age, nothing else
+  - entity: calendar.family
+    allowlist: 'Birthday of'
+    replace_pattern: 'Birthday of '
+    label: 🎂
+    show_time: false
+    show_location: false
+
+  # 🗑️ Bin day — gone once the truck has been
+  - entity: calendar.family
+    allowlist: 'collection'
+    event_type: all_day
+    allday_expires_at: '11:00'
+    label: 🗑️
+
+  # Everything else on the family calendar
+  - entity: calendar.family
+    blocklist: 'Birthday of|collection'
+
+  # 💼 Work — that someone is busy, not what with
+  - entity: calendar.work
+    replace_with: 'Busy'
+    show_location: false
+    show_description: false
+```
+
+`Birthday of Lena Weber — All day` becomes **🎂 Lena Weber (32)**, and says 33 next year without anyone editing anything. Bin day retires itself at eleven. The children see that a parent is busy at nine, not that the meeting is a performance review. The first three blocks are the **same calendar**, three times.
+
+Four of the features below are in those thirty lines, and not one of them is announced — you write what you want the row to say, and the card gets out of the way. The walkthrough is [One Calendar, Many Purposes](https://calendar-card-pro.alexpfau.com/guide/one-calendar-many-purposes); everything from here on is the parts list.
 
 ## 🎉 New Features
 

--- a/docs/guide/one-calendar-many-purposes.md
+++ b/docs/guide/one-calendar-many-purposes.md
@@ -1,0 +1,101 @@
+# One Calendar, Many Purposes
+
+Most calendar cards treat a calendar as one thing: you add it, and it contributes all of its events, styled one way. This page is about the other approach — listing the same calendar several times and letting each copy answer a different question. It is one worked example rather than a list of options, and every setting in it links back to its own reference.
+
+## 🏡 The Hallway Tablet
+
+A screen in the hall, on all day, that the whole household walks past. It needs to answer three questions at a glance — _whose birthday is it, do the bins go out, and is anyone busy_ — without turning into a wall of text, and without putting a parent's work life in front of the children.
+
+Two calendars go into it. One of them does three different jobs.
+
+```yaml
+type: custom:calendar-card-pro
+title: Family
+days_to_show: 3
+entities:
+  # 🎂 Birthdays — the name and the age, nothing else
+  - entity: calendar.family
+    allowlist: 'Birthday of'
+    replace_pattern: 'Birthday of '
+    label: 🎂
+    accent_color: '#e91e63'
+    show_time: false
+    show_location: false
+
+  # 🗑️ Bin day — gone once the truck has been
+  - entity: calendar.family
+    allowlist: 'collection'
+    event_type: all_day
+    allday_expires_at: '11:00'
+    label: 🗑️
+    accent_color: '#607d8b'
+
+  # Everything else on the family calendar
+  - entity: calendar.family
+    blocklist: 'Birthday of|collection'
+
+  # 💼 Work — that someone is busy, not what with
+  - entity: calendar.work
+    replace_with: 'Busy'
+    label: 💼
+    accent_color: '#455a64'
+    show_location: false
+    show_description: false
+```
+
+The first three blocks are **the same calendar**, three times. Nothing is duplicated on screen, because their patterns are complementary — the first two claim what they match, and the third takes everything they did not.
+
+### A Birthday Should Read Like a Name
+
+Calendars write birthdays badly. Google exports them as _Birthday of Lena Weber_, and the card shows that under an _All day_ label, in a row that also has room for a location it does not have.
+
+Four settings fix it, and they cooperate:
+
+- [`allowlist`](/features/core-settings#filtering-by-event-name) claims the birthdays for this block.
+- [`replace_pattern`](/features/core-settings#text-replacement) deletes the prefix. With no `replace_with` beside it, the match is removed rather than substituted.
+- The age arrives on its own. Put `YEAR=1994` in the event's description and the card works out the rest — see [Birthday Ages & Anniversary Counts](/features/event-content#birthday-ages-anniversary-counts).
+- `show_time` and `show_location` are off, because a birthday has neither worth reading.
+
+What was _Birthday of Lena Weber — All day_ becomes **🎂 Lena Weber (32)**. Next year it says 33, and nobody edits anything.
+
+### A Reminder That Retires Itself
+
+Bin day is only useful before the collection. After it, it is a line of text taking up space until midnight.
+
+[`allday_expires_at`](/features/core-settings#retiring-all-day-events-during-the-day) sets the time it stops counting as today's news. [`event_type: all_day`](/features/core-settings#separating-all-day-from-timed-events) keeps the block to all-day entries, so a timed event that happens to mention collection cannot wander in.
+
+### Busy & Nothing Else
+
+This is the block that could not be built before. A shared screen should say that a parent is unavailable at nine; it should not say _Quarterly planning with the board_, and it certainly should not say _1:1 with Sarah — performance review_.
+
+`replace_with: 'Busy'` **with no `replace_pattern` beside it** replaces the whole title rather than part of it. That asymmetry is deliberate: a pattern alone deletes, a pattern with a replacement substitutes, and a replacement alone overrides the field entirely.
+
+::: warning A Title Is Not the Only Thing That Leaks
+Replacing the title does **not** make a calendar private on its own. The location still names the meeting room and the description may hold the agenda, so `show_location: false` and `show_description: false` are part of the recipe rather than decoration.
+:::
+
+## 🧭 Why This Works
+
+The pattern underneath is worth more than the example. **Every option here is per calendar**, so a calendar listed twice is two blocks that filter and style themselves independently, and the [visual editor's](/features/editor) **Duplicate** action builds the second one for you.
+
+Two rules keep it predictable:
+
+**Make the blocks complementary.** Each event should match exactly one block. The example allowlists two patterns and then blocklists both in the catch-all, so every event lands once. Blocks that overlap render their events more than once — there is no automatic de-duplication between two copies of one calendar.
+
+**Finish with a catch-all.** A block with only a `blocklist` is the safety net. Without it, an event nobody wrote a rule for simply never appears, and it is very hard to notice something missing.
+
+## 🔭 Where Else to Take It
+
+The same shape solves problems that look unrelated:
+
+- **A meeting URL where a room name should be.** Split on the location, and set `show_location: false` on the half that carries a link — or rewrite it to something readable with `replace_field: location`.
+- **Online and in-person, told apart.** Filter on `location`, and give each half its own [`location_icon`](/features/event-content#the-location-icon) and color. Teams meetings get their icon without being asked.
+- **A work calendar that goes quiet at the weekend.** [`days_of_week: weekdays`](/features/core-settings#showing-a-calendar-on-weekdays-only) on that block alone.
+- **One calendar, one color per category.** Duplicate it per keyword and give each block its own `accent_color`.
+
+## 📚 Next Steps
+
+- [Core Settings](/features/core-settings) — every per-calendar option, with the filtering and rewriting patterns in full
+- [Event Content & Display](/features/event-content) — what each row carries, including birthday ages
+- [Configuration Reference](/reference/configuration) — the complete option table
+- [Examples](/reference/examples) — shorter, single-purpose configurations


### PR DESCRIPTION
Twelve features read one at a time invite "do I need this?", and each one individually loses. Read together they are a different product. This adds the page that reads them together, and rewrites the release notes to open on it.

## The page

`docs/guide/one-calendar-many-purposes.md` — a hallway tablet, built from two calendars, one of which does three different jobs:

- **🎂 Birthdays** — allowlisted, prefix deleted, age added from a `YEAR=` marker, time and location off. `Birthday of Lena Weber — All day` becomes `🎂 Lena Weber (32)`.
- **🗑️ Bin day** — all-day only, retiring at 11:00 once the truck has been.
- **Everything else** — a catch-all blocklist.
- **💼 Work** — whole title replaced with `Busy`, location and description off.

The first three blocks are the **same calendar**, three times.

It teaches the pattern rather than the options: make the blocks complementary so each event matches exactly one, and always finish with a catch-all so nothing vanishes silently. It closes with four other problems the same shape solves.

## Verified before it was written, not after

The config was built on a real Home Assistant with six purpose-made fixtures, deployed, and rendered. Everything the page claims is what the screenshot shows: the two birthdays read `Grandpa Karl (75)` and `Lena Weber (32)` with no time row, recycling carries its own color, the four work events all read `Busy` with no locations, and the Disneyland trip and swim class come through the catch-all untouched.

That ordering matters — a page of aspirational YAML is how examples rot.

## Two corrections I made to my own draft

**The feature count was wrong, twice.** I wrote "nine of this release's twelve features are in those thirty lines". There are **eleven** feature sections, and the config genuinely uses **four** of them. Corrected to four, and the fraction dropped — the point is that nothing in the config announces itself, not that it scores well.

**Four house-style violations, caught by `check:docs` rather than by me**: three h3 headings starting with an emoji, one using "and" instead of "&", and a link to `#rewriting-an-events-text` when the real anchor is `#text-replacement`. Worth noting the last one only failed because the anchor gate was widened in #550 — before that it resolved cross-page fragments and this would have shipped dead.

## Release notes

The v4.1.0 intro previously stated the per-calendar idea abstractly. It now shows the config, says what it produces in three sentences, and links to the walkthrough — so a reader meets the release as one thing before meeting it as a parts list.

## Also

Sidebar entry under **Guide**, after Usage.

`check:format`, `check:docs`, `docs:build`, `lint` green. Docs only.
