### PR TITLE
fix(events): stop allday_expires_at deleting the middle of a split timed event

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -490,6 +490,30 @@ export interface CalendarEventData {
    * count whole calendar days for every segment.
    */
   _isMultiDaySegment?: boolean;
+  /**
+   * Set on every segment produced by splitting a **timed** multi-day event, recording the
+   * class of the event the segment came from rather than the shape the segment now has.
+   *
+   * The two differ, and only for these: splitting rewrites the middle days of a timed
+   * event as `start: { date }`, so they read as all-day to everything downstream. That is
+   * right for layout — a middle day genuinely occupies the whole day and draws no time —
+   * and wrong for `allday_expires_at`, which is a statement about all-day *events*. Without
+   * this, a calendar set to retire bin collections at 10:00 also deleted the middle day of
+   * a three-day conference while it was still running.
+   *
+   * `_isMultiDaySegment` cannot answer the question, because segments of a genuinely
+   * all-day event carry it too and must keep expiring one day at a time.
+   *
+   * 🚨 Set on **all three** segment kinds so the name is literally true of anything
+   * carrying it, but only the middle ones can ever be read: the first and last keep their
+   * `dateTime`, so the expiry branch's `isAllDayEvent` test excludes them before this is
+   * consulted. Removing it from those two therefore breaks no test — it records provenance
+   * there, not behaviour, and the alternative is a flag that lies about half its subjects.
+   *
+   * Carried into the display copies alongside `_isMultiDaySegment` for symmetry, though
+   * only the expiry filter reads it today — that filter runs before the copies are built.
+   */
+  _splitFromTimedEvent?: boolean;
   _matchedConfig?: EntityConfig;
 }
 

--- a/src/utils/event-age.ts
+++ b/src/utils/event-age.ts
@@ -147,14 +147,31 @@ export function resolveAgeCount(eventYear: number, markerYear: number): number |
  * chain that tries entity index first, so it only ever fires within one calendar at one
  * all-day start; two genuinely identical titles then order by count, which is harmless.
  *
