### PR TITLE
fix(editor): resolve the Events panel's styling gates per view

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -60,7 +60,7 @@ question. HACS does all of this for you, which is why it is the recommended rout
 ::: tip Optional: Compress The Files Yourself
 Home Assistant serves a pre-compressed `.gz` beside a file when it finds one, and does not
 compress on the fly. Neither install route ships one, so the card transfers at its full
-199 KB and the editor at 349 KB — once per version, then the browser caches both.
+199 KB and the editor at 350 KB — once per version, then the browser caches both.
 
 If you want the smaller transfer, create the companions yourself and keep them beside the
 originals:

--- a/src/rendering/editor/schemas/events.ts
+++ b/src/rendering/editor/schemas/events.ts
@@ -4,6 +4,7 @@
 
 import { mdiCalendarText } from '@mdi/js';
 
+import * as ViewConfig from '../../../config/view';
 import * as Helpers from '../../../utils/helpers';
 import type { HaFormSchema } from '../ha-form';
 import type { SchemaCtx } from '../panels';
@@ -172,14 +173,23 @@ const eventsSchema = Helpers.memoizeLast(
  * @returns The panel's schema
  */
 export function buildEventsSchema(ctx: SchemaCtx): HaFormSchema[] {
+  // 🚨 Each of these five gates a group of styling fields, and every one of them is a
+  // `COLUMN_OVERRIDE_KEYS` member — so reading `ctx.config` directly answers for the card
+  // rather than for the view it is configured to render. A card with
+  // `column: { show_location: true }` over a card-level `false` drew its locations and
+  // offered no control for styling them, which is the direction that costs the user
+  // something they can see on screen. `schemas/content.ts` already resolves per view for
+  // `show_empty_days`; this is the same read.
+  //
+  // The resolved values are the memo keys, not the raw ones, so switching view rebuilds.
   return eventsSchema(
     ctx.language,
-    ctx.config.show_time,
-    ctx.config.show_location,
-    ctx.config.show_description,
+    ViewConfig.resolveViewOption(ctx.config, 'show_time', ctx.view),
+    ViewConfig.resolveViewOption(ctx.config, 'show_location', ctx.view),
+    ViewConfig.resolveViewOption(ctx.config, 'show_description', ctx.view),
     Synthetic.locationCountryMode(ctx.config),
-    ctx.config.show_countdown,
-    ctx.config.show_progress_bar,
+    ViewConfig.resolveViewOption(ctx.config, 'show_countdown', ctx.view),
+    ViewConfig.resolveViewOption(ctx.config, 'show_progress_bar', ctx.view),
     Synthetic.accentColorMode(ctx.config),
   );
 }

--- a/tests/editor-events-view-scope.test.ts
+++ b/tests/editor-events-view-scope.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import type { HaFormSchema } from '../src/rendering/editor/ha-form';
+import { walkSchema } from '../src/rendering/editor/panels';
+import { buildEventsSchema } from '../src/rendering/editor/schemas/events';
+
+/**
+ * The card-level Events panel must offer the styling controls that apply in the view the
+ * card renders, not the ones that would apply in list view.
+ *
+ * 🚨 Every `show_*` flag gating a styling group is a `COLUMN_OVERRIDE_KEYS` member, so a
+ * card carrying a `column:` block renders one thing and configures another. Reading
+ * `ctx.config` directly answered for the card; `resolveViewOption` answers for the view.
+ *
+ * The harmful direction is the second of the two below: locations render in column view
+ * and every control for styling them is absent from the editor, so the user can see the
+ * thing on screen and has no way to configure it without hand-editing YAML.
+ */
+
+function fieldNames(schema: ReadonlyArray<HaFormSchema>): string[] {
+  return [...walkSchema(schema)]
+    .filter(({ node }) => !('schema' in node))
+    .map(({ node }) => node.name);
+}
+
+function eventsFields(config: Types.Config, view: Types.EffectiveView): string[] {
+  return fieldNames(buildEventsSchema({ view, config, language: 'en' }));
+}
+
+describe('card-level Events panel resolves its gates per view', () => {
+  it('offers location styling in column view when the column override turns locations on', () => {
+    const config = buildConfig({
+      show_location: false,
+      column: { show_location: true },
+    } as Partial<Types.Config>);
+
+    const fields = eventsFields(config, 'column');
+
+    // The control the user needs and could not reach.
+    expect(fields).toContain('location_font_size');
+    expect(fields).toContain('location_color');
+  });
+
+  it('withholds location styling in column view when the column override turns locations off', () => {
+    const config = buildConfig({
+      show_location: true,
+      column: { show_location: false },
+    } as Partial<Types.Config>);
+
+    const fields = eventsFields(config, 'column');
+
+    expect(fields).not.toContain('location_font_size');
+    expect(fields).not.toContain('location_color');
+  });
+
+  it('still reads the card-level value in list view, where no override applies', () => {
+    const on = eventsFields(
+      buildConfig({
+        show_location: true,
+        column: { show_location: false },
+      } as Partial<Types.Config>),
+      'list',
+    );
+    const off = eventsFields(
+      buildConfig({
+        show_location: false,
+        column: { show_location: true },
+      } as Partial<Types.Config>),
+      'list',
+    );
+
+    // A column override must not reach list view in either direction.
+    expect(on).toContain('location_font_size');
+    expect(off).not.toContain('location_font_size');
+  });
+
+  it('resolves every gated group, not only locations', () => {
+    // 🚨 The denominator matters: `show_location` was the one reported, and the other four
+    // are equally column-overridable. A fix covering only the reported one would pass the
+    // three cases above and leave four groups wrong.
+    const allOff = buildConfig({
+      show_time: true,
+      show_description: true,
+      show_countdown: true,
+      show_progress_bar: true,
+      column: {
+        show_time: false,
+        show_description: false,
+        show_countdown: false,
+        show_progress_bar: false,
+      },
+    } as Partial<Types.Config>);
+
+    const fields = eventsFields(allOff, 'column');
+
+    expect(fields).not.toContain('time_font_size');
+    expect(fields).not.toContain('description_font_size');
+    expect(fields).not.toContain('progress_bar_height');
+
+    // Control: the panel is not simply empty — ungated fields survive.
+    expect(fields).toContain('event_font_size');
+  });
+});


### PR DESCRIPTION
Fixes #557 before the v4.1 release rather than after it.

## What was wrong

The card-level **Events** panel decided which styling controls to show by reading the raw card-level `show_*` value. Every one of those flags is a `COLUMN_OVERRIDE_KEYS` member, so a card with a `column:` block rendered one thing and configured another.

`schemas/content.ts` already resolves per view for `show_empty_days`. This is the same read, in the panel next door.

## Both directions were wrong, and one cost the user a control

| Config | Rendered | Editor offered |
| --- | --- | --- |
| `show_location: true` + `column: { show_location: false }` | no locations | location font size, color, icon size, max lines — all inert |
| `show_location: false` + `column: { show_location: true }` | **locations** | **nothing** |

The second row is the harmful one: the user sees locations on their card and has no way to style them without hand-editing YAML.

## Five options, not one

The audit reported `show_location`. Checking the other four arguments against `COLUMN_OVERRIDE_KEYS` showed all five are affected — `show_time`, `show_location`, `show_description`, `show_countdown`, `show_progress_bar` — gating time, location, description, countdown and progress-bar styling respectively.

A fix covering only the reported option would have passed a `show_location` test and left four groups wrong, which is why the new test carries a case asserting the whole set.

## Verified in both directions

Written as a failing test first. With the fix, 4 pass. Reverting to `ctx.config.show_*` fails **3 of the 4** — and the one that still passes is the deliberate control asserting that a column override must not leak into list view, which is correct either way. A control that flipped with the fix would mean the test was measuring the fix rather than the behavior.

## Also here

`docs/guide/installation.md`: editor bundle 349 KB → 350 KB. `ViewConfig` is now imported by the editor entry, and `check:bundle` fails without the update.

## Why now rather than in its own release

I filed #557 rather than fixing it, reasoning that a behavior change to an existing panel belonged in its own release. That was my call to make and it was the wrong one — the maintainer's standard is that a known bug does not ship, and the fix is small, tested in both directions, and touches one function.

## Gates

`tsc --noEmit`, `lint`, `check:format`, `check:i18n`, `check:docs`, `test` (2768 across 139 files), `docs:build`, `build`, `check:bundle` all green.
