### PR TITLE
docs(guide): rebuild the flagship story on one calendar and a fixed window

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -25,20 +25,22 @@ entities:
     allday_expires_at: '11:00'
     label: 🗑️
 
-  # Everything else on the family calendar
-  - entity: calendar.family
-    blocklist: 'Birthday of|collection'
-
   # 💼 Work — that someone is busy, not what with
-  - entity: calendar.work
+  - entity: calendar.family
+    allowlist: 'Work:'
     replace_with: 'Busy'
+    label: 💼
     show_location: false
     show_description: false
+
+  # Everything else — the safety net
+  - entity: calendar.family
+    blocklist: 'Birthday of|collection|Work:'
 ```
 
-`Birthday of Lena Weber — All day` becomes **🎂 Lena Weber (32)**, and says 33 next year without anyone editing anything. Bin day retires itself at eleven. The children see that a parent is busy at nine, not that the meeting is a performance review. The first three blocks are the **same calendar**, three times.
+`Birthday of Lena Weber — All day` becomes **🎂 Lena Weber (32)**, and says 33 next year without anyone editing anything. Bin day retires itself at eleven. The children see that a parent is busy at nine, not that the meeting is a performance review. All four blocks are the **same calendar**, four times, and the last one's `blocklist` is exactly the union of the three allowlists above it — which is what stops anything being drawn twice or going missing.
 
-Four of the features below are in those twenty-five lines, and not one of them is announced — you write what you want the row to say, and the card gets out of the way. The walkthrough is [One Calendar, Many Purposes](https://calendar-card-pro.alexpfau.com/guide/one-calendar-many-purposes); everything from here on is the parts list.
+Four of the features below are in those twenty-seven lines, and not one of them is announced — you write what you want the row to say, and the card gets out of the way. The walkthrough is [One Calendar, Many Purposes](https://calendar-card-pro.alexpfau.com/guide/one-calendar-many-purposes); everything from here on is the parts list.
 
 ## 🎉 New Features
 

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -672,8 +672,8 @@ Three per-calendar options do it. `replace_field` names which field to rewrite a
 to the title; `replace_pattern` is what to find, as a regular expression; `replace_with` is
 what to put there.
 
-[One Calendar, Many Purposes](/guide/one-calendar-many-purposes) puts all three to work in a
-single card, alongside the filters above.
+[One Calendar, Many Purposes](/guide/one-calendar-many-purposes) puts `replace_pattern` and
+`replace_with` to work in a single card, alongside the filters above.
 
 ### What Each Combination Does
 

--- a/docs/guide/one-calendar-many-purposes.md
+++ b/docs/guide/one-calendar-many-purposes.md
@@ -6,7 +6,7 @@ Most calendar cards treat a calendar as one thing: you add it, and it contribute
 
 A screen in the hall, on all day, that the whole household walks past. It needs to answer three questions at a glance — _whose birthday is it, do the bins go out, and is anyone busy_ — without turning into a wall of text, and without putting a parent's work life in front of the children.
 
-Two calendars go into it. One of them does three different jobs.
+One calendar goes into it, four times.
 
 ```yaml
 type: custom:calendar-card-pro
@@ -28,22 +28,25 @@ entities:
     event_type: all_day
     allday_expires_at: '11:00'
     label: 🗑️
-    accent_color: '#607d8b'
-
-  # Everything else on the family calendar
-  - entity: calendar.family
-    blocklist: 'Birthday of|collection'
+    accent_color: '#7cb342'
 
   # 💼 Work — that someone is busy, not what with
-  - entity: calendar.work
+  - entity: calendar.family
+    allowlist: 'Work:'
     replace_with: 'Busy'
     label: 💼
-    accent_color: '#455a64'
+    accent_color: '#546e7a'
     show_location: false
     show_description: false
