### PR TITLE
docs: audit the v4.1 documentation against the code it describes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ show_month: false
 
 Swap `calendar.family` for one of your own `calendar.*` entities and you have a working card.
 
-**➡️ From here, [Usage](https://calendar-card-pro.alexpfau.com/guide/usage) walks you through multiple calendars, per-calendar colours and compact mode. Every available option is listed in the [Configuration reference](https://calendar-card-pro.alexpfau.com/reference/configuration), and more ready-made setups are in [Examples](https://calendar-card-pro.alexpfau.com/reference/examples).**
+**➡️ From here, [Usage](https://calendar-card-pro.alexpfau.com/guide/usage) walks you through multiple calendars, per-calendar colors and compact mode. Every available option is listed in the [Configuration reference](https://calendar-card-pro.alexpfau.com/reference/configuration), and more ready-made setups are in [Examples](https://calendar-card-pro.alexpfau.com/reference/examples).**
 
 <p align="right"><a href="#top">⬆️ back to top</a></p>
 
@@ -154,6 +154,8 @@ Swap `calendar.family` for one of your own `calendar.*` entities and you have a 
 - 🗂️ **Split One Calendar by Event Type**: [`event_type`](https://calendar-card-pro.alexpfau.com/features/core-settings) takes `all`, `timed` or `all_day`, card-wide or per calendar — list one calendar twice, once each way, for a color on each, and [**Duplicate** in the editor](https://calendar-card-pro.alexpfau.com/features/editor#per-calendar-panels-actions) builds it for you
 - 🔍 **Two New Per-Calendar Filters**: [`allday_expires_at`](https://calendar-card-pro.alexpfau.com/features/core-settings#retiring-all-day-events-during-the-day) gives one calendar's all-day events the end time they lack, so a bin collection stops sitting on the card until midnight, and [`days_of_week`](https://calendar-card-pro.alexpfau.com/features/core-settings#showing-a-calendar-on-weekdays-only) keeps a single calendar to weekdays or weekends while every other one keeps its weekend
 - 💬 **Teams Meetings Get the Teams Icon**: online meetings now show [the Teams logo instead of a map pin](https://calendar-card-pro.alexpfau.com/features/event-content#the-location-icon), automatically and in any language Teams writes them in — set `location_icon` on a calendar to name a different icon, or the plain marker to opt out
+- 🎂 **Ages on Birthdays, Counts on Anniversaries**: Write `YEAR=1986` in a birthday event's description and the card appends the age to the title — [nothing to configure](https://calendar-card-pro.alexpfau.com/features/event-content#birthday-ages-anniversary-counts), and it stays right every year, because each occurrence of a repeating birthday already carries its own date
+- ✏️ **Rewrite What an Event Says**: [`replace_pattern`, `replace_with` and `replace_field`](https://calendar-card-pro.alexpfau.com/features/core-settings#text-replacement) rewrite one field of a calendar's events as the card draws them, leaving the calendar untouched — strip a `Geburtstag von ` prefix off every birthday, or show `Busy` in place of every title on a shared family card. [One Calendar, Many Purposes](https://calendar-card-pro.alexpfau.com/guide/one-calendar-many-purposes) puts this and three of the options above into a single card
 
 ### v4.0
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -38,7 +38,7 @@ entities:
 
 `Birthday of Lena Weber — All day` becomes **🎂 Lena Weber (32)**, and says 33 next year without anyone editing anything. Bin day retires itself at eleven. The children see that a parent is busy at nine, not that the meeting is a performance review. The first three blocks are the **same calendar**, three times.
 
-Four of the features below are in those thirty lines, and not one of them is announced — you write what you want the row to say, and the card gets out of the way. The walkthrough is [One Calendar, Many Purposes](https://calendar-card-pro.alexpfau.com/guide/one-calendar-many-purposes); everything from here on is the parts list.
+Four of the features below are in those twenty-five lines, and not one of them is announced — you write what you want the row to say, and the card gets out of the way. The walkthrough is [One Calendar, Many Purposes](https://calendar-card-pro.alexpfau.com/guide/one-calendar-many-purposes); everything from here on is the parts list.
 
 ## 🎉 New Features
 
@@ -76,11 +76,11 @@ Because a birthday is stored as an event that repeats every year, each occurrenc
 
 ### 💬 A Teams Icon on Your Teams Meetings
 
-**Your online meetings now show the Teams logo instead of a map pin, and there is nothing to set up.** The card recognises the location text Teams writes into an event — including its translations, so `Microsoft Teams-Besprechung` and `Réunion Microsoft Teams` are recognised alongside the English wording — as well as a `teams.microsoft.com` join link stored there in place of a phrase. Meetings that are actually somewhere keep the map pin.
+**Your online meetings now show the Teams logo instead of a map pin, and there is nothing to set up.** The card recognizes the location text Teams writes into an event — including its translations, so `Microsoft Teams-Besprechung` and `Réunion Microsoft Teams` are recognized alongside the English wording — as well as a `teams.microsoft.com` join link stored there in place of a phrase. Meetings that are actually somewhere keep the map pin.
 
 **This changes how your card looks the moment you upgrade**, if you have Teams meetings on it. To go back to the map pin on a calendar, give it `location_icon: mdi:map-marker-outline`.
 
-Teams is the only service recognised this way, and the reason is worth stating plainly because the obvious next question is "why not Zoom": Material Design Icons, the set Home Assistant ships, has a brand icon for Teams and none for Zoom, Google Meet or Webex. There is simply no logo to show for the others. The new per-calendar `location_icon` covers every other case — including anyone who has installed an icon pack of their own — by naming the icon one calendar's locations should carry. (#205)
+Teams is the only service recognized this way, and the reason is worth stating plainly because the obvious next question is "why not Zoom": Material Design Icons, the set Home Assistant ships, has a brand icon for Teams and none for Zoom, Google Meet or Webex. There is simply no logo to show for the others. The new per-calendar `location_icon` covers every other case — including anyone who has installed an icon pack of their own — by naming the icon one calendar's locations should carry. (#205)
 
 ### 🔍 Filter on the Location or the Description
 

--- a/docs/features/column-view.md
+++ b/docs/features/column-view.md
@@ -164,7 +164,7 @@ column:
   filter_duplicates: true # and too narrow to show the same meeting twice
 ```
 
-An entry the card does not recognise is ignored rather than treated as an error, so one stray line cannot break the rest of the card. If an override seems to do nothing, check it is not one of the options above.
+An entry the card does not recognize is ignored rather than treated as an error, so one stray line cannot break the rest of the card. If an override seems to do nothing, check it is not one of the options above.
 
 ## 💤 Options That Do Nothing in Column View
 

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -180,7 +180,7 @@ calendar in a way a color does not — a single label in front of every event wo
 nothing about which calendar the event came from.
 
 **A calendar Home Assistant has no icon for shows no label**, rather than an empty space
-where one would go. That is the same nothing an unlabelled calendar shows, so mixing the two
+where one would go. That is the same nothing an unlabeled calendar shows, so mixing the two
 costs nothing in alignment.
 
 Most integrations supply no icon, so this usually means setting one yourself — the same
@@ -438,6 +438,11 @@ Wednesday retires on Wednesday morning rather than Monday's. Split the calendar 
 Leaving the option out keeps the default, midnight — the option changes _when_ within the
 final day, never _whether_.
 
+Write the time as `HH:MM` on a 24-hour clock. A single-digit hour works, and so do seconds
+if you want them, so `9:30` and `10:00:30` are both read. A value the card cannot read as a
+time falls back to midnight, which looks exactly like leaving the option out — so check the
+value first if a calendar is not retiring when you expect it to.
+
 ::: warning It Only Applies While Past Events Are Hidden
 `allday_expires_at` decides _when_ an all-day event becomes past. Whether past events are
 drawn at all is [`show_past_events`](/reference/configuration#core-settings), which
@@ -498,7 +503,7 @@ view defaults to, the day still appears carrying the usual _No upcoming events_ 
 :::
 
 Weekend means Saturday and Sunday. That is the same definition the
-[weekend colors](/features/layout-appearance#week-numbers-visual-separators) use, so a day
+[weekend colors](/features/layout-appearance#date-column-customization) use, so a day
 this option treats as a weekend is a day the card already colors as one.
 
 ### Filtering Duplicate Events
@@ -725,6 +730,13 @@ is the other way round.
 An empty field is never filled in. A `replace_with` on the location rewrites the events that
 have one and leaves the rest alone, rather than giving every event a location it never had.
 
+::: warning Rewriting a Location Also Decides Its Icon
+The [Teams icon](/features/event-content#the-location-icon) is chosen from the location the
+card is about to draw, so a rewrite that removes the words `Microsoft Teams` — or the join
+link — takes the Teams icon with it and leaves the map marker. Set `location_icon` on the
+same block to name the icon you want and the detection stops mattering either way.
+:::
+
 ### One Field Per Block
 
 ::: warning A Calendar Cannot Be Listed Twice to Rewrite Two Fields
@@ -761,7 +773,7 @@ Calendar Card Pro offers powerful controls for managing what appears in compact 
 days_to_show: 7
 
 # Event limit for compact mode
-compact_events_to_show: 5 # Preferred: New parameter name
+compact_events_to_show: 5 # Preferred: New option name
 
 # Day limit in compact mode
 compact_days_to_show: 2 # Fewer days to display in compact mode

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -640,6 +640,9 @@ Three per-calendar options do it. `replace_field` names which field to rewrite a
 to the title; `replace_pattern` is what to find, as a regular expression; `replace_with` is
 what to put there.
 
+[One Calendar, Many Purposes](/guide/one-calendar-many-purposes) puts all three to work in a
+single card, alongside the filters above.
+
 ### What Each Combination Does
 
 `replace_pattern` and `replace_with` are independently optional, and which of them you set

--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -24,7 +24,7 @@ The editor is organized into nine panels, each named for what it configures rath
 
 Panels open one at a time, and options inside them appear only when they apply — enabling a feature reveals the settings that belong to it.
 
-The longer panels are divided further by sub-headings, which name what the options beneath them decide. **Calendars** and **Time Range & Content** share the same spine, because they configure the same pipeline one level apart: **Which Events Appear** comes first, then **Events Across Several Days**. A calendar adds **Label & Colors** above them and **What Each Event Shows** below; the card-level panel adds **When There Is Nothing To Show** at the end. Reading either panel therefore answers the same questions in the same order.
+The longer panels are divided further by sub-headings, which name what the options beneath them decide. **Calendars** and **Time Range & Content** share the same spine, because they configure the same pipeline one level apart: **Event Filtering** comes first, then **Multi-Day Events**. A calendar adds **Label & Colors** above them, **Text Replacement** between the two — its options are written the same way the filters are, so the two read as a pair — and **Event Details** below; the card-level panel adds **Empty Days** at the end. Reading either panel therefore answers the same questions in the same order.
 
 ## ✨ Key Features
 

--- a/docs/features/event-content.md
+++ b/docs/features/event-content.md
@@ -105,7 +105,7 @@ This would keep location details like "Paris, France" intact while simplifying d
 ### The Location Icon
 
 Locations carry a map marker by default, and Microsoft Teams meetings carry the Teams
-icon instead. That happens on its own, with nothing to configure: the card recognises the
+icon instead. That happens on its own, with nothing to configure: the card recognizes the
 text Teams writes into an event's location — including its translations, such as
 `Microsoft Teams-Besprechung` or `Réunion Microsoft Teams` — as well as a
 `teams.microsoft.com` join link stored there in place of a phrase.
@@ -134,6 +134,11 @@ Name the marker explicitly — `location_icon: mdi:map-marker-outline` — and t
 goes back to the plain marker on every event. `location_icon_size` above sizes whichever
 icon ends up being drawn.
 :::
+
+The detection reads the location the card is about to draw, not the one your calendar sent,
+so [rewriting a location](/features/core-settings#replacing-a-location-that-is-a-meeting-url)
+can take the Teams icon away or hand it to an event that never had it. `location_icon`
+settles it on any calendar where that matters.
 
 ## 📝 Event Description Display
 
@@ -210,7 +215,7 @@ The marker is instruction to the card, not something to read, so it never appear
 Filtering is the deliberate exception. [`blocklist` and `allowlist`](/features/core-settings) read the event exactly as your calendar delivered it, so a `filter_field: description` pattern still sees the raw `YEAR=1986`. That is what makes it possible to filter a birthday calendar on its markers.
 
 ::: info Always On, and How to Turn It Off
-There is no option for this. A four-digit year written this precisely is not something a calendar produces by accident, so an option would be one more setting for everybody in exchange for a case that does not really happen — and the way back is simply to write the year differently: `Born in 1986`, or `YEAR - 1986`, are both invisible to the card.
+There is no option for this. A four-digit year written this precisely is not something a calendar produces by accident, so an option would be one more thing to configure for everybody in exchange for a case that does not really happen — and the way back is simply to write the year differently: `Born in 1986`, or `YEAR - 1986`, are both invisible to the card.
 
 One thing worth knowing on a narrow card: the number sits at the end of the title, so it is the first thing to be cut when `title_max_lines` truncates a long one.
 :::
@@ -318,4 +323,4 @@ column:
 
 The progress bar is especially useful for tracking ongoing meetings, webinars, or appointments, giving you a quick visual reference of how much time remains.
 
-Every option on this page lives under the card's event column settings — see [Event Column in the configuration reference](/reference/configuration#event-column).
+Most options on this page live under the card's event column settings — see [Event Column in the configuration reference](/reference/configuration#event-column). Two groups sit elsewhere: the empty-day options are card-wide and belong to [Core Settings](/reference/configuration#core-settings), and `location_icon` is per calendar, listed under [Per-Entity Options](/reference/configuration#per-entity-options).

--- a/docs/features/layout-appearance.md
+++ b/docs/features/layout-appearance.md
@@ -257,7 +257,7 @@ The date column appears on the left side of each day's events and helps users qu
 - **Weekend days** (Saturday and Sunday) using the `weekend_*` options
 - **Today's date** using the `today_*` options
 
-When special styling parameters are not specified, they will inherit from the base styling. If today falls on a weekend, today styling takes precedence over weekend styling.
+When the special styling options are not specified, they will inherit from the base styling. If today falls on a weekend, today styling takes precedence over weekend styling.
 
 ## 🌟 Today Indicator
 

--- a/docs/features/multi-day-events.md
+++ b/docs/features/multi-day-events.md
@@ -3,7 +3,7 @@
 Calendar Card Pro can display multi-day events on each day they cover, making it easier to see all ongoing events and potential conflicts:
 
 ```yaml
-# Global setting for all calendars
+# Global option for all calendars
 split_multiday_events: true
 
 # Entity-specific settings
@@ -30,9 +30,9 @@ This feature is especially useful for:
 
 Because each row stands for a day rather than for the event as a whole, a [countdown](/features/event-content#countdown-display) on a split row counts whole calendar days to that row's own date. A holiday starting Monday reads as "in 4 days" on its first row, "in 5 days" on the second, and so on, whether or not the original event had a start time.
 
-The setting can be applied globally to all calendars or controlled separately for each calendar entity.
+The option can be applied globally to all calendars or controlled separately for each calendar entity.
 
-This is the `split_multiday_events` option — see [Event Column in the configuration reference](/reference/configuration#event-column).
+This is the `split_multiday_events` option — see [Core Settings in the configuration reference](/reference/configuration#core-settings).
 
 ::: tip Column View Splits by Default
 In the [column layout](/features/column-view) this option starts from `true` rather than

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -82,6 +82,7 @@ Calendar Card Pro offers two ways to customize your card:
 ## 🚀 Next Steps
 
 - **Explore the Features** - [Core Settings](/features/core-settings), [Layout & Appearance](/features/layout-appearance) and [Event Content](/features/event-content) cover the options most people reach for first
+- **Follow a Worked Example** - [One Calendar, Many Purposes](/guide/one-calendar-many-purposes) builds a single hallway card out of one calendar listed three times, explaining each setting as it goes
 - **Discover Advanced Capabilities** - Add [weather forecasts](/features/weather), filter events with [blocklists and allowlists](/features/core-settings), or set up [tap and hold actions](/features/actions)
 - **See Examples** - Browse [Examples](/reference/examples) for complete, ready-made setups
 - **Reference Configuration** - Use [Configuration Options](/reference/configuration) as the complete option reference

--- a/docs/guide/whats-new.md
+++ b/docs/guide/whats-new.md
@@ -14,8 +14,10 @@ public release in January 2025 to today.
 - 🗑️ **All-Day Events That Clear During the Day**: [`allday_expires_at`](/features/core-settings#retiring-all-day-events-during-the-day) moves the moment one calendar's all-day events count as past earlier into the final day, so a bin emptied this morning stops sitting on the card until midnight
 - 🐛 **Finished All-Day Events Stayed on the Card**: with past events hidden, an all-day event that had already ended kept its row on any card whose window reached backwards, while timed events beside it were correctly gone
 - 📅 **A Calendar on Weekdays Only**: [`days_of_week`](/features/core-settings#showing-a-calendar-on-weekdays-only) takes `weekdays` or `weekends` for a single calendar, judged on the day each row lands on, while every other calendar keeps its weekend
+- 🎂 **Ages on Birthdays, Counts on Anniversaries**: Write `YEAR=1986` in a birthday event's description and the card appends the age to the title — [nothing to configure](/features/event-content#birthday-ages-anniversary-counts), and it stays right every year, because each occurrence of a repeating birthday already carries its own date
 - 💬 **Teams Meetings Get the Teams Icon**: online meetings show [the Teams logo in place of the map pin](/features/event-content#the-location-icon) automatically, in any language Teams writes them in, and the new per-calendar `location_icon` names a different icon for any calendar — including back to the plain marker
 - 🔍 **Filter on the Location or Description**: [`filter_field`](/features/core-settings#matching-the-location-or-description-instead) points `blocklist` and `allowlist` at an event's location or description instead of its title, so a Zoom URL in a location field can finally be filtered on
+- ✏️ **Rewrite What an Event Says**: [`replace_pattern`, `replace_with` and `replace_field`](/features/core-settings#text-replacement) rewrite one field of a calendar's events as the card draws them, leaving the calendar untouched — strip a `Geburtstag von ` prefix off every birthday, or show `Busy` in place of every title on a shared family card
 
 ## v4.0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,6 @@ Built with **performance in mind**, the card leverages **intelligent refresh mec
 
 **Calendar Card Pro** requires at least **one calendar entity** in Home Assistant. It is compatible with any integration that generates `calendar.*` entities, with **CalDAV** and **Google Calendar** being the primary tested integrations.
 
-:::warning Prerequisite
+::: warning Prerequisite
 Ensure you have at least **one calendar integration set up** in Home Assistant before using this card.
 :::


### PR DESCRIPTION
Eleven features, documented by six sessions over one day, each writing only its own section. Nobody had read the result end to end. This is that read, plus the fixes.

Scope was `docs/` and `README.md` only — `src/` and `tests/` belong to sibling sessions. Two code defects found are reported at the bottom rather than fixed.

## The one that matters most

**`docs/features/editor.md` described editor sub-headings that v4.1 renamed away.** Four of the five names in the shared-spine paragraph no longer exist, and the section this release added was missing entirely:

| the page said | the editor says |
| --- | --- |
| Which Events Appear | **Event Filtering** |
| Events Across Several Days | **Multi-Day Events** |
| What Each Event Shows | **Event Details** |
| When There Is Nothing To Show | **Empty Days** |
| Label & Colors | Label & Colors — the only survivor |
| *(absent)* | **Text Replacement** |

Verified against the `heading_*` block in `src/rendering/editor/strings.ts` and the schema order in `schemas/entity.ts` (`buildEntitySchema`) and `schemas/content.ts`. Not ambiguity: the comment above those strings names `Which Events Appear` and `What Each Event Shows` explicitly as "the earlier set". A reader trusts documentation over their own screen, so prose describing a UI that shipped differently reads as the card being broken.

## Cross-links that resolve but land in the wrong place

Worth calling out on its own, because **an anchor that exists passes every gate we have**. `check:docs` resolved both of these happily; only reading catches them.

- The weekend-colors link pointed at `layout-appearance#week-numbers-visual-separators`. Those options are under **Date Column Customization**.
- `multi-day-events.md` sent `split_multiday_events` to **Event Column**, where it has never lived — it is a **Core Setting**.

## A false absolute

`event-content.md` closed with "Every option on this page lives under the card's event column settings." Four do not: `show_empty_days`, `empty_day_text` and `hide_when_empty` are card-wide Core Settings, and `location_icon` is per-calendar and in no reference table at all.

## Two v4.1 features interact and neither section said so

`resolveLocationIcon` is handed the location the card is **about to draw** (`presentation.ts`: *"Read from the location the card is about to draw, not the raw event"*), and text replacement rewrites exactly that string in `groupEventsByDay`. So `replace_field: location` can take the Teams icon away — or hand it to an event that never had it. Stated once on each side, with `location_icon` named as the settlement, rather than as a caveat pile.

## Everything else

- `allday_expires_at` documented only `HH:MM`; `TIME_OF_DAY_PATTERN` also accepts a single-digit hour and optional seconds. Widened the docs rather than narrowing the pattern. The fallback is described **without** promising a console message — `Logger.warn` is gated by `CURRENT_LOG_LEVEL`, which the production build rewrites to `ERROR`, so users never see it. (`Logger.deprecation` calls `console.warn` directly and bypasses the gate, which is why the editor page's console instruction *is* correct and my first draft of this one would not have been.)
- Both What's New surfaces were missing **birthday ages** and **text replacement**. The archive gains both; the README reel goes 4 → 6 bullets, with the flagship story linked from the text-replacement bullet.
- `One Calendar, Many Purposes` shipped reachable from the sidebar and the release notes only — no feature page and not Usage. Added a Next Steps bullet and one line under Text Replacement, the section it demonstrates.
- British spellings: `recognises`, `unlabelled`, `recognise`, `colours`, and `recognises`/`recognised` ×3 in the **unreleased** v4.1 release notes. (`RELEASE_NOTES.md` is style-exempt in `check-docs.mjs` as a historical record — that rationale does not cover a section describing a release that has not happened.)
- Wrong noun for a config key in four places, none of them the backticked construction check 15 matches.
- The release-notes intro counted "thirty lines" in a twenty-five-line example.
- One `:::warning` without a space, the only one in the tree.

## Verified clean, with the method

- **Every YAML block parses**, and every key in one resolves to a real config field — extracted from `types.ts` + `config.ts` and diffed. The 9 parse "failures" are all the deliberate repeated-key "pick one" idiom, all pre-existing, none in a v4.1 section.
- **Every v4.1 option** has a prose section *and* a real YAML example. No repeat of the `show_countdown_allday` table-row-only failure.
- **All language counts**: 11 / 35 / nine / ten / 24 in `editor.md` and `contributing.md` reconcile against the files. The release notes' **364** strings per full language, **44** in `en-GB` and **52** added this release are exact — the last confirmed by diffing `de.json` against `v4.0.0` (312 → 364).
- **Every birthday-marker claim** checked against the `MARKER` regex, including `YEAR=198`, `YEAR=19866`, `BIRTHYEAR=`, `?year=`, `YEAR = 1986` and the no-count-below-1 rule.
- **The text-replacement duplication limitation** is stated in all four places a reader meets it. It is also correctly precise about which case they hit: `filter_duplicates` defaults to `false`, so the default outcome is both blocks rendering, and the silent-drop needs the option on.
- **Home Assistant 2026.2** for calendar colors, confirmed against the upstream changelog.
- **The ordering claims** in `core-settings.md` match the numbered comment in `groupEventsByDay` exactly, including the title case running *before* `appendAgeCount`.
- Confirmed by **simulating the version bump** that `check:docs` still passes at 4.1.0. `package.json` is left at 4.0.0 — bumping it is release-PR work.

## Code defects found, deliberately not fixed

1. **`src/utils/event-age.ts`**, `appendAgeCount` docblock: *"🚨 If a `title_replace` option is ever built (#153), it runs **before** this."* It **was** built in v4.1 as `replace_pattern`, and the ordering it asks for is implemented and tested. The conditional framing now reads as pending work.
2. Minor: the docs previously under-described `allday_expires_at`'s accepted formats. Resolved on the docs side, per the call to keep the permissive pattern.

## Not done

- `whats-new.md` and the README's v4.1 entries were brought current but **not** re-curated or restructured — that stays release-PR work.
- Three v4.1 release-notes headings use "and" where the style rule prefers `&`. Left alone: `RELEASE_NOTES.md` is in `STYLE_EXCLUDES`, and "and" there is grammatical rather than a topic join.
- `docs/contributing.md` instructs "in alphabetical order" but the list places Croatian and the two Chinese entries by language *code*. Pre-existing, cosmetic, and reordering risks the count reconciliation for no reader benefit — flagged rather than changed.

`check:docs`, `check:format` and `docs:build` all pass.