- * 🚨 If a `title_replace` option is ever built (#153), it runs **before** this. A user's
- * replacement pattern should see the title the calendar delivered, not one the card has
- * already decorated — otherwise an end-anchored pattern has to tolerate a suffix its
- * author never wrote. And a privacy option that blanks a title to something like "Busy"
- * (#212) must suppress the count rather than have one appended to it, or the card
- * announces that the hidden event is a birthday.
+ * 🚨 **Two constraints this function does not enforce and cannot, both now live.** They
+ * were written here conditionally, against a `title_replace` option that had not been
+ * built; #153 and #212 shipped it in v4.1 as `replace_pattern` / `replace_with`, and both
+ * requirements are implemented in `groupEventsByDay`:
  *
- * @param summary Title as the calendar delivered it
+ * 1. **The rewrite runs before this.** `applyTextReplacement` is applied to the raw
+ *    `summary` and it is that result — not the calendar's own title — that arrives here.
+ *    A user's pattern therefore sees the title the calendar delivered rather than one the
+ *    card has already decorated, so an end-anchored pattern does not have to tolerate a
+ *    suffix its author never wrote.
+ * 2. **A withheld title suppresses the count entirely**, rather than having one appended.
+ *    `groupEventsByDay`'s `titleWithheld` decides that, and calls this only when it is
+ *    false. `Busy (40)` announces that the hidden event is a birthday, which is exactly
+ *    what #212 asked to be spared.
+ *
+ * The second is why the empty-title branch below is narrower than it looks. Drawing a bare
+ * `(40)` is right for an event that never had a title and a **louder** leak than `Busy (40)`
+ * after a deliberate deletion, since a lone bracketed number is nothing else. `titleWithheld`
+ * is what tells those apart, and it has to ask the same question this function asks — it
+ * tests `.trim()` on both sides for that reason. Testing the replaced title for exact
+ * emptiness instead let a blank-but-not-empty result through: `Alex Geburtstag` minus
+ * `[A-Za-z]+` is two spaces, which passed the guard, failed the branch below, and rendered
+ * the bare count. Keep the two tests spelled the same way.
+ *
+ * @param summary Title to append to — the calendar's own, or what a rewrite left of it
  * @param count Count to show
  * @returns The title with the count appended
  */

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -507,14 +507,24 @@ export function groupEventsByDay(
       // it. `show_past_events` decides *whether* past events are shown; the expiry decides
       // *when* an all-day event becomes past. With `show_past_events: true` there is
       // nothing for either to do, which is why both sit inside this branch.
-      if (
-        isAllDayEvent &&
-        now >=
-          allDayExpiryInstant(
-            endDate,
-            getEntitySetting(event._entityId, 'allday_expires_at', config, event),
-          )
-      ) {
+      //
+      // 🚨 A segment split out of a **timed** event reads as all-day here — splitting
+      // rewrites the middle days as `start: { date }` — so it reaches this branch and the
+      // configured time must not be applied to it. `allday_expires_at` is a statement about
+      // all-day events; a conference running Monday to Wednesday is not one, and retiring
+      // its Tuesday at 10:00 deleted a day out of the middle of an event still in progress.
+      //
+      // The configured value is withheld rather than the whole branch skipped, which is the
+      // difference between fixing this and reopening the defect the option's **default**
+      // was introduced to close. Skipping outright would exempt these segments from expiry
+      // altogether, and a backwards window — `start_date: 'today-7'` — would then keep the
+      // middle days of last week's meetings on a card that hides past events. Midnight
+      // after the segment's own day is already the right answer for it.
+      const configuredExpiry = event._splitFromTimedEvent
+        ? undefined
+        : getEntitySetting(event._entityId, 'allday_expires_at', config, event);
+
+      if (isAllDayEvent && now >= allDayExpiryInstant(endDate, configuredExpiry)) {
         return false;
       }
     }
@@ -641,8 +651,19 @@ export function groupEventsByDay(
       // announces that the hidden event is a birthday, and a bare `(40)` announces it
       // louder. A title merely *edited* keeps its count, which is the case #153 ex.1 wants:
       // stripping `Geburtstag von ` off a birthday should still say how old they are.
+      //
+      // 🚨 **Both sides are trimmed, and each side is trimmed for its own reason.** The
+      // right-hand test has to ask the same question `appendAgeCount` asks — it draws a
+      // bare count when `summary.trim()` is empty — because any disagreement between the
+      // two is a leak by construction, and testing `text === ''` disagreed on precisely
+      // the blank-but-not-empty titles an ordinary pattern produces: `Alex Geburtstag`
+      // minus `[A-Za-z]+` is two spaces, which suppressed nothing and rendered `(40)`.
+      // The left-hand side is trimmed so a title that was *already* only whitespace is not
+      // read as a deletion — nothing was taken away from it, so it keeps the bare count an
+      // untitled event has always drawn.
       const titleWithheld =
-        replacedSummary.replacedWholeField || (summary !== '' && replacedSummary.text === '');
+        replacedSummary.replacedWholeField ||
+        (summary.trim() !== '' && replacedSummary.text.trim() === '');
 
       eventsByDay[eventDateKey].events.push({
         summary:
@@ -673,6 +694,7 @@ export function groupEventsByDay(
         _isEmptyDay: event._isEmptyDay,
         _isCustomEmptyText: event._isCustomEmptyText,
         _isMultiDaySegment: event._isMultiDaySegment,
+        _splitFromTimedEvent: event._splitFromTimedEvent,
       });
     });
   }
@@ -1124,6 +1146,7 @@ function splitMultiDayEvent(event: Types.CalendarEventData): Types.CalendarEvent
         start: { dateTime: startDateTime.toISOString() },
         end: { dateTime: firstDayEnd.toISOString() },
         _isMultiDaySegment: true,
+        _splitFromTimedEvent: true,
       };
       segments.push(firstDaySegment);
 
@@ -1149,6 +1172,7 @@ function splitMultiDayEvent(event: Types.CalendarEventData): Types.CalendarEvent
           start: { date: currentDateStr },
           end: { date: nextDateStr },
           _isMultiDaySegment: true,
+          _splitFromTimedEvent: true,
         };
 
         segments.push(middleDaySegment);
@@ -1159,6 +1183,7 @@ function splitMultiDayEvent(event: Types.CalendarEventData): Types.CalendarEvent
         start: { dateTime: lastDayStart.toISOString() },
         end: { dateTime: endDateTime.toISOString() },
         _isMultiDaySegment: true,