+
+  # Everything else — the safety net
+  - entity: calendar.family
+    blocklist: 'Birthday of|collection|Work:'
 ```
 
-The first three blocks are **the same calendar**, three times. Nothing is duplicated on screen, because their patterns are complementary — the first two claim what they match, and the third takes everything they did not.
+Every block is **the same calendar**. Nothing is drawn twice, because the first three claim what they match and the fourth takes everything they did not — its `blocklist` is exactly the union of the three allowlists above it.
+
+Three of the four carry a label, and the fourth deliberately does not. The labels mark the three questions the screen exists to answer; family life is everything else, and it does not need announcing.
 
 ### A Birthday Should Read Like a Name
 
@@ -62,27 +65,35 @@ What was _Birthday of Lena Weber — All day_ becomes **🎂 Lena Weber (32)**. 
 
 Bin day is only useful before the collection. After it, it is a line of text taking up space until midnight.
 
-[`allday_expires_at`](/features/core-settings#retiring-all-day-events-during-the-day) sets the time it stops counting as today's news. [`event_type: all_day`](/features/core-settings#separating-all-day-from-timed-events) keeps the block to all-day entries, so a timed event that happens to mention collection cannot wander in.
+One pattern covers every stream, because `collection` catches _Recycling collection_ and _Trash collection_ alike. [`allday_expires_at`](/features/core-settings#retiring-all-day-events-during-the-day) then sets the time they stop counting as today's news, and [`event_type: all_day`](/features/core-settings#separating-all-day-from-timed-events) keeps the block to all-day entries, so a timed event that happens to mention collection cannot wander in.
 
 ### Busy & Nothing Else
 
-This is the block that could not be built before. A shared screen should say that a parent is unavailable at nine; it should not say _Quarterly planning with the board_, and it certainly should not say _1:1 with Sarah — performance review_.
+A parent who blocks out work time on the shared calendar has already put it where the whole household can read it. That is half the point — everyone can see the morning is gone. The other half is that it should not say _Quarterly planning with the board_, and it certainly should not say _1:1 with Sarah — performance review_.
 
-`replace_with: 'Busy'` **with no `replace_pattern` beside it** replaces the whole title rather than part of it. That asymmetry is deliberate: a pattern alone deletes, a pattern with a replacement substitutes, and a replacement alone overrides the field entirely.
+Prefixing those entries is enough for an `allowlist` to find them, and [`replace_with`](/features/core-settings#hiding-what-an-event-is-about) **with no `replace_pattern` beside it** then replaces the whole title rather than part of it. That asymmetry is deliberate: a pattern alone deletes, a pattern with a replacement substitutes, and a replacement alone overrides the field entirely.
+
+The row keeps its time, its color and its place in the day, so the screen still says that something is on at nine. It just stops saying what.
 
 ::: warning A Title Is Not the Only Thing That Leaks
-Replacing the title does **not** make a calendar private on its own. The location still names the meeting room and the description may hold the agenda, so `show_location: false` and `show_description: false` are part of the recipe rather than decoration.
+Replacing the title does **not** make an event private on its own.
+
+`show_location: false` is doing real work here — locations are shown by default, and _Meeting Room 2_ gives the game away on its own.
+
+`show_description: false` is not, yet. Descriptions are hidden by default, so on this card it changes nothing. Set it anyway: it is what keeps this block safe the day you turn [`show_description`](/reference/configuration#core-settings) on card-wide.
 :::
 
 ## 🧭 Why This Works
 
-The pattern underneath is worth more than the example. **Every option here is per calendar**, so a calendar listed twice is two blocks that filter and style themselves independently, and the [visual editor's](/features/editor) **Duplicate** action builds the second one for you.
+The pattern underneath is worth more than the example. **Every option here is per calendar**, so a calendar listed four times is four blocks that filter and style themselves independently, and the [visual editor's](/features/editor) **Duplicate** action builds each new one for you.
 
 Two rules keep it predictable:
 
-**Make the blocks complementary.** Each event should match exactly one block. The example allowlists two patterns and then blocklists both in the catch-all, so every event lands once. Blocks that overlap render their events more than once — there is no automatic de-duplication between two copies of one calendar.
+**Make the blocks complementary.** Each event should match exactly one block. The example allowlists three patterns and blocklists all three in the catch-all, so every event lands once. Blocks that overlap render their events more than once — there is no automatic de-duplication between two copies of one calendar.
 
-**Finish with a catch-all.** A block with only a `blocklist` is the safety net. Without it, an event nobody wrote a rule for simply never appears, and it is very hard to notice something missing.
+**Finish with a catch-all.** A block with only a `blocklist` is the safety net, and it goes last for the same reason it exists: it is what is left over. Without it, an event nobody wrote a rule for simply never appears, and it is very hard to notice something missing.
+
+Those are one rule read from either end, which gives you something to check against. **The catch-all's `blocklist` should be exactly the union of the allowlists above it.** The day it stops being, either an event is drawn twice or one has quietly gone missing.
 
 ## 🔭 Where Else to Take It
 

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -82,7 +82,7 @@ Calendar Card Pro offers two ways to customize your card:
 ## 🚀 Next Steps
 
 - **Explore the Features** - [Core Settings](/features/core-settings), [Layout & Appearance](/features/layout-appearance) and [Event Content](/features/event-content) cover the options most people reach for first
-- **Follow a Worked Example** - [One Calendar, Many Purposes](/guide/one-calendar-many-purposes) builds a single hallway card out of one calendar listed three times, explaining each setting as it goes
+- **Follow a Worked Example** - [One Calendar, Many Purposes](/guide/one-calendar-many-purposes) builds a single hallway card out of one calendar listed four times, explaining each setting as it goes
 - **Discover Advanced Capabilities** - Add [weather forecasts](/features/weather), filter events with [blocklists and allowlists](/features/core-settings), or set up [tap and hold actions](/features/actions)
 - **See Examples** - Browse [Examples](/reference/examples) for complete, ready-made setups
 - **Reference Configuration** - Use [Configuration Options](/reference/configuration) as the complete option reference


### PR DESCRIPTION
Rebuilds the flagship story so the *rendering* carries it, not just the prose. The page and the card existed; what they drew from was two live test calendars whose contents drift and were built for other purposes.

## What changed on the instance

Ten events created on `calendar.calendar_card_pro_testing`, in a window no existing fixture reaches, and section 7 of `ccp-current-testing` rebuilt around them. Sections 1–6 and 8 untouched; the `TEST` / `RPL` fixtures untouched.

![the flagship story card as rendered](https://github.com/user-attachments/assets/50b97c0e-5e1e-4933-973a-7c41ad0c063c)

Mon 21 Sep · 🎂 Lena Weber (32) · 🗑️ Recycling collection · 💼 Busy 9:00–10:30 · Swimming lessons 16:30, Riverside Pool
Tue 22 Sep · Dentist — Mia 8:15, Dr. Whitfield · 💼 Busy 14:00–14:45 · Book club 19:30, Anna's place
Wed 23 Sep · 🎂 Tom Weber (10) · 🗑️ Trash collection · Parent-teacher conference 18:00, Northgate Elementary

Ten events in, ten rows out.

## The window moved to 2026-09-21

The brief named `2026-09-07`. That Monday is covered by the existing `TEST school holidays — Fri to Tue (delete me)` fixture, which runs 09-04→09-08 and would have drawn a `(delete me)` row into the catch-all block. I was told to leave that fixture alone and to control the story completely, and those two together rule the date out. `2026-09-21` is the same weekday two weeks later, and nothing exists on that calendar after 09-15.

## The story is now one calendar, four ways

The fourth block used to come from `calendar.work`, which let a reader tell themselves it was just a second calendar. It is now the same entity behind `allowlist: 'Work:'`, and the page's title is literally true.

Two things fall out of that:

- **The catch-all moved last**, so the example finally obeys the rule the page states two sections later.
- **Its `blocklist` is now exactly the union of the three allowlists above it.** That turns "make the blocks complementary" from advice into something a reader can check, and it is asserted mechanically in this PR rather than by eye.

## The expiry trade-off

A fixed future window means nothing is ever *today*, so `allday_expires_at` never fires — confirmed in `events.ts`, where the comparison is `now >= allDayExpiryInstant(...)`. I kept the fixed window.

The reason is not just stability. **A screenshot could never have shown that feature working anyway**: its visible effect is a row's *absence*, and you cannot photograph a row that is not there. A capture taken after 11:00 shows the same thing as a card without the option. So the fixed window costs nothing real and buys a card that renders identically today, at release, and in six months.

## Docs

The same config now lives in three places and they agree:

| | entity | extra lines |
|---|---|---|
| dashboard card | `calendar.calendar_card_pro_testing` | `start_date: '2026-09-21'`, `language: en` |
| `docs/guide/one-calendar-many-purposes.md` | `calendar.family` | — |
| `docs/RELEASE_NOTES.md` v4.1.0 intro | `calendar.family` | minus `type`/`title`/`days_to_show`/`accent_color` |

Both delta lines on the dashboard are capture scaffolding — a fixed window so the card cannot drift, and a pinned locale on a German instance. Neither belongs in a hallway-tablet recipe a reader copies, and the markdown above the card says so.

The line count in the release-notes intro is recounted at **twenty-seven** (was twenty-five, for a shorter block).

### Two corrections found on the way

- The privacy warning claimed `show_location: false` and `show_description: false` were both load-bearing. Only the first is — descriptions are hidden by default. The page now names the asymmetry, which is more useful than hiding it: it says what the second option is actually for.
- `usage.md` described the card as one calendar listed **three** times, and `core-settings.md` said the page puts **all three** replacement options to work when it has only ever used two. The second was wrong before this PR, but it is a sentence pointing straight at the page being rewritten.

## Verification

All nine gates green on the tip: `tsc --noEmit`, `lint`, `check:format`, `test` (2858 passed), `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`.

Beyond the gates, two claims made in prose are asserted mechanically rather than read:

- the release-notes config equals the guide config minus `accent_color` — block for block, by parsed YAML;
- the guide config equals the deployed dashboard card once the two scaffolding lines, the entity id and the `-dev` suffix are removed.

My local run was on Node 25.8.0 rather than the pinned Node 22 — there is no nvm on this machine. `ci.yml` runs all nine of those gates from `node-version-file: .nvmrc`, and `lint-build` is green on this branch, so they have now been run under the pin as well.

## Leave-alone list, honored

Both What's New surfaces, sections 1–6 (and 8) of the dashboard view, and the existing `TEST` / `RPL` fixtures.

