### PR TITLE
fix(colors): hold the registry subscription for exactly as long as a card wants it

### DIFF
--- a/scripts/editor-glossary.mjs
+++ b/scripts/editor-glossary.mjs
@@ -750,8 +750,13 @@ export const GLOSSARY_TERMS = [
     // — all legitimate — and a rejected form is a build **error**, so over-matching fails
     // CI on a correct translation. That is strictly worse than the gap it closes, which is
     // why Polish carries one entry per case rather than a bare `powszedn`.
+    //
+    // For the same reason Slovak carries `pracovných dní` in full rather than shortening
+    // `pracovných dň` to `pracovných d`. The two Slovak plurals diverge before the stem
+    // ends — genitive `dní` has a plain `n`, locative `dňoch` has `ň` — so one stem cannot
+    // reach both, and the `d` that would has `pracovných dokumentov` behind it.
     rejected: {
-      sk: ['pracovný deň', 'pracovného dňa', 'pracovné dni', 'pracovných dň'],
+      sk: ['pracovný deň', 'pracovného dňa', 'pracovné dni', 'pracovných dň', 'pracovných dní'],
       it: ['giorno ferial', 'giorni ferial'],
       lv: ['darbdien'],
       sv: ['vardag'],

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -425,6 +425,8 @@ class CalendarCardPro extends LitElement {
 
     document.addEventListener('visibilitychange', this._handleVisibilityChange);
 
+    this._syncEntityColors();
+
     this._startWidthObserver();
   }
 
@@ -587,11 +589,7 @@ class CalendarCardPro extends LitElement {
       );
     }
 
-    if (EntityColors.usesEntityColor(this.config)) {
-      EntityColors.ensureEntityColors(this.hass, this._onEntityColorsChanged);
-    } else {
-      EntityColors.releaseEntityColors(this._onEntityColorsChanged);
-    }
+    this._syncEntityColors();
 
     if (changedProps.has('hass') || changedProps.has('config')) {
       this._updateTitleSubscription();
@@ -698,6 +696,25 @@ class CalendarCardPro extends LitElement {
   private _onEntityColorsChanged = () => {
     this.requestUpdate();
   };
+
+  /**
+   * Hold a registry-color subscription for exactly as long as the config asks for one.
+   *
+   * Called from `connectedCallback` as well as `updated()`, because `disconnectedCallback`
+   * releases and Lit requests no update on reconnect — so a card that came back without a
+   * reactive property changing would stay deregistered. It re-registered in practice only
+   * because `updateEvents()` happens to flip `isLoading` on its way through, which is
+   * incidental rather than designed and does not happen when that method returns early.
+   * Every other subscription in this file is acquired in `connectedCallback`; this one now
+   * matches its neighbours.
+   */
+  private _syncEntityColors(): void {
+    if (EntityColors.usesEntityColor(this.config)) {
+      EntityColors.ensureEntityColors(this.hass, this._onEntityColorsChanged);
+    } else {
+      EntityColors.releaseEntityColors(this._onEntityColorsChanged);
+    }
+  }
 
   /**
    * Start the refresh timer

--- a/src/rendering/editor/schemas/events.ts
+++ b/src/rendering/editor/schemas/events.ts
@@ -173,13 +173,35 @@ const eventsSchema = Helpers.memoizeLast(
  * @returns The panel's schema
  */
 export function buildEventsSchema(ctx: SchemaCtx): HaFormSchema[] {
-  // 🚨 Each of these five gates a group of styling fields, and every one of them is a
-  // `COLUMN_OVERRIDE_KEYS` member — so reading `ctx.config` directly answers for the card
-  // rather than for the view it is configured to render. A card with
-  // `column: { show_location: true }` over a card-level `false` drew its locations and
+  // 🚨 Two of these config reads are deliberately raw beside five that resolve per view,
+  // and the discriminator is not which keys are column-overridable. It is this:
+  //
+  //   Resolve a gate per view when the key it reads is **not** a key the fields it opens
+  //   edit. Read it raw when the gate and the field it opens are two projections of the
+  //   **same** key.
+  //
+  // The main form is the card-level editor — `element.ts`'s `_formData()` spreads the
+  // config raw, so every value control here reports the card-level value whatever the
+  // view. `ctx.view` therefore decides which controls are *relevant to what is on screen*,
+  // never what a control reports.
+  //
+  // The five `show_*` satisfy the first half: `show_location` gates `location_font_size`
+  // and friends, which are independent keys still shown and written at card level. A card
+  // with `column: { show_location: true }` over a card-level `false` drew its locations and
   // offered no control for styling them, which is the direction that costs the user
-  // something they can see on screen. `schemas/content.ts` already resolves per view for
+  // something they can see. `schemas/content.ts` already resolves per view for
   // `show_empty_days`; this is the same read.
+  //
+  // `locationCountryMode` satisfies the second, so resolving it would be a regression
+  // rather than the same fix one line down. It and `location_country_pattern` are both
+  // projections of `remove_location_country`, and `synthetic.ts` derives the pattern from
+  // raw config — so a view-resolved gate renders an empty pattern box under a dropdown
+  // still reading "Keep", and a keystroke in that box writes the card-level key. The
+  // column value is not stranded: `overrides.ts` declares `remove_location_country` a
+  // union-typed per-view exception, so it is edited in the `column:` block where it lives.
+  //
+  // `accentColorMode` is raw for a third reason and needs no rule: `accent_color` is not a
+  // `COLUMN_OVERRIDE_KEYS` member at all, so there is no per-view value to resolve.
   //
   // The resolved values are the memo keys, not the raw ones, so switching view rebuilds.
   return eventsSchema(

--- a/src/utils/entity-colors.ts
+++ b/src/utils/entity-colors.ts
@@ -132,6 +132,7 @@ let colors: Map<string, string> = new Map();
 let loaded = false;
 let inFlight: Promise<void> | undefined;
 let unsubscribe: (() => void) | undefined;
+let subscribeGeneration = 0;
 let reportedUnavailable = false;
 
 /** Cards waiting to be told the registry moved. */
@@ -230,6 +231,8 @@ function fetchColors(hass: Types.Hass): Promise<void> | undefined {
  *
  * Home Assistant sends no payload worth patching in — its own frontend re-reads the whole
  * list — so this does the same, and only while at least one card is listening.
+ * {@link releaseEntityColors} is what enforces that second clause; it used to be a
+ * statement of intent here with nothing behind it.
  *
  * @param hass - Home Assistant instance
  */
@@ -242,6 +245,7 @@ function subscribe(hass: Types.Hass): void {
   // Claim the slot before awaiting, so two cards connecting in the same tick cannot both
   // pass the guard above and open a second subscription.
   unsubscribe = () => {};
+  const generation = ++subscribeGeneration;
 
   connection
     .subscribeEvents(() => {
@@ -251,11 +255,43 @@ function subscribe(hass: Types.Hass): void {
       }
     }, 'entity_registry_updated')
     .then((off) => {
+      // The last card can leave while this is still in flight, and the placeholder it
+      // tore down cannot close a subscription that did not exist yet. Closing it here is
+      // the only remaining chance — storing it would leave a live subscription that
+      // nothing holds a handle to.
+      if (generation !== subscribeGeneration) {
+        off();
+        return;
+      }
+
       unsubscribe = off;
     })
     .catch(() => {
-      unsubscribe = undefined;
+      if (generation === subscribeGeneration) {
+        unsubscribe = undefined;
+      }
     });
+}
+
+/**
+ * Stop watching the registry, and forget that it was ever read.
+ *
+ * Invalidating is half the job and the easier half to miss. The registry can move while
+ * nobody is subscribed, so leaving `loaded` set would let the next card read a map frozen
+ * at the moment the last one left — a regression the untorn-down subscription was
+ * accidentally preventing. `colors` itself is kept: a stale color repainted once beats
+ * rendering no color at all, which is the trade {@link entityColors} already documents for
+ * a cold cache.
+ */
+function teardown(): void {
+  subscribeGeneration++;
+
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = undefined;
+  }
+
+  loaded = false;
 }
 
 /**
@@ -296,10 +332,19 @@ export function ensureEntityColors(
 /**
  * Stop telling a card about registry changes.
  *
+ * The last card out closes the subscription. Without that, one card that opted in once
+ * left the page re-reading the whole entity registry on every `entity_registry_updated`
+ * for as long as the tab stayed open, notifying nobody and holding its `hass` — which is
+ * the opposite of what {@link subscribe} says it does.
+ *
  * @param onChange - The callback given to {@link ensureEntityColors}
  */
 export function releaseEntityColors(onChange: () => void): void {
   listeners.delete(onChange);
+
+  if (listeners.size === 0) {
+    teardown();
+  }
 }
 
 /**
@@ -307,13 +352,9 @@ export function releaseEntityColors(onChange: () => void): void {
  */
 export function resetEntityColors(): void {
   colors = new Map();
-  loaded = false;
   inFlight = undefined;
   reportedUnavailable = false;
   listeners.clear();
 
-  if (unsubscribe) {
-    unsubscribe();
-    unsubscribe = undefined;
-  }
+  teardown();
 }

--- a/tests/editor-events-view-scope.test.ts
+++ b/tests/editor-events-view-scope.test.ts
@@ -1,3 +1,40 @@
+/**
+ * The card-level Events panel must offer the styling controls that apply in the view the
+ * card renders, not the ones that would apply in list view.
+ *
+ * 🚨 Every `show_*` flag gating a styling group is a `COLUMN_OVERRIDE_KEYS` member, so a
+ * card carrying a `column:` block renders one thing and configures another. Reading
+ * `ctx.config` directly answered for the card; `resolveViewOption` answers for the view.
+ *
+ * The harmful direction is the narrative case at the foot of this file: locations render in
+ * column view and every control for styling them is absent from the editor, so the user can
+ * see the thing on screen and has no way to configure it without hand-editing YAML.
+ *
+ * 🚨 The first version of this file asserted per gate by hand and left `show_countdown`
+ * entirely unconstrained — reverting that one argument to a raw read passed all four cases,
+ * as did hardcoding four of the five to `false`. Only `show_location` was pinned in both
+ * directions, while the file's own comment claimed it asserted the whole set. The hole was
+ * not a missing assertion but a misaimed one: the case meant to cover the group checked
+ * `progress_bar_height`, which belongs to `show_progress_bar`, so `show_countdown` was
+ * never named by anything. That mattered rather than merely reading badly, because
+ * `show_countdown_allday` is itself a `COLUMN_OVERRIDE_KEYS` member.
+ *
+ * So the shape is fixed rather than the count. Each gate is pinned through a field **only
+ * that gate controls**, and `isolates its own field` proves the 1:1 rather than asserting
+ * it in a comment — a field shared with a second gate would make its row pass for the
+ * wrong reason. The table is then reconciled against the source, so a sixth gate cannot be
+ * added, nor an existing one dropped, without a row here.
+ *
+ * The denominator is hand-declared on purpose. Deriving it from the schema's own response
+ * to a toggle reads like a reconciliation and is not: a mutation that stops a key gating
+ * anything also drops it from a derived denominator, so the test would agree with the bug.
+ * There is no runtime enumeration of "gates in this panel", which is the case AGENTS.md
+ * answers with an explicit list plus a source check.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { buildConfig } from './fixtures';
@@ -7,17 +44,46 @@ import { walkSchema } from '../src/rendering/editor/panels';
 import { buildEventsSchema } from '../src/rendering/editor/schemas/events';
 
 /**
- * The card-level Events panel must offer the styling controls that apply in the view the
- * card renders, not the ones that would apply in list view.
+ * Every gate the panel resolves per view, and one field each proves reachable.
  *
- * 🚨 Every `show_*` flag gating a styling group is a `COLUMN_OVERRIDE_KEYS` member, so a
- * card carrying a `column:` block renders one thing and configures another. Reading
- * `ctx.config` directly answered for the card; `resolveViewOption` answers for the view.
- *
- * The harmful direction is the second of the two below: locations render in column view
- * and every control for styling them is absent from the editor, so the user can see the
- * thing on screen and has no way to configure it without hand-editing YAML.
+ * The field must belong to that gate's group and to no other, which `isolates its own
+ * field` checks rather than trusting.
  */
+const GATES = [
+  { gate: 'show_time', field: 'time_font_size' },
+  { gate: 'show_location', field: 'location_font_size' },
+  { gate: 'show_description', field: 'description_font_size' },
+  { gate: 'show_countdown', field: 'show_countdown_allday' },
+  { gate: 'show_progress_bar', field: 'progress_bar_height' },
+] as const;
+
+/**
+ * The keys `buildEventsSchema` actually resolves per view, read from the source.
+ *
+ * Read as text because the call site leaves no runtime trace: the resolved values reach
+ * `eventsSchema` as bare booleans, so nothing importable says which keys produced them.
+ *
+ * @returns Every key passed to `resolveViewOption` inside the builder
+ */
+function resolvedGateKeys(): string[] {
+  const source = readFileSync(
+    join(process.cwd(), 'src/rendering/editor/schemas/events.ts'),
+    'utf-8',
+  );
+  const block = source.match(/export function buildEventsSchema\([\s\S]*?\n\}/);
+
+  if (!block) throw new Error('buildEventsSchema not found in events.ts — fix this scan');
+
+  const keys = [...block[0].matchAll(/resolveViewOption\(\s*ctx\.config,\s*'([a-z0-9_]+)'/g)].map(
+    (match) => match[1],
+  );
+
+  if (keys.length === 0) {
+    throw new Error('no resolveViewOption calls found in buildEventsSchema — fix this scan');
+  }
+
+  return keys;
+}
 
 function fieldNames(schema: ReadonlyArray<HaFormSchema>): string[] {
   return [...walkSchema(schema)]
@@ -29,77 +95,76 @@ function eventsFields(config: Types.Config, view: Types.EffectiveView): string[]
   return fieldNames(buildEventsSchema({ view, config, language: 'en' }));
 }
 
+/** Every gate at `card`, except `gate`, which the `column:` block sets to `column`. */
+function split(gate: string, card: boolean, column: boolean): Types.Config {
+  const top = Object.fromEntries(GATES.map((g) => [g.gate, card]));
+
+  return buildConfig({ ...top, column: { [gate]: column } } as unknown as Partial<Types.Config>);
+}
+
 describe('card-level Events panel resolves its gates per view', () => {
+  it('resolves exactly the gates this file drives', () => {
+    // Both directions. A sixth `resolveViewOption` with no row here is an untested gate; a
+    // row whose key stopped being resolved is a test asserting nothing.
+    expect([...resolvedGateKeys()].sort()).toEqual([...GATES.map((g) => g.gate)].sort());
+  });
+
+  it.each(GATES)('$gate isolates its own field, $field', ({ gate, field }) => {
+    // The property every row below depends on: this field answers for this gate and for
+    // nothing else. Without it a row can pass because some *other* gate happened to open
+    // the same field, which is exactly how `show_countdown` went unpinned.
+    const fields = eventsFields(split(gate, true, false), 'column');
+
+    expect(fields).not.toContain(field);
+    for (const other of GATES) {
+      if (other.gate !== gate) expect(fields).toContain(other.field);
+    }
+  });
+
+  it.each(GATES)('offers $field in column view when column: { $gate: true }', ({ gate, field }) => {
+    expect(eventsFields(split(gate, false, true), 'column')).toContain(field);
+  });
+
+  it.each(GATES)('keeps $field in list view when the card sets $gate on', ({ gate, field }) => {
+    // A column override must not reach list view in either direction.
+    expect(eventsFields(split(gate, true, false), 'list')).toContain(field);
+  });
+
+  it.each(GATES)(
+    'withholds $field in list view when the card sets $gate off',
+    ({ gate, field }) => {
+      expect(eventsFields(split(gate, false, true), 'list')).not.toContain(field);
+    },
+  );
+
   it('offers location styling in column view when the column override turns locations on', () => {
-    const config = buildConfig({
-      show_location: false,
-      column: { show_location: true },
-    } as Partial<Types.Config>);
-
-    const fields = eventsFields(config, 'column');
-
-    // The control the user needs and could not reach.
-    expect(fields).toContain('location_font_size');
-    expect(fields).toContain('location_color');
-  });
-
-  it('withholds location styling in column view when the column override turns locations off', () => {
-    const config = buildConfig({
-      show_location: true,
-      column: { show_location: false },
-    } as Partial<Types.Config>);
-
-    const fields = eventsFields(config, 'column');
-
-    expect(fields).not.toContain('location_font_size');
-    expect(fields).not.toContain('location_color');
-  });
-
-  it('still reads the card-level value in list view, where no override applies', () => {
-    const on = eventsFields(
-      buildConfig({
-        show_location: true,
-        column: { show_location: false },
-      } as Partial<Types.Config>),
-      'list',
-    );
-    const off = eventsFields(
+    // The case a user reported (#557), kept whole: the parameterized rows above read as a
+    // matrix, and this is the story they came from.
+    const fields = eventsFields(
       buildConfig({
         show_location: false,
         column: { show_location: true },
       } as Partial<Types.Config>),
-      'list',
+      'column',
     );
 
-    // A column override must not reach list view in either direction.
-    expect(on).toContain('location_font_size');
-    expect(off).not.toContain('location_font_size');
+    // The controls the user needed and could not reach.
+    expect(fields).toContain('location_font_size');
+    expect(fields).toContain('location_color');
   });
 
-  it('resolves every gated group, not only locations', () => {
-    // 🚨 The denominator matters: `show_location` was the one reported, and the other four
-    // are equally column-overridable. A fix covering only the reported one would pass the
-    // three cases above and leave four groups wrong.
-    const allOff = buildConfig({
-      show_time: true,
-      show_description: true,
-      show_countdown: true,
-      show_progress_bar: true,
-      column: {
-        show_time: false,
-        show_description: false,
-        show_countdown: false,
-        show_progress_bar: false,
-      },
-    } as Partial<Types.Config>);
+  it('empties every gated group at once without emptying the panel', () => {
+    const top = Object.fromEntries(GATES.map((g) => [g.gate, true]));
+    const off = Object.fromEntries(GATES.map((g) => [g.gate, false]));
+    const allOff = buildConfig({ ...top, column: off } as unknown as Partial<Types.Config>);
 
     const fields = eventsFields(allOff, 'column');
 
-    expect(fields).not.toContain('time_font_size');
-    expect(fields).not.toContain('description_font_size');
-    expect(fields).not.toContain('progress_bar_height');
+    for (const { field } of GATES) expect(fields).not.toContain(field);
 
-    // Control: the panel is not simply empty — ungated fields survive.
+    // Control: the panel is not simply empty — ungated fields survive, so the assertions
+    // above are about the gates rather than about the builder having returned nothing.
     expect(fields).toContain('event_font_size');
+    expect(fields.length).toBeGreaterThan(GATES.length);
   });
 });

--- a/tests/entity-colors-lifecycle.test.ts
+++ b/tests/entity-colors-lifecycle.test.ts
@@ -1,0 +1,332 @@
+/**
+ * The registry-color subscription lifecycle, driven through the real card element.
+ *
+ * 🚨 `src/calendar-card-pro.ts` was in no v4.1 audit's scope — the runtime pass took
+ * `src/utils/`, the editor pass took `src/rendering/editor/`, and the entry point fell
+ * between them. Two things were wrong at the seam between the card and
+ * `utils/entity-colors`, and neither is visible from either side alone:
+ *
+ * 1. `disconnectedCallback` released and `connectedCallback` did not re-acquire. Every
+ *    other subscription in that file is acquired on connect; this one re-registered only
+ *    because `updateEvents()` happens to flip `isLoading`, which does not happen when that
+ *    method returns early.
+ * 2. The websocket subscription outlived every card on the page. `releaseEntityColors`
+ *    dropped the listener and nothing closed the subscription, so a tab that had once
+ *    shown an opted-in card kept re-reading the whole entity registry on every
+ *    `entity_registry_updated`, notifying nobody — while `subscribe`'s own docblock said
+ *    it did this "only while at least one card is listening".
+ *
+ * Fixing 2 naively regresses, which is why `refetches rather than freezing` is here: the
+ * untorn-down subscription was accidentally keeping `colors` current, so tearing it down
+ * without clearing `loaded` would hand the next card a map frozen at the moment the last
+ * one left.
+ *
+ * These drive the element rather than the module, because the module's own tests cannot
+ * see a lifecycle callback that never fires.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '../src/calendar-card-pro';
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import * as EntityColors from '../src/utils/entity-colors';
+
+interface CardElement extends HTMLElement {
+  hass: Types.Hass;
+  isInitialLoad: boolean;
+  updateComplete: Promise<boolean>;
+  setConfig(config: Types.Config): void;
+}
+
+/** Resolve pending microtasks *and* the macrotask queue. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * A fake connection that exposes whether anything is subscribed, and counts fetches.
+ *
+ * `handler` is the live `entity_registry_updated` callback, or `undefined` when nothing is
+ * subscribed — which is the observable the teardown tests turn on. `color` stands in for
+ * the registry itself, so a test can move it while nobody is watching.
+ */
+function makeHass(color = 'red') {
+  const state = {
+    handler: undefined as undefined | (() => void),
+    fetches: 0,
+    color,
+    gate: null as Promise<void> | null,
+    open: null as (() => void) | null,
+  };
+
+  const hass = {
+    states: {},
+    callService: () => {},
+    locale: { language: 'en' },
+    callApi: async () => [],
+    callWS: async () => {
+      state.fetches += 1;
+      return [{ entity_id: 'calendar.personal', options: { calendar: { color: state.color } } }];
+    },
+    connection: {
+      subscribeEvents: async (cb: () => void) => {
+        if (state.gate) await state.gate;
+        state.handler = cb;
+        return () => {
+          state.handler = undefined;
+        };
+      },
+    },
+  } as unknown as Types.Hass;
+
+  return {
+    state,
+    hass,
+    /** Hold `subscribeEvents` open, so a card can come and go mid-handshake. */
+    hold() {
+      state.gate = new Promise<void>((resolve) => {
+        state.open = resolve;
+      });
+    },
+    release() {
+      state.open?.();
+      state.gate = null;
+      state.open = null;
+    },
+  };
+}
+
+async function mount(
+  hass: Types.Hass,
+  overrides: Record<string, unknown> = { accent_color: 'home-assistant' },
+): Promise<CardElement> {
+  const card = document.createElement('calendar-card-pro-dev') as unknown as CardElement;
+  card.setConfig(buildConfig(overrides) as Types.Config);
+  card.hass = hass;
+  card.isInitialLoad = false;
+  document.body.appendChild(card);
+  await card.updateComplete;
+  await flush();
+  return card;
+}
+
+/** How many times a registry change reaches this card. */
+function watchRepaints(card: CardElement) {
+  return vi.spyOn(card as unknown as { requestUpdate: () => void }, 'requestUpdate');
+}
+
+describe('registry colors: who is listening', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    EntityColors.resetEntityColors();
+    vi.restoreAllMocks();
+  });
+
+  it('repaints an opted-in card when the registry moves', async () => {
+    // The positive control for every zero below: without it, a test asserting "no repaint"
+    // cannot tell a working teardown from a probe that never reached the subscription.
+    const { state, hass } = makeHass();
+    const card = await mount(hass);
+    const repaints = watchRepaints(card);
+
+    expect(state.handler).toBeTypeOf('function');
+    state.handler!();
+    await flush();
+
+    expect(repaints).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribes to nothing for a card that never opts in', async () => {
+    const { state, hass } = makeHass();
+    await mount(hass, { accent_color: '#ff0000' });
+
+    expect(state.handler).toBeUndefined();
+    expect(state.fetches).toBe(0);
+  });
+
+  it('registers once however many times the card updates', async () => {
+    const { state, hass } = makeHass();
+    const card = await mount(hass);
+
+    card.hass = { ...hass } as Types.Hass;
+    await card.updateComplete;
+    card.hass = { ...hass } as Types.Hass;
+    await card.updateComplete;
+    await flush();
+
+    const repaints = watchRepaints(card);
+    state.handler!();
+    await flush();
+
+    // A stable field rather than an inline arrow is what makes `listeners` a set of one.
+    expect(repaints).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('registry colors: connect and disconnect are symmetric', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    EntityColors.resetEntityColors();
+    vi.restoreAllMocks();
+  });
+
+  it('stops repainting a card that has left the document', async () => {
+    const { state, hass } = makeHass();
+    const card = await mount(hass);
+    card.remove();
+    await flush();
+
+    const repaints = watchRepaints(card);
+    state.handler?.();
+    await flush();
+
+    expect(repaints).not.toHaveBeenCalled();
+  });
+
+  it('repaints again once the card is put back', async () => {
+    const { state, hass } = makeHass();
+    const card = await mount(hass);
+
+    card.remove();
+    await flush();
+    document.body.appendChild(card);
+    await card.updateComplete;
+    await flush();
+
+    const repaints = watchRepaints(card);
+    state.handler!();
+    await flush();
+
+    expect(repaints).toHaveBeenCalledTimes(1);
+  });
+
+  it('repaints again after a reconnect that changes no reactive property', async () => {
+    // 🚨 The case the old code got wrong, and the reason `connectedCallback` may not lean
+    // on `updateEvents()`: with no entities that method returns before touching
+    // `isLoading`, so Lit requests no update and `updated()` never runs. The card came back
+    // deregistered and stayed that way until something unrelated moved.
+    const { state, hass } = makeHass();
+    const card = await mount(hass, { accent_color: 'home-assistant', entities: [] });
+
+    card.remove();
+    await flush();
+    document.body.appendChild(card);
+    await card.updateComplete;
+    await flush();
+
+    const repaints = watchRepaints(card);
+    state.handler!();
+    await flush();
+
+    expect(repaints).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops repainting a card whose config no longer asks for registry colors', async () => {
+    const { state, hass } = makeHass();
+    const card = await mount(hass);
+
+    card.setConfig(buildConfig({ accent_color: '#ff0000' }) as Types.Config);
+    await card.updateComplete;
+    await flush();
+
+    const repaints = watchRepaints(card);
+    state.handler?.();
+    await flush();
+
+    expect(repaints).not.toHaveBeenCalled();
+  });
+});
+
+describe('registry colors: the last card out closes the subscription', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    EntityColors.resetEntityColors();
+    vi.restoreAllMocks();
+  });
+
+  it('closes it when the only card leaves', async () => {
+    const { state, hass } = makeHass();
+    const card = await mount(hass);
+    expect(state.handler).toBeTypeOf('function');
+
+    card.remove();
+    await flush();
+
+    expect(state.handler).toBeUndefined();
+  });
+
+  it('keeps it open while a second card is still listening', async () => {
+    // The reference count is the whole point: a per-card teardown would cut the surviving
+    // card off from the registry the moment its neighbour was removed.
+    const { state, hass } = makeHass();
+    const first = await mount(hass);
+    const second = await mount(hass);
+
+    first.remove();
+    await flush();
+
+    expect(state.handler).toBeTypeOf('function');
+
+    const repaints = watchRepaints(second);
+    state.handler!();
+    await flush();
+    expect(repaints).toHaveBeenCalledTimes(1);
+
+    second.remove();
+    await flush();
+    expect(state.handler).toBeUndefined();
+  });
+
+  it('refetches rather than freezing when a later card arrives', async () => {
+    // 🚨 Tearing the subscription down without clearing `loaded` would be a regression
+    // rather than a fix: the registry can move while nobody is watching, and the
+    // subscription that outlived every card was accidentally the thing keeping `colors`
+    // current.
+    const { state, hass } = makeHass('red');
+    const first = await mount(hass);
+    await flush();
+
+    expect(EntityColors.entityColors().get('calendar.personal')).toBe('var(--red-color)');
+    const fetchesWhileWatched = state.fetches;
+
+    first.remove();
+    await flush();
+
+    // Home Assistant repaints the calendar with nobody subscribed to hear about it.
+    state.color = 'blue';
+
+    await mount(hass);
+    await flush();
+
+    expect(state.fetches).toBeGreaterThan(fetchesWhileWatched);
+    expect(EntityColors.entityColors().get('calendar.personal')).toBe('var(--blue-color)');
+  });
+
+  it('closes a subscription that arrives after the card that asked for it', async () => {
+    // 🚨 `subscribeEvents` is a websocket round-trip, so a card mounted and removed inside
+    // that window — a dashboard edit, a view switch — tears down a placeholder that cannot
+    // close a subscription which does not exist yet. Without the generation guard the real
+    // unsubscriber is then stored *after* teardown, leaving a live subscription with no
+    // listeners: the very leak this teardown exists to prevent, reached by a race instead.
+    //
+    // Nothing else in this file can see it. The mutation survived a sweep of the other
+    // three until this case was written, because every other fixture resolves the
+    // handshake in one microtask.
+    const conn = makeHass();
+    conn.hold();
+
+    const card = document.createElement('calendar-card-pro-dev') as unknown as CardElement;
+    card.setConfig(buildConfig({ accent_color: 'home-assistant' }) as Types.Config);
+    card.hass = conn.hass;
+    card.isInitialLoad = false;
+    document.body.appendChild(card);
+    await card.updateComplete;
+
+    // The card is gone before Home Assistant ever answers.
+    card.remove();
+    await flush();
+
+    conn.release();
+    await flush();
+
+    expect(conn.state.handler).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Audits the two v4.1 surfaces no earlier pass covered: `src/calendar-card-pro.ts`, which fell between the runtime audit (`src/utils/`, `src/config/`) and the editor audit (`src/rendering/editor/`), and the four files changed after those audits closed.

Four findings, three defects fixed and one report withdrawn. Everything below was established by running something; where a result is a null, the probe's own self-test is stated with it.

## 1. The registry-color subscription outlived every card on the page

`releaseEntityColors` dropped the listener and nothing closed the subscription — nothing called `unsubscribe` outside the test-only `resetEntityColors`. A tab that had once shown a card with `accent_color: home-assistant` kept re-reading the **whole entity registry** on every `entity_registry_updated` for as long as it stayed open, notifying nobody and retaining its `hass`. `subscribe`'s own docblock said it did this _"only while at least one card is listening"_, which was a statement of intent with nothing behind it.

**Tearing it down naively regresses**, and that is the half worth recording: the untorn-down subscription was accidentally the thing keeping `colors` current. Teardown therefore clears `loaded` so the next card refetches instead of reading a map frozen at the moment the last one left. `colors` itself is kept — a stale color repainted once beats rendering none, the trade `entityColors()` already documents for a cold cache.

A generation ticket closes a subscription that resolves *after* the card that asked for it. `subscribeEvents` is a websocket round-trip, so a card mounted and removed inside that window tears down a placeholder that cannot close a subscription which does not yet exist; without the ticket the real unsubscriber is stored after teardown and the leak returns by race.

## 2. `connectedCallback` did not re-acquire what `disconnectedCallback` released

Entity colors was the only subscription in the file released on disconnect with no counterpart on connect — the width observer, weather, title and `visibilitychange` are all re-acquired. It re-registered in practice only because `updateEvents()` happens to flip `isLoading` on its way through, which is incidental and does not happen when that method returns early.

Probe, driving the real element: reconnect notified **once** with entities configured and **zero** without.

## 3. The test shipped with #560 was weaker than its own comment

Mutation sweep scored against `editor-events-view-scope.test.ts` alone, control green (4 passed / 0 failed / 4 ran), failure counts differing per mutation, restored green:

| mutation | before | after |
| --- | --- | --- |
| revert `show_time` to raw | caught (1) | caught (4) |
| revert `show_location` to raw | caught (2) | caught (5) |
| revert `show_description` to raw | caught (1) | caught (4) |
| **revert `show_countdown` to raw** | **SURVIVED** | caught (4) |
| revert `show_progress_bar` to raw | caught (1) | caught (4) |
| revert all five (pre-#560 code) | caught (3) | caught (13) |
| hardcode `show_time` → `false` | **SURVIVED** | caught (7) |
| hardcode `show_description` → `false` | **SURVIVED** | caught (7) |
| hardcode `show_countdown` → `false` | **SURVIVED** | caught (7) |
| hardcode `show_progress_bar` → `false` | **SURVIVED** | caught (7) |
| hardcode `show_location` → `false` | caught (2) | caught (8) |

5 of 11 caught, now 11 of 11. Only `show_location` was pinned in both directions, while the file's comment claimed it asserted the whole set.

**The hole was a misaimed assertion, not a missing one.** The case meant to cover the group checked `progress_bar_height`, which belongs to `show_progress_bar`; `show_countdown` gates only `show_countdown_allday` and was never named by anything. That makes it a **live defect rather than a coverage gap** — `show_countdown_allday` is itself a `COLUMN_OVERRIDE_KEYS` member, so a card with `column: { show_countdown: … }` hit the same class of bug #560 was written for.

Each gate is now pinned through a field **only that gate controls**, and `isolates its own field` proves the 1:1 rather than asserting it in a comment. The table is reconciled against the source, so a sixth gate cannot be added — nor an existing one dropped — without a row. Both directions verified: reverting a gate fails it, and a planted sixth `resolveViewOption` call fails it too.

The denominator is hand-declared on purpose. Deriving it from the schema's own response to a toggle reads like a reconciliation and is not — a mutation that stops a key gating anything also drops it from a derived denominator, so the test would agree with the bug.

## 4. `countryMode` is not the same bug one line down — report withdrawn

Reported as an unfixed twin of the five gates. Applying the suggested fix and reading the form back the way `element.ts._formData()` builds it:

```
A. CURRENT       mode field: rendered   pattern field: absent    dropdown VALUE: "keep"
B. SUGGESTED FIX mode field: rendered   pattern field: RENDERED  dropdown VALUE: "keep"
C. RESTORED      == A
```

An empty "Country pattern" box under a dropdown reading **Keep** — a control `locationCountryFields` only emits in `custom` mode — because `location_country_pattern.derive` still reads raw config. A keystroke there writes `remove_location_country` at the **card level**, silently flipping the mode from a control that should not have existed.

The rule, now stated at the call site as the discriminator rather than as three special cases:

> Resolve a gate per view when the key it reads is **not** a key the fields it opens edit. Read it raw when the gate and the field it opens are two projections of the **same** key.

`show_location` gates `location_font_size` — independent keys, still shown and written at card level, so resolving the gate is coherent. `remove_location_country` gates its own value, so resolving desynchronizes a key from itself. `accentColorMode` is raw for a third reason needing no rule: `accent_color` is not a `COLUMN_OVERRIDE_KEYS` member at all.

**And nothing is stranded.** `overrides.ts` already declares `remove_location_country` a union-typed per-view exception. Driving `panelSubforms` for the Events panel in column view:

```
subform path=[column]  fields=22
    -> remove_location_country
    -> location_country_mode
    -> location_country_pattern
column-block dropdown VALUE: "custom"
column-block pattern  VALUE: "GmbH"
```

## 5. Slovak `pracovných dň` cannot match `pracovných dní`

The genitive plural of `deň` is `dní` with a plain `n`; the locative is `dňoch` with `ň`. One stem cannot reach both, so the entry covered the locative only and left the genitive plural — the likelier form in a UI string — open, which is exactly the class of miss #561 existed to close.

Added as an **exact form** rather than shortening to `pracovných d`, which would have `pracovných dokumentov` behind it and reintroduce the over-match risk that got `pracovn` refused.

## What came back clean, and why the null is worth something

**Glossary over-matching: no hits.** Ran the real matcher from `check-i18n.mjs` against the 8 keys whose English governs the `weekday` term, with legitimate text including the exact `pracovn` trap — `Pracovný kalendár`, `Pracovník`, `Pracovné`, `pracovných dokumentov`, `Počet pracovných hodín` — plus `Darba kalendārs` / `Darbs` / `Darbadienas` against `darbdien`. All clean. **The probe self-tests**: a deliberately planted Italian sample *did* over-match, so the zero distinguishes a working check from a probe that never fired. Direction A went from 1 miss to 0.

**Italian is complete.** All four English clauses survive the rewrite: when it applies, empty means midnight (`Se lasciato vuoto, restano tali fino a mezzanotte`), only while past events are hidden, and next refresh rather than the minute. Both numeric claims in #559 check out — the label is exactly 30 characters, and `di` consistency is 7/0.

Also cleared by execution rather than reading: registration **is** idempotent (three `updated()` passes → one notification), disconnect releases, switching config away releases, the typing **is** honest (`Types.Config['show_time']` is non-optional `boolean`, so nothing non-boolean is passed), and `memoizeLast` compares every argument with `Object.is` — view enters the memo only through the resolved values, which is correct.

## Not done

- **No release-notes or What's New change.** `entity-colors.ts` is absent from `v4.0.0`, so both lifecycle defects were introduced and repaired inside unreleased work — the shape AGENTS.md disqualifies. Those surfaces belong to the release PR regardless.
- **No docs change.** No config surface moves; `check:docs` passes unchanged.
- **Glossary direction A is sampled, not exhaustive.** I tested the inflections each stem was added for across five languages, not a full paradigm for each. The Slovak addition is a morphology call worth a native reader's confirmation, though direction B is provably safe for it.
- **`src/utils/`, `src/config/`, `src/rendering/` outside the editor and `docs/` were out of scope** and not audited. Nothing noticed in passing.

## Gates

All nine green, and re-run under Node 22.23.2 as well as the local Node 25 — `.nvmrc` pins 22 and results through zlib and CLDR are not portable across majors.

`npx tsc --noEmit` · `lint` · `check:format` · `test` (140 files) · `check:i18n` (0 errors) · `check:docs` · `docs:build` · `build` · `check:bundle`
