### PR TITLE
chore(i18n): complete the Slovak plural cases for the weekday term

### DIFF
--- a/scripts/editor-glossary.mjs
+++ b/scripts/editor-glossary.mjs
@@ -756,7 +756,20 @@ export const GLOSSARY_TERMS = [
     // ends — genitive `dní` has a plain `n`, locative `dňoch` has `ň` — so one stem cannot
     // reach both, and the `d` that would has `pracovných dokumentov` behind it.
     rejected: {
-      sk: ['pracovný deň', 'pracovného dňa', 'pracovné dni', 'pracovných dň', 'pracovných dní'],
+      // Slovak declines both words, and the plural obliques diverge from each other:
+      // `pracovných dní` is a plain `n` where `pracovných dňoch` is `ň`, so no single
+      // stem reaches both. Exact phrases rather than a shorter stem, because `pracovn`
+      // would also match `pracovný kalendár`, `pracovné stretnutie` and `pracovník` — all
+      // legitimate, and a rejected form is a build error.
+      sk: [
+        'pracovný deň',
+        'pracovného dňa',
+        'pracovné dni',
+        'pracovných dň',
+        'pracovných dní',
+        'pracovným dňom',
+        'pracovnými dňami',
+      ],
       it: ['giorno ferial', 'giorni ferial'],
       lv: ['darbdien'],
       sv: ['vardag'],


### PR DESCRIPTION
Closes the open question left by #563, which flagged that `pracovných dň` cannot reach `pracovných dní` — the genitive plural uses a plain `n` where the locative uses `ň`, so no single stem reaches both.

A native reader confirmed the genitive plural and **found two more** the four existing entries cannot reach:

| Form | Case | Realistic in UI text |
| --- | --- | --- |
| `pracovných dní` | genitive pl | `počas pracovných dní`, `okrem pracovných dní` |
| `pracovným dňom` | dative pl | less common, possible |
| `pracovnými dňami` | instrumental pl | possible |

## Verified in three directions

Against the real matcher from `check-i18n.mjs`:

```
already caught by the existing four?
  genitive pl    false  :: Zobraziť počas pracovných dní.
  dative pl      false  :: Priradené pracovným dňom.
  instrumental   false  :: Obmedzené pracovnými dňami.

over-match legitimate Slovak?
  false :: Pracovný kalendár       false :: Pracovné stretnutie
  false :: Pracovná doba           false :: pracovník
  false :: Pracovných dokumentov

control — each form matches its own text:
  true  :: pracovných dní          true  :: pracovným dňom
  true  :: pracovnými dňami
```

The last block is the control: without it, three `false` rows above would be consistent with a probe that matches nothing at all.

Exact phrases rather than a shorter stem, for the reason `pracovn` was refused — it would also match `pracovný kalendár`, `pracovné stretnutie` and `pracovník`, and a rejected form is a build **error**. The comment at the site now records that, so the seven entries are not "simplified" later.

All gates green.