### PR TITLE
chore(i18n): catch the weekday-term inflections the rejected forms missed

### DIFF
--- a/scripts/editor-glossary.mjs
+++ b/scripts/editor-glossary.mjs
@@ -739,12 +739,23 @@ export const GLOSSARY_TERMS = [
       sk: 'Deň v týždni',
       sv: 'Veckodag',
     },
+    // 🚨 These are **stems, not words**, wherever a stem is safe. The matcher anchors at a
+    // word start and has no trailing boundary, so a rejected form catches inflections that
+    // *append* to it and misses any that change a character inside the stem — `darbdiena`
+    // never caught `darbdienās`, and `dzień powszedni` never caught `dni powszednie`. Of
+    // the five languages this term rejects, only Swedish was actually protected.
+    //
+    // The stems stop short of the adjective on purpose. A bare `pracovn` would catch every
+    // Slovak inflection and also `pracovný kalendár`, `pracovné stretnutie` and `pracovník`
+    // — all legitimate — and a rejected form is a build **error**, so over-matching fails
+    // CI on a correct translation. That is strictly worse than the gap it closes, which is
+    // why Polish carries one entry per case rather than a bare `powszedn`.
     rejected: {
-      sk: ['pracovný deň', 'pracovného dňa'],
-      it: ['giorno feriale'],
-      lv: ['darbdiena'],
+      sk: ['pracovný deň', 'pracovného dňa', 'pracovné dni', 'pracovných dň'],
+      it: ['giorno ferial', 'giorni ferial'],
+      lv: ['darbdien'],
       sv: ['vardag'],
-      pl: ['dzień powszedni'],
+      pl: ['dzień powszedn', 'dnia powszedn', 'dniu powszedn', 'dni powszedn', 'dniach powszedn'],
     },
   },
 ];


### PR DESCRIPTION
Closes #543.

## What was weak

The glossary's `rejected` matcher anchors at a word start and has **no trailing boundary**, deliberately, so a rejected form catches compounds. The consequence is that it only catches inflections that **append** to the form — anything changing a character inside the stem escapes.

On the `weekday` term, whose rejected forms are the "working day" noun each language reaches for first, that meant four of the five languages were unprotected:

| Language | Rejected form | Natural inflection | Caught before |
| --- | --- | --- | --- |
| sv | `vardag` | `vardagarna` | ✅ pure suffix |
| lv | `darbdiena` | `darbdienās` | ❌ `a` → `ā` |
| it | `giorno feriale` | `giorni feriali` | ❌ diverges at `giorn·o/i` |
| pl | `dzień powszedni` | `dni powszednie` | ❌ different stem |
| sk | `pracovný deň` | `pracovných dňoch` | ❌ space vs `ch` |

Nothing was wrong in the translations — every governed key was written to the decided form. This closes a hole in the check, not a defect in the output.

## Vetted by a native reader, who rejected my first proposal

My draft was a bare `pracovn` for Slovak, on the reasoning that it covers every inflection and matches nothing in the current files. I verified that second claim mechanically: zero hits across all ten translation files.

**That check was insufficient and the proposal was wrong.** A hit-count establishes what is true today; it cannot see that `pracovn` would also match `pracovný kalendár`, `pracovné stretnutie`, `pracovná doba` and `pracovník` — all legitimate Slovak a correct translation of this card might contain. A rejected form is a build **error**, so an over-matching stem fails CI on good work, which is strictly worse than the gap it closes.

The same reasoning ruled out bare `ferial` for Italian and bare `powszedn` for Polish. Polish therefore carries one entry per case rather than one stem.

## What ships

- **lv** — `darbdien`, a stem covering `darbdiena/-as/-ā/-ās/-ām/-u`. Specific to the workday word family, not general "work" vocabulary.
- **it** — `giorno ferial`, `giorni ferial`. Phrase stems, singular and plural, so `nei giorni feriali` is caught.
- **pl** — `dzień powszedn`, `dnia powszedn`, `dniu powszedn`, `dni powszedn`, `dniach powszedn`. Per-case, because the noun itself declines.
- **sk** — existing two kept, plus `pracovné dni` and `pracovných dň`.
- **sv** — unchanged; `vardag` already catches its inflections.

## Verified both directions, with a control

Every case tested against the checker's real regex:

```
lang  old-form  new-form   the inflection a translator would write
 lv   false     true       Rāda tikai darbdienās.
 it   false     true       Mostra solo nei giorni feriali.
 pl   false     true       Pokazuj tylko w dni powszednie.
 sk   false     true       Zobraziť iba v pracovných dňoch.
```

And the control that justifies the conservative choice — the shipped Slovak stem against legitimate text, beside the stem that was refused:

```
"pracovných dň" vs "Pracovný kalendár"   -> false
"pracovn"       vs "Pracovný kalendár"   -> true    <-- why it was refused
"pracovných dň" vs "Pracovné stretnutie" -> false
"pracovn"       vs "Pracovné stretnutie" -> true
"pracovných dň" vs "pracovník"           -> false
"pracovn"       vs "pracovník"           -> true
```

Without the control the first table alone would have justified the broader stem, since it also turns every row true.

## Also

A comment at the site recording that these are stems rather than words, why they stop short of the adjective, and that over-matching a build error is worse than the gap — so the next person adding a term does not "simplify" Polish's five entries into one.

`tsc`, `lint`, `check:format`, `check:i18n`, `check:docs`, `test` (2768) green.