+        _splitFromTimedEvent: true,
       };
       segments.push(lastDaySegment);
     } else {

--- a/tests/allday-expiry.test.ts
+++ b/tests/allday-expiry.test.ts
@@ -336,6 +336,62 @@ describe('allday_expires_at: what it deliberately does not touch', () => {
   });
 
   /**
+   * The same rule, one layer down, and the case that made it a real defect rather than a
+   * tidiness point.
+   *
+   * `splitMultiDayEvent` rewrites the **middle** days of a *timed* multi-day event as
+   * `start: { date }` segments, so they read as all-day to every later test — including
+   * this option's. A three-day conference therefore lost its middle day at 10:00 on a
+   * calendar configured for bin collections, while the event was still in progress. The
+   * event did not vanish, it lost a day out of its middle, which reads as a data problem
+   * rather than a configuration one.
+   *
+   * The **default** is correct for these segments and must stay: midnight after the
+   * segment's own day is exactly when a middle day stops being today. Only an explicit
+   * time misfires, which is why nothing caught it — the option is unset in `DEFAULT_CONFIG`.
+   *
+   * The genuinely all-day counterpart is pinned above by *retires split segments one day at
+   * a time*, and that is the behaviour a broader fix would break: exempting every
+   * `_isMultiDaySegment` would stop the waste feed retiring at all once a collection spans
+   * a weekend. The distinction is the segment's **origin**, not its shape.
+   */
+  it('leaves the middle day of a split timed event alone', () => {
+    // Yesterday 09:00 through tomorrow 17:00, so today is a middle segment.
+    const conference: Types.CalendarEventData[] = [
+      {
+        summary: 'Conference',
+        start: { dateTime: '2026-06-16T09:00:00.000Z' },
+        end: { dateTime: `${TOMORROW}T17:00:00.000Z` },
+        _entityId: 'calendar.waste',
+      },
+    ];
+
+    const entity = { allday_expires_at: '10:00', split_multiday_events: true };
+
+    // Today's middle segment and tomorrow's closing segment. Yesterday's is outside the
+    // window, which opens today.
+    expect(render(conference, entity)).toEqual(['Conference', 'Conference']);
+  });
+
+  it('control: the same split event with no expiry set keeps the same two days', () => {
+    // Without this, the assertion above cannot tell "the expiry left it alone" from "the
+    // window or the splitter never produced it".
+    const conference: Types.CalendarEventData[] = [
+      {
+        summary: 'Conference',
+        start: { dateTime: '2026-06-16T09:00:00.000Z' },
+        end: { dateTime: `${TOMORROW}T17:00:00.000Z` },
+        _entityId: 'calendar.waste',
+      },
+    ];
+
+    expect(render(conference, { split_multiday_events: true })).toEqual([
+      'Conference',
+      'Conference',
+    ]);
+  });
+
+  /**
    * Per-calendar, and only this calendar. The card's other calendars keep their all-day
    * events, which is the whole reason the option is not card-level: a household calendar's
    * birthdays should not vanish at 10:00 because the bin feed does.

--- a/tests/text-replace.test.ts
+++ b/tests/text-replace.test.ts
@@ -330,6 +330,27 @@ describe('the age count from #124', () => {
     expect(drawn(allDay(BIRTHDAY), { replace_pattern: '.+' }).summary).toBe('');
   });
 
+  it('is suppressed when a pattern left the title as whitespace', () => {
+    // The near-miss of the case above, and the one that reached the leak it exists to
+    // prevent. The guard asked `text === ''` while `appendAgeCount` asks
+    // `text.trim() !== ''`, so the two disagreed on exactly the inputs that are blank but
+    // not empty — and a title reduced to a single space rendered a bare `(40)`.
+    //
+    // Reachable from an ordinary pattern rather than a contrived one: any rewrite whose
+    // remainder is a separator. `Alex Geburtstag` minus `[A-Za-z]+` is two spaces.
+    expect((drawn(allDay(BIRTHDAY), { replace_pattern: '[A-Za-z]+' }).summary ?? '').trim()).toBe(
+      '',
+    );
+  });
+
+  it('appends to a title that was only ever whitespace, which is not a deletion', () => {
+    // The discriminator for the fix above, and the reason the guard trims **both** sides.
+    // Nothing was taken away from this title, so it is not withheld — it is simply absent,
+    // and `appendAgeCount` deliberately draws a bare count for an untitled event. Trimming
+    // only the right-hand side would reclassify this as a deletion and suppress it.
+    expect(drawn(allDay({ ...BIRTHDAY, summary: '   ' }), {}).summary).toBe('(40)');
+  });
+
   it('still appends when the rewrite targets another field', () => {
     // The discriminator for the two suppression cases above: a rewrite of the *location*
     // says nothing about the title, so an implementation suppressing on any configured


### PR DESCRIPTION
Pre-release audit of the v4.1 runtime surface (`src/utils/`, `src/config/`). Two defects found and fixed, both cross-feature — each is invisible from the feature it belongs to, and neither was reachable by the isolated testing each feature got.

## 1. `allday_expires_at` deleted the middle of a split timed event

`splitMultiDayEvent` rewrites the middle days of a **timed** multi-day event as `start: { date }` segments, so they read as all-day to every later test — including this option's. A calendar configured to retire bin collections at 10:00 therefore also deleted the Tuesday of a Monday-to-Wednesday conference **while it was still in progress**. The event did not disappear; it lost a day out of its middle, which reads as a data problem rather than a configuration one.

Two things hid it. The option is unset in `DEFAULT_CONFIG`, so it is invisible to a suite built from defaults unless a case sets it. And the **default** is correct for these segments — midnight after the segment's own day is exactly right — so only an explicit time misfires.

Segments now record the class of the event they came from, and the configured time is withheld from timed-origin ones while the default still applies to them.

**Withholding the value rather than skipping the branch is the load-bearing part.** Exempting these segments from expiry outright reopens the defect the option's default was introduced to close: with a backwards window (`start_date: 'today-7'`) and `show_past_events: false`, the middle days of last week's meetings would stay on the card.

**Exempting every `_isMultiDaySegment` — the obvious wider fix — is wrong**, and I checked rather than assumed. Segments of a genuinely all-day event carry that flag too and must keep retiring one day at a time; that is the waste-feed case and it is already pinned by *"retires split segments one day at a time"*, which the wider fix turns red (`['Away','Away']` vs `['Away']`). The distinction is the segment's **origin**, not its shape.

## 2. #124's age count could still leak on a blanked title

`titleWithheld` tested `text === ''` while `appendAgeCount` tests `summary.trim()`. The two therefore disagreed on precisely the blank-but-not-empty titles an ordinary pattern produces — `Alex Geburtstag` minus `[A-Za-z]+` is two spaces — which passed the guard, failed the append's own empty test, and rendered a bare `(40)`.

That is the #212 privacy leak the guard exists to prevent, reached by a near-miss input, and louder than `Busy (40)` since a lone bracketed number is nothing else.

Both sides are now trimmed. The right-hand side so the two tests ask one question; the left-hand side so a title that was *already* only whitespace is not misread as a deletion — nothing was taken away from it, and it keeps the bare count an untitled event has always drawn. That second case is pinned as its own test, because trimming only the right side would silently reclassify it.

## 3. Stale docblock

`appendAgeCount`'s docblock still described #153 and #212 as hypothetical (*"If a `title_replace` option is ever built…"*) after both shipped in v4.1. It now states the constraints in the present tense, names the `groupEventsByDay` call sites that implement them, and records why the two empty-title tests must stay spelled the same way. Reported by the sibling docs session and fixed here since it is in `src/utils/`.

## Verification

Both defects were reproduced with failing tests **before** either fix. Mutation results differ per site, which is the signature of real detection rather than a probe measuring itself:

| Mutation | Result |
| --- | --- |
| Guard reverted to the original | *leaves the middle day of a split timed event alone* fails |
| Sibling's wider fix (exempt every `_isMultiDaySegment`) | *retires split segments one day at a time* fails |
| Flag removed from **middle** segments | 1 failed / 2551 passed |
| Flag removed from **first + last** segments | 2552 passed — inert there by design, and documented as such |
| Unmutated control | 2756 passed across 137 files |

All nine gates pass, run under Node 22 (v22.23.2) as well as the local Node 25, since `check:bundle` and the CLDR-sensitive locale test are not portable across majors.

## Areas checked and found clean

Established by execution, not reading:

- **`replace_*` cannot change which events exist**, in both directions and on `filter_field: location` as well as the title. A blocklist matching only the *rewritten* text does not filter; one matching the *raw* text still does; `show_location: false` does not empty the filter's subject. The core property was already pinned for the title field, so no redundant test was added.
- **`event_type` × splitting.** `timed` keeps all three segments of a split timed event and `all_day` drops it entirely, confirming `filterEventsByType` runs before the split. AGENTS.md asserts this; it is now verified by running it.
- **`event_type` × `days_of_week` × `allday_expires_at`** on one block behaves coherently.
- **`days_of_week`** correctly drops weekend segments of a split timed event, and works in column view.
- **Expiry boundaries**: `00:00` retires immediately, `23:59` holds, and `24:00` and `''` both fall back to the default.
- **Column view** behaves identically for the new options, including the fix above.
- **`normalizeEntities`** drops entries whose `entity` key is missing or empty, which makes the one asymmetry I found — `resolveDaysOfWeek` reads `_matchedConfig` directly while `allday_expires_at` goes through `getEntitySetting`, which returns `undefined` on a falsy entity id — **unreachable**. It exists in the code; no input exposes it.

Read rather than run: `PROCESSING_TIME_KEYS` is still exactly right (`resolveEventType` is the only card-level processing-time read), and the four user-supplied regexes are consistent — render-path patterns cache their failures, fetch-path ones compile once per entity per fetch, and all four cost the user their rule rather than their content.

## Not fixed, reported instead

- `replace_with: '$1'` with no capture group renders the literal `$1`. Standard `String.replace` semantics; a docs note at most, and `docs/` is another session's scope.
- A multi-day event spanning New Year with a `YEAR=` marker shows a different count per segment, since each reads its own segment's year. Real but not a configuration anyone has.