### PR TITLE
fix(gates): stop three doc checks reporting verdicts they have not earned

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1593,20 +1593,47 @@ function checkLanguageCounts() {
   return checked;
 }
 
+/**
+ * Print what was inspected, then the errors and warnings.
+ *
+ * 🚨 **Every clause on the summary line is a count of what was *inspected*, never a
+ * verdict on how it came out.** The line is printed before the error list is evaluated,
+ * so a clause phrased as an outcome states that outcome on a failing run too, directly
+ * above the errors contradicting it — and the summary is what a reader reads first.
+ *
+ * #547 found this in the release-surface clause and fixed it there, reasoning that the
+ * others were safe because "a link that did not resolve is not among the resolved ones".
+ * That was not true of this file: the counters increment *before* their error branches,
+ * so a broken link is counted like any other. Planting one moved "internal links
+ * resolved" from 203 to 204 while the planted link was the thing failing. The same held
+ * for the absolute-link, citation, language, enum and example clauses.
+ *
+ * Reword rather than recount. `checked` also feeds the staleness guards — `if (!checked)`
+ * and `if (checked < 20)` both exit 2 meaning "the pattern has gone stale" — so counting
+ * only successes would make a run with many genuinely broken links report a stale pattern
+ * and send the reader to edit the regex.
+ *
+ * Clauses that increment only on success (`reachable`, `themed`) and ones that report the
+ * size of something parsed (`defaults`, `rows`, `fields`, `docs`, `releases`) are already
+ * true as written and are left alone.
+ *
+ * @param counts - What each check inspected
+ * @returns Process exit code
+ */
 function report(counts) {
   console.log(
     `${counts.defaults} defaults in code, ${counts.rows} rows in the reference, ` +
-      `${counts.fields} config fields, ${counts.docs} pages, ${counts.complete} complete examples, ` +
-      `${counts.releases} release lines documented, ${counts.links} internal links resolved, ` +
-      `${counts.siteLinks} absolute site links resolved, ` +
-      `${counts.gates} CI gates documented, ` +
-      `${counts.enums} enumerated options fully listed, ` +
+      `${counts.fields} config fields, ${counts.docs} pages, ${counts.complete} card examples checked, ` +
+      `${counts.releases} release lines documented, ${counts.links} internal links checked, ` +
+      `${counts.siteLinks} absolute site links checked, ` +
+      `${counts.gates} CI gates checked, ` +
+      `${counts.enums} enumerated options checked, ` +
       `${counts.sentinels} sentinel rows checked, ` +
-      `${counts.removed} removed options migrated, ` +
+      `${counts.removed} removed options checked, ` +
       `${counts.reachable} pages reachable from the navigation, ` +
       `${counts.themed} theme defaults documented, ` +
-      `${counts.citations} line citations resolved, ` +
-      `${counts.languages} language counts reconciled, ` +
+      `${counts.citations} line citations checked, ` +
+      `${counts.languages} language counts checked, ` +
       `${counts.readmeAnchors} README anchor links checked, ` +
       `release surfaces checked against v${counts.version}.\n`,
   );
@@ -1928,37 +1955,40 @@ function checkEnumValues(enums) {
  * in code fails this check instead of silently outdating the docs. Only the pairing of
  * option to module is written down.
  *
- * `doc` names where the option's row lives, because a per-calendar-only option has none in
- * the reference: `configuration.md` lists those as prose and links to the table in
- * `core-settings.md`. Pointing this check at the reference regardless would have failed on
- * `label` for a row that is not supposed to exist, and duplicating the per-entity table to
- * satisfy it would trade one undocumented sentinel for two tables that can disagree.
+ * Which page carries the row is deliberately *not* written down, because writing it down
+ * is what left half the corpus unchecked. `label` is per-calendar only and has no row in
+ * the reference, so an earlier version named one page per option to avoid demanding a row
+ * that is not supposed to exist — and thereby stopped looking at `core-settings.md` for
+ * `accent_color`, which has a row in *both* pages. Blanking the sentinel from the
+ * per-entity row passed the gate while the identical omission in the reference failed it.
+ *
+ * So both pages are searched and every row found in either must name the sentinel, with
+ * one row somewhere required rather than one row per page. That is how check 21 already
+ * reads its two sources, and it satisfies the original concern without the blind spot:
+ * `label`'s absence from the reference is simply no row there, not a failure.
  */
 const SENTINEL_OPTIONS = [
   {
     fields: ['accent_color'],
     file: 'src/utils/entity-colors.ts',
     constant: 'ENTITY_COLOR_SENTINEL',
-    doc: REFERENCE_DOC,
   },
   {
     fields: ['label'],
     file: 'src/utils/entity-icons.ts',
     constant: 'ENTITY_ICON_SENTINEL',
-    doc: ENTITY_OPTIONS_DOC,
   },
 ];
 
 /**
  * Read each declared sentinel's value out of the module that owns it.
  *
- * @returns {Map<string, {values: string[], doc: string}>} option name -> its reserved words
- *   and the page documenting it
+ * @returns {Map<string, string[]>} option name -> its reserved words
  */
 function readSentinelOptions() {
   const out = new Map();
 
-  for (const { fields, file, constant, doc } of SENTINEL_OPTIONS) {
+  for (const { fields, file, constant } of SENTINEL_OPTIONS) {
     const src = readFileSync(join(ROOT, file), 'utf8');
     const match = src.match(new RegExp(`export const ${constant}\\s*=\\s*'([^']+)'`));
 
@@ -1968,8 +1998,7 @@ function readSentinelOptions() {
     }
 
     for (const field of fields) {
-      const existing = out.get(field);
-      out.set(field, { values: [...(existing?.values ?? []), match[1]], doc });
+      out.set(field, [...(out.get(field) ?? []), match[1]]);
     }
   }
 
@@ -1978,40 +2007,43 @@ function readSentinelOptions() {
 }
 
 /**
- * Every reference row for an option with a sentinel has to name that sentinel.
+ * Every row for an option with a sentinel has to name that sentinel, on either page.
  *
  * Rows are matched the same way check 21 matches them, so a per-entity row written
  * `` `entity → accent_color` `` is covered as well as the card-wide one.
  *
- * @param {Map<string, {values: string[], doc: string}>} sentinels option name -> reserved
- *   words and the page documenting them
+ * @param {Map<string, string[]>} sentinels option name -> reserved words
  * @returns {number} rows checked
  */
 function checkSentinelValues(sentinels) {
+  const sources = [REFERENCE_DOC, ENTITY_OPTIONS_DOC].map((file) => ({
+    file,
+    lines: readFileSync(file, 'utf8').split('\n'),
+  }));
   let checked = 0;
 
-  for (const [field, { values, doc }] of sentinels) {
-    const lines = readFileSync(doc, 'utf8').split('\n');
-
-    const rows = lines.filter((line) =>
-      new RegExp(`^\\|\\s*\`(?:[a-z0-9_]+ → )?${field}\``).test(line),
+  for (const [field, values] of sentinels) {
+    const rows = sources.flatMap(({ file, lines }) =>
+      lines
+        .filter((line) => new RegExp(`^\\|\\s*\`(?:[a-z0-9_]+ → )?${field}\``).test(line))
+        .map((row) => ({ file, row })),
     );
 
     if (!rows.length) {
       error(
-        `${relative(ROOT, doc)}: no row documents \`${field}\`, which accepts ` +
+        `No row on either page documents \`${field}\`, which accepts ` +
           `${values.map((v) => `\`${v}\``).join(', ')}.`,
       );
       continue;
     }
 
-    for (const row of rows) {
+    for (const { file, row } of rows) {
       checked++;
-      const named = values.filter((value) => row.includes(value));
-      if (named.length !== values.length) {
+      const missing = values.filter((value) => !row.includes(`\`${value}\``));
+      if (missing.length) {
         error(
-          `${relative(ROOT, doc)}: the \`${field}\` row never mentions ` +
-            `${values.map((v) => `\`${v}\``).join(', ')}, so a reader cannot discover that ` +
+          `${relative(ROOT, file)}: the \`${field}\` row never mentions ` +
+            `${missing.map((v) => `\`${v}\``).join(', ')}, so a reader cannot discover that ` +
             `the option accepts it. It is a reserved word, not a value the type system can ` +
             `advertise — nothing else will catch this.`,
         );
@@ -2501,7 +2533,20 @@ function checkAbsoluteSiteLinks(docs) {
   assertFound(surfaces, 'surfaces that can carry absolute site links', ROOT);
 
   const SITE = 'https://calendar-card-pro.alexpfau.com';
-  const pattern = new RegExp(`${SITE.replace(/\./g, '\\.')}([^)\\s"'\\]]*)`, 'g');
+
+  // The excluded set is every delimiter a link can be wrapped in, not just the markdown
+  // ones. `>` and a backtick were missing, so the two commonest non-markdown forms — an
+  // autolink `<https://…/features/weather>` and a code span — captured their own closing
+  // delimiter, and a *correct* link was reported as `/features/weather>`, "no page
+  // publishes at". That is the expensive direction: valid prose failing CI. It was latent
+  // only because nobody had written either form into a scanned file, while AGENTS.md uses
+  // the autolink form twice.
+  //
+  // Excluding them cannot hide a real broken link: RFC 3986 forbids `<`, `>` and a
+  // backtick unencoded in a URI, so no genuine target can contain one. Widening the class
+  // to what a URL can actually hold is what makes this safe by construction, rather than
+  // patching the two forms that happened to be reported.
+  const pattern = new RegExp(`${SITE.replace(/\./g, '\\.')}([^)\\s"'\\]<>\`]*)`, 'g');
   let checked = 0;
 
   for (const file of surfaces) {

--- a/src/calendar-card-pro.ts
+++ b/src/calendar-card-pro.ts
@@ -707,8 +707,21 @@ class CalendarCardPro extends LitElement {
    * incidental rather than designed and does not happen when that method returns early.
    * Every other subscription in this file is acquired in `connectedCallback`; this one now
    * matches its neighbours.
+   *
+   * 🚨 The `isConnected` guard is what stops the `updated()` call site undoing
+   * `disconnectedCallback`. Lit does not cancel an update scheduled before the element
+   * left the document, so `updated()` runs for a card that is already detached — and
+   * re-acquiring there puts a detached card back into the listener set and re-opens the
+   * websocket subscription that `disconnectedCallback` had just closed. Nothing releases
+   * it a second time, because that card's `disconnectedCallback` has already run. This is
+   * the same leak the teardown exists to prevent, reached from the other side, and the
+   * shape is invisible to a test that removes a card with no update in flight.
    */
   private _syncEntityColors(): void {
+    if (!this.isConnected) {
+      return;
+    }
+
     if (EntityColors.usesEntityColor(this.config)) {
       EntityColors.ensureEntityColors(this.hass, this._onEntityColorsChanged);
     } else {

--- a/tests/entity-colors-lifecycle.test.ts
+++ b/tests/entity-colors-lifecycle.test.ts
@@ -47,14 +47,20 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
  * `handler` is the live `entity_registry_updated` callback, or `undefined` when nothing is
  * subscribed — which is the observable the teardown tests turn on. `color` stands in for
  * the registry itself, so a test can move it while nobody is watching.
+ *
+ * `subscribes` counts handshakes rather than live subscriptions, which is the only way to
+ * see a *duplicate* one: a second `subscribeEvents` overwrites `handler` with an
+ * indistinguishable function, so "is anything subscribed" cannot tell one from two.
  */
 function makeHass(color = 'red') {
   const state = {
     handler: undefined as undefined | (() => void),
     fetches: 0,
+    subscribes: 0,
     color,
     gate: null as Promise<void> | null,
     open: null as (() => void) | null,
+    reject: false,
   };
 
   const hass = {
@@ -68,7 +74,9 @@ function makeHass(color = 'red') {
     },
     connection: {
       subscribeEvents: async (cb: () => void) => {
+        state.subscribes += 1;
         if (state.gate) await state.gate;
+        if (state.reject) throw new Error('websocket refused the subscription');
         state.handler = cb;
         return () => {
           state.handler = undefined;
@@ -328,5 +336,102 @@ describe('registry colors: the last card out closes the subscription', () => {
     await flush();
 
     expect(conn.state.handler).toBeUndefined();
+  });
+
+  it('closes it when a card is removed with an update still in flight', async () => {
+    // 🚨 Lit does not cancel an update scheduled before an element leaves the document, so
+    // `updated()` — and with it `_syncEntityColors` — runs for a card that is already
+    // detached. Re-acquiring there puts a detached card back in the listener set and
+    // reopens the subscription `disconnectedCallback` had just closed, and nothing
+    // releases it a second time because that card's `disconnectedCallback` has run.
+    //
+    // The teardown cases above all remove a card with nothing pending, which is why they
+    // could not see it. `isConnected` in `_syncEntityColors` is what this pins; without it
+    // the assertion below finds a live handler.
+    //
+    // It also masked a mutant: with the detached card re-subscribing, a later `subscribe()`
+    // supplied the generation bump that `teardown()` is supposed to, so deleting that bump
+    // left this file green. It fails now.
+    const { state, hass } = makeHass();
+    const card = await mount(hass);
+    expect(state.handler).toBeTypeOf('function');
+
+    // A hass change schedules an update; the card leaves before it flushes.
+    card.hass = { ...hass } as Types.Hass;
+    card.remove();
+    await flush();
+    await flush();
+
+    expect(state.handler).toBeUndefined();
+  });
+});
+
+describe('registry colors: one subscription, one fetch', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    EntityColors.resetEntityColors();
+    vi.restoreAllMocks();
+  });
+
+  it('opens one subscription however many cards and updates there are', async () => {
+    // The guard `subscribe()` opens with claims to do this — "two cards connecting in the
+    // same tick cannot both pass the guard above and open a second subscription" — and
+    // nothing measured it. `handler` cannot: a second `subscribeEvents` overwrites it with
+    // a function indistinguishable from the first, so two subscriptions read exactly like
+    // one. Counting handshakes is the only observable that separates them.
+    const { state, hass } = makeHass();
+    const first = await mount(hass);
+    await mount(hass);
+
+    first.hass = { ...hass } as Types.Hass;
+    await first.updateComplete;
+    await flush();
+
+    expect(state.subscribes).toBe(1);
+  });
+
+  it('reads the registry once for two cards mounted together', async () => {
+    // `inFlight` is the half of the guard that a second card racing the first depends on:
+    // `loaded` is still false while the first fetch is in the air, so without it every
+    // card on the dashboard re-reads the whole entity registry on load.
+    const { state, hass } = makeHass();
+    await mount(hass);
+    await mount(hass);
+    await flush();
+
+    expect(state.fetches).toBe(1);
+  });
+
+  it('recovers when the handshake is refused', async () => {
+    // The rejection path was reached by nothing at all. It matters because `subscribe()`
+    // claims the slot with a placeholder *before* awaiting: if a refused handshake left
+    // that placeholder in place, the `if (unsubscribe)` guard would block every later
+    // attempt for the life of the page, and colors would silently stop updating.
+    //
+    // 🚨 The card must stay mounted for this to test anything. Removing it and mounting a
+    // second one recovers either way, because `teardown()` clears the slot on the way out
+    // — the first version of this test did that and passed with the whole `.catch` body
+    // deleted. With one card still listening there is no teardown, so `.catch` is the only
+    // thing that can free the slot.
+    const { state, hass } = makeHass();
+    state.reject = true;
+
+    const card = await mount(hass);
+    await flush();
+    expect(state.handler).toBeUndefined();
+
+    const attemptsWhileRefused = state.subscribes;
+    expect(attemptsWhileRefused).toBeGreaterThan(0);
+
+    // Home Assistant answers this time, and the same card gets through on its next update.
+    state.reject = false;
+    card.hass = { ...hass } as Types.Hass;
+    await card.updateComplete;
+    await flush();
+
+    // A retry happened at all — with the slot still claimed, `subscribe()` returns at its
+    // guard and this number never moves.
+    expect(state.subscribes).toBeGreaterThan(attemptsWhileRefused);
+    expect(state.handler).toBeTypeOf('function');
   });
 });


### PR DESCRIPTION
Audits the machinery that catches defects — `scripts/` and the v4.1 test suite — which no previous round covered. `check-docs.mjs` gained 188 lines in v4.1, `check-bundle.mjs` 80, and `tests/` 6087 across 19 files, none of it reviewed.

Every finding below was proven by planting a violation and reading the output, never by reading the code alone. What I established **clean** is at the bottom, with the same standard applied.

---

## 1 — #547 is incomplete, and the reasoning it shipped with is false

#547 fixed the release-surface clause on the summary line and argued the others were safe:

> Every other clause on that line counts what was inspected and stays truthful on a failing run — a link that did not resolve is not among the resolved ones.

That is not true of this file. The counters increment **before** their error branches, so a broken link is counted like any other. Planting one broken same-page fragment:

| | summary said | exit |
| --- | --- | --- |
| control | `203 internal links resolved` | 0 |
| planted | `204 internal links resolved` | 1 |

The planted link is the thing failing, and it is inside the 204. Confirmed the same way across the line:

| clause | probe | result |
| --- | --- | --- |
| `internal links resolved` | broken same-page fragment | 203 → **204** |
| `absolute site links resolved` | two broken site links | 76 → **78** |
| `line citations resolved` | `view.ts:99999` | 4 → **5** |
| `language counts reconciled` | wrong published count | stayed **11**, error fired |
| `enumerated options fully listed` | `event_type` loses `all_day` | stayed **9**, error fired |
| `complete examples` | card block with no `entities:` | 28 → **29** |

`gates` and `removed` are reworded on the same reading of their code — both report what was *found* (gate commands in `ci.yml`, keys in `DEPRECATED_CONFIG_MAP`), not what passed. `reachable` and `themed` increment only on success and are left alone, as are the plain sizes.

**Reworded rather than recounted, deliberately.** `checked` also feeds the staleness guards — `if (!checked)` and `if (checked < 20)` both `exit 2` meaning *"the pattern has gone stale"*. Counting only successes would make a run with many genuinely broken links report a stale pattern and send the reader off to edit the regex. The precedent was already in the file: `sentinel rows checked` and `README anchor links checked` increment in the identical position and read as truthful purely because of the verb.

## 2 — `checkAbsoluteSiteLinks` rejected correct prose

The character class excluded `)`, whitespace, `"`, `'` and `]` — but not `>` or a backtick. So the two commonest non-markdown forms captured their own closing delimiter:

```
✗ …/features/weather#weather-configuration-options>, but #weather-configuration-options> is not a heading
✗ …/features/weather>, but no page publishes at /features/weather>
✗ …/features/weather`, but no page publishes at /features/weather`
```

All three links are **valid**. A markdown-link control in the same file passed, so the failure is specific to the wrapper.

This is the expensive direction — correct work failing CI. It is latent only because nobody has written either form into a scanned file; `AGENTS.md` uses the autolink form at lines 498 and 906, and `AGENTS.md` is not scanned. Copying that style into the README or a docs page fails the build.

Excluding them cannot hide a real broken link: RFC 3986 forbids `<`, `>` and a backtick unencoded in a URI, so no genuine target contains one. Verified both directions — three valid forms now pass, and a genuinely broken autolink is still caught, now reported with a clean anchor name.

The five sibling patterns were **checked rather than assumed**. `LINK` (both), the design-doc `LINK`, `CITE` and the GitHub-anchor pattern are each terminated by `)` or `"` or use a class that cannot reach `>`. Only this one had the gap.

## 3 — `checkSentinelValues` looked at one page while the option lives on two

`accent_color` has a row in **both** `configuration.md` and `core-settings.md`; only the first was read. Blanking the sentinel from the per-entity row **passed the gate**, while the identical omission in the reference failed it. Its sibling `checkEnumValues` was widened to read both pages in this same release.

Both are searched now, with one row required *somewhere* rather than one per page — which preserves the reason the single page was named in the first place (`label` is per-calendar only and has no reference row, so demanding one there would fail on a row that is not supposed to exist).

The match also tightened to the backticked form. Bare `includes('home-assistant')` was satisfied by a link to `home-assistant.io`, so a row could document no sentinel at all and pass; that is now caught. Row count moves 2 → **3**, which is the previously-unread row becoming visible.

## 4 — A card removed mid-update reopened the subscription #563 had just closed

Found by mutating what #563's own falsifiers did not reach.

`_syncEntityColors` is called from `updated()` as well as `connectedCallback`, and **Lit does not cancel an update scheduled before an element leaves the document**. So `updated()` runs for a detached card, re-adds it to the listener set and reopens the websocket that `disconnectedCallback` closed. Nothing releases it again, because that card's `disconnectedCallback` has already run.

It is the leak #563 exists to prevent, reached from the other side. Traced live:

```
[probe] release -> listeners.size 0        <- card removed, teardown ran
[probe] ensureEntityColors <- _syncEntityColors <- CalendarCardPro.updated
[probe]   listeners.size now 1             <- the detached card re-registers
[probe] STORING off -> live subscription now held
```

The existing teardown cases could not see it — they all remove a card with nothing pending. A deterministic probe (schedule an update, remove before it flushes) fails on the old code and passes on the new.

**It was also masking a mutant.** With the detached card re-subscribing, a later `subscribe()` supplied the generation bump that `teardown()` owes, so deleting that bump left the file green. It fails now.

### The sweep

Ten mutations against `entity-colors.ts`. Unmutated control green with a stated denominator; verdicts keyed off the presence of a `Tests` summary line rather than the exit code.

> The first version sniffed stdout for `/Error:/` and reported four mutations as "BUILD ERROR", counting them as caught. A failing assertion prints a stack trace containing `Error:`, and with every test failing `passed === 0` — the exact way `AGENTS.md` records a sweep manufacturing a uniform verdict. Corrected before any conclusion was drawn from it.

| | before fix | after fix + tests |
| --- | --- | --- |
| caught | 5/9 | **9/10** |
| failure counts | — | 1 / 7 / 3 / 3 / 1 / 7 / 1 / 1 / 1 |

Different mutations give different failure counts, which is the signal that detection is real rather than the probe measuring itself.

Three tests added for the blind spots it exposed: a **duplicate subscription** (invisible to `handler`, which a second handshake overwrites indistinguishably — only counting handshakes separates one from two), a **duplicate registry read** while the first is in flight, and the **rejection path**, which nothing reached at all.

The first version of that last test passed with the entire `.catch` body deleted, because removing the card tore the slot down anyway — it was passing for a reason other than the one named. It keeps one card mounted now, so `.catch` is the only thing that can free the slot.

**One mutant survives and is left uncaught deliberately.** Clearing the slot regardless of generation in `.catch` needs an old rejection resolving *after* a newer successful handshake, and a test for it would turn on microtask ordering between two continuations. A brittle test there would block legitimate future change to guard a narrow leak.

---

## Established clean, by execution

- **`check-bundle.mjs`.** A wrong uncompressed figure, a reworded sentence that stales the pattern, and an edited frozen percentage are each caught with a distinct message, and the clean tree passes after each. The installation page's four figures all track the build (199/350 KB raw, 60/95 KB gzip-9, editor inside its 1 KB tolerance).
- **No typo'd globals in `scripts/`.** `no-undef` is deliberately off there, so eslint was rerun over all 12 files with it on and Node globals declared. Zero findings — and a planted `procss` is caught, so the null is the tree being clean rather than the config failing to match.
- **`ownRoute` in #550** derives identically to `buildAnchorMap`, including the `/index` case, so a same-page link cannot be attributed to the wrong page. The two are duplicated code rather than shared, so the comment's "cannot disagree" is optimistic — a note, not a defect.
- **`editor-events-view-scope.test.ts` is not a table walk.** It reconciles `GATES` against the `resolveViewOption` calls parsed from the source, in both directions, with an `isolates its own field` case proving the 1:1 and a control in the last test.
- **`VIEW_SCOPE` / `ENTITY_VIEW_SCOPE`** are pinned by value. Deleting a `DEPRECATED_CONFIG_MAP` entry raises two `check:docs` errors and fails a test — the `AGENTS.md`-documented hole is closed.

## Gates

All nine run green locally, with `check:bundle` and the CLDR-sensitive locale test under the `.nvmrc` pin rather than the local Node 25:

`tsc --noEmit` · `lint` · `check:format` · `test` (2802 across 140 files) · `check:i18n` · `check:docs` · `docs:build` · `build` · `check:bundle`

No release-notes entry: `entity-colors.ts` is absent from v4.0.0, so the lifecycle defect was introduced and repaired inside unreleased work, and the three gate fixes change no user-facing behavior.

`AGENTS.md` is untouched on purpose — a sibling session is editing it, and these findings are reported there rather than committed here to avoid conflicting edits.
