### PR TITLE
feat(today-indicator): draw any text as the indicator, not only text with a digit in it

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -126,6 +126,14 @@ Both panels for one calendar carry the same heading, because they name the same 
 
 That is eleven editor languages in total, counting US English in code and British English, which carries only the 44 strings where it differs. The other 24 of the card's 35 languages render the editor in English, which is fully supported and still resolves per string. The calendar itself continues to speak all 35.
 
+### 🔤 A Today Indicator That Can Be Words
+
+**`today_indicator` now takes any text, so the marker on today can read `KW 34` or `Sprint 12` instead of only being a dot, an icon, an emoji or a picture.** It half-worked already, which is the odd part: the test deciding whether a value was drawable asked Unicode whether it contained an emoji, and Unicode says the ASCII digits, `#` and `*` all qualify — they are the bases of keycap sequences like 2️⃣. So `Sprint 12` was drawn as words and `Sprint` was drawn as a dot, with nothing anywhere explaining the difference.
+
+Widening that rather than closing it is the direction that takes nothing away: every value that drew text before still does, and `true` or `dot` is still how you ask for a plain dot. What changes is what happens to a value the card does not recognize — it is drawn now rather than silently replaced by a dot, so a typo shows up instead of looking deliberate.
+
+Two things to know if you use it. Text is sized by `today_indicator_size`, which ships at `6px` because that is right for an emoji and far too small for a word, so raise it. And a value shaped like an address is still read as an image, which means `/dev` and `https://…` cannot be drawn as literal text. (#573)
+
 ## 🐛 Bug Fixes
 
 - **Finished All-Day Events Stayed on the Card** - With `show_past_events: false`, a timed event vanished when it ended but an all-day one never did: an all-day event has no end _time_, only an end _date_, so the card had nothing to compare against and exempted them all. Any card whose window reached backwards therefore kept showing all-day events from days that were over — `start_date: 'today-7'`, or `start_of_week` read on a Thursday, which the start-date docs actively recommend pairing with past events hidden. All-day events are now past at midnight after the last day they cover, so a finished one goes and today's stays up all day. If you use a backward-looking window, expect finished all-day entries to disappear from it
@@ -156,6 +164,7 @@ That is eleven editor languages in total, counting US English in code and Britis
 - [#215](https://github.com/alexpfau/calendar-card-pro/issues/215) - Use a person entity's picture as a calendar's label by @fl0om, supported by @voyagers21 — who had the right address all along, `/api/image/serve/…` read off the browser, and was told it was not working because the card drew it as text. A person's picture now works as a `label` with nothing else to set. The person picker the request suggested is not what shipped, and is not needed for it: the address is already on the person entity, as its `entity_picture` attribute
 - [#566](https://github.com/alexpfau/calendar-card-pro/issues/566) - A label pointing at an image outside `/local/` silently rendered as its own URL by @alexpfau
 - [#569](https://github.com/alexpfau/calendar-card-pro/issues/569) - `today_indicator` silently fell back to a dot for image addresses its list did not name by @alexpfau
+- [#573](https://github.com/alexpfau/calendar-card-pro/issues/573) - `today_indicator` had an undocumented text mode, gated on whether the text contained a digit by @alexpfau
 
 ---
 

--- a/docs/features/layout-appearance.md
+++ b/docs/features/layout-appearance.md
@@ -274,6 +274,7 @@ today_indicator: pulse # Animated pulsing dot
 today_indicator: glow # Glowing dot
 today_indicator: mdi:star # Any Material Design icon
 today_indicator: 🎯 # Emoji
+today_indicator: KW 34 # Any text — raise today_indicator_size to make words readable
 today_indicator: /local/custom-indicator.png # Image path
 today_indicator: https://example.com/today.png # Or any image URL
 
@@ -299,6 +300,9 @@ Available indicator types:
 - `mdi:icon-name`: Any Material Design Icon
 - Emoji characters: Any emoji like `🎯` or `⭐`
 - Image path: Any image URL or local path
+- Any other text: Drawn as the characters themselves — a week number, a quarter, a sprint name
+
+Anything the card does not recognize as one of the first four is drawn as its own characters, so a typo shows up on the card instead of quietly falling back to a dot. Two things follow from that. Text is sized by `today_indicator_size`, which defaults to `6px` — right for an emoji, far too small for a word, so raise it when you use one. And a value shaped like an address is read as an image, so there is no way to draw `/dev` or a URL as literal text.
 
 The `today_indicator_position` option accepts CSS-like position values in the format "x% y%", allowing precise placement of the indicator anywhere within the date column.
 
@@ -306,6 +310,6 @@ The `today_indicator_position` option accepts CSS-like position values in the fo
 `today_indicator_position` applies in list view only. A column header is as wide as the whole column with its date flush left, so a percentage that works beside a narrow date column lands on top of the day number instead — and a value far enough right ends up closer to the next day than to today. Rather than ask you to calibrate a percentage against your column width, column view puts the indicator immediately before the weekday, giving an unmistakable marker whatever the column measures. Every other indicator option — the type, `today_indicator_size` and `today_indicator_color` — works the same in both views.
 :::
 
-`today_indicator_size` scales every indicator type — it sets the icon size, the emoji font size and the image width. `today_indicator_color` colors the icon-based types (the dot, `pulse`, `glow` and any `mdi:` icon) and is also the color of the glow itself; emojis and images keep their own colors.
+`today_indicator_size` scales every indicator type — it sets the icon size, the font size for emoji and text, and the image width. `today_indicator_color` colors the icon-based types (the dot, `pulse`, `glow` and any `mdi:` icon) and is also the color of the glow itself; emojis and images keep their own colors, and text takes the color it inherits.
 
 The options on this page are grouped in the reference under [Layout & Spacing](/reference/configuration#layout-spacing), [Week Numbers & Horizontal Separators](/reference/configuration#week-numbers-horizontal-separators), [Today Indicator](/reference/configuration#today-indicator) and [Date Column](/reference/configuration#date-column).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -129,12 +129,12 @@ Both height options may be overridden inside a `column:` block, and usually shou
 
 ## 🌟 Today Indicator
 
-| Option                     | Type              | Default   | Description                                                                                                                                               |
-| -------------------------- | ----------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `today_indicator`          | boolean or string | `false`   | Today indicator type: `true`/`dot` (basic dot), `pulse` (animated dot), `glow` (glowing effect), custom MDI icon (e.g., `mdi:star`), emoji, or image path |
-| `today_indicator_position` | string            | `15% 50%` | Position of today indicator in CSS-like format (x% y%)                                                                                                    |
-| `today_indicator_color`    | string            | `#03a9f4` | Color of the today indicator                                                                                                                              |
-| `today_indicator_size`     | string            | `6px`     | Size of the today indicator                                                                                                                               |
+| Option                     | Type              | Default   | Description                                                                                                                                                               |
+| -------------------------- | ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `today_indicator`          | boolean or string | `false`   | Today indicator type: `true`/`dot` (basic dot), `pulse` (animated dot), `glow` (glowing effect), custom MDI icon (e.g., `mdi:star`), emoji, image path, or any other text |
+| `today_indicator_position` | string            | `15% 50%` | Position of today indicator in CSS-like format (x% y%)                                                                                                                    |
+| `today_indicator_color`    | string            | `#03a9f4` | Color of the today indicator                                                                                                                                              |
+| `today_indicator_size`     | string            | `6px`     | Size of the today indicator                                                                                                                                               |
 
 **→ [Today indicator](/features/layout-appearance#today-indicator)** — all four indicator types, shown side by side.
 

--- a/src/rendering/editor/strings.ts
+++ b/src/rendering/editor/strings.ts
@@ -426,6 +426,8 @@ export const EDITOR_STRINGS: Readonly<Record<string, string>> = {
   'today_indicator_style.option.custom.label': 'An Emoji or Image',
   today_indicator_icon: 'Icon',
   today_indicator_custom: 'Emoji Or Image Path',
+  'today_indicator_custom.helper':
+    'An emoji, an image path or URL, or any text. Words need a larger Indicator Size than the size an emoji reads at.',
   today_indicator_color: 'Indicator Color',
   today_indicator_size: 'Indicator Size',
   today_indicator_position: 'Indicator Position',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -112,8 +112,20 @@ export function getTodayIndicatorType(value: string | boolean): string {
   }
 
   if (typeof value === 'string') {
-    if (value === 'pulse' || value === 'glow') {
+    // 🚨 `dot` belongs here and not in the fallthrough, which is where it used to arrive.
+    // It is a documented value and it is what the editor's own Dot option writes
+    // (`BUILT_IN_INDICATORS`), so it reached the right answer only because *every*
+    // unrecognized string did. The moment the fallthrough below became text rather than a
+    // dot, that accident would have drawn the word "dot" on the card.
+    if (value === 'dot' || value === 'pulse' || value === 'glow') {
       return value;
+    }
+
+    // Nothing to draw. `renderTodayIndicator` short-circuits on a falsy value before it ever
+    // asks, so this is here for the editor, which does ask: without it an empty field would
+    // read as text and open the Custom control on a value that is not set.
+    if (value.trim() === '') {
+      return 'dot';
     }
 
     if (isIconValue(value)) {
@@ -125,26 +137,21 @@ export function getTodayIndicatorType(value: string | boolean): string {
     // extension, the four-letter `.jpeg`, and `avif`, `bmp`, `ico` and `apng` — and, being
     // `includes` on a lower-case literal, missed `.PNG` and `.JPEG` outright (#569).
     //
-    // 🚨 Two things make this safe to widen even though `today_indicator` has no
-    // `today_indicator_type` to undo a wrong reading with, and both turn on `dot` being the
-    // *fallthrough* as well as the default:
-    //
-    //   - Nothing working is taken. Every arm that gives a value meaning — `pulse`/`glow`,
-    //     then `isIconValue` — runs above this one, so the only values this can claim are
-    //     ones that reached `dot`, which is the bucket for "not understood". A widening here
-    //     cannot reclassify a configuration that draws what its author asked for.
-    //   - Nothing readable is taken. Unlike `label` there is no `text` branch to fall into:
-    //     this option has no prose case at all, so there is no rendering that free text was
-    //     the right answer for and that an address test could steal.
-    //
-    // That asymmetry is also why the missing escape hatch is affordable here and is not on
-    // `label`, where the fallthrough is a meaningful rendering.
+    // 🚨 What this costs changed when the fallthrough became text (#573). It used to cost
+    // nothing at all — the only values these arms could claim were ones that reached `dot`,
+    // the bucket for "not understood" — and that was the argument for widening them without
+    // an escape hatch. Now they can claim a value that would otherwise be *drawn*, so the
+    // rule is the trade instead: an address-shaped value is an image, everything else is
+    // drawn literally, and there is no way to ask for an address-shaped value as text.
+    // `label` makes the same trade and can undo it with `label_type`; this option has no
+    // counterpart, so the case to weigh is a badge that is meant to read as `/dev` or as a
+    // URL. Both are addresses far more often than they are captions.
     if (value.startsWith('/') || /^https?:\/\//i.test(value)) {
       return 'image';
     }
 
     // 🚨 Anchored, where the old test was `includes`, so this narrows as well as widens:
-    // `report.gifted`, `a.pngx` and `Meeting.jpg tomorrow` were images and are now dots.
+    // `report.gifted`, `a.pngx` and `Meeting.jpg tomorrow` were images and are now text.
     // That is deliberate. With the two prefix arms above taking every absolute path and every
     // URL, this arm is only ever reached by a *relative* path — and a relative path that is an
     // image ends at its extension, or at the `?` or `#` that ends the path. So the set this
@@ -154,12 +161,25 @@ export function getTodayIndicatorType(value: string | boolean): string {
       return 'image';
     }
 
-    const emojiRegex = /[\p{Emoji}]/u;
-    if (emojiRegex.test(value)) {
-      return 'emoji';
-    }
-
-    return 'dot';
+    // Anything still here is drawn as its own characters (#573).
+    //
+    // This used to be `/[\p{Emoji}]/u`, which is not "is this a pictograph": the Unicode
+    // `Emoji` property is `Yes` for the ASCII digits, `#` and `*`, because those are the
+    // bases of keycap sequences. So `Sprint 12` was drawn as text and `Sprint` was drawn as
+    // a dot, and nothing in the config, the docs or the editor explained the difference —
+    // the option had a text mode gated on whether the text happened to contain a digit.
+    //
+    // Widening it rather than narrowing it is the one direction that takes nothing away:
+    // every value that drew text before still draws text, `dot`/`pulse`/`glow` are matched
+    // above, and `true`/`dot` remain the way to ask for a plain dot. What it costs is the
+    // "I typed nonsense and got a dot" fallback — a typo is now visible instead of looking
+    // deliberate, which is the better failure for an option whose whole defect history is
+    // silent fallbacks.
+    //
+    // The returned name stays `emoji` on purpose. It is the discriminator for a branch that
+    // renders the value verbatim, and it decides the public `today-indicator emoji` class
+    // that themes and card-mod select on; renaming it would break those to no benefit.
+    return 'emoji';
   }
 
   return 'none';

--- a/tests/editor-schema.test.ts
+++ b/tests/editor-schema.test.ts
@@ -2204,14 +2204,43 @@ describe('editor: fields that must survive being typed into', () => {
   }
 
   /**
-   * The renderer classifies any string it does not recognise as a plain dot, so
-   * committing each keystroke of `star.png` would switch the style to Dot on the `s`,
-   * remove this field, and leave `s` in the user's configuration.
+   * The field must not be taken away under the cursor. Two mechanisms serve that now, and
+   * which one applies depends on what is being typed.
+   *
+   * A word-shaped partial classifies as text since #573, so every keystroke of `star.png`
+   * leaves the style on Custom and commits — the field stands because the classification
+   * keeps it standing, not because the value was withheld. The cost is that the fragment
+   * reaches the config on the way, which is what every other free-text field in the editor
+   * already does.
+   *
+   * An `mdi:` partial is the case the hold still exists for: `mdi:c` classifies as an icon,
+   * which *would* move the style to Icon and replace this field mid-word, so it is held
+   * pending until the user leaves it.
    */
   it('keeps the custom indicator field standing while an image path is typed', () => {
     const start = buildConfig({ today_indicator: '⭐' });
 
     for (const partial of ['s', 'st', 'star', 'star.pn']) {
+      const { config } = type(start, 'today_indicator_custom', [partial]);
+
+      expect(config.today_indicator, partial).toBe(partial);
+      expect(
+        fieldNames(() => buildDayHeaderSchema({ view: 'list', config, language: 'en' })),
+        partial,
+      ).toContain('today_indicator_custom');
+    }
+
+    const done = type(start, 'today_indicator_custom', ['s', 'st', 'star', 'star.pn', 'star.png']);
+    expect(done.config.today_indicator).toBe('star.png');
+  });
+
+  /**
+   * The half the hold still covers, and the one that would actually lose the field.
+   */
+  it('holds an icon-shaped value rather than switching the style under the cursor', () => {
+    const start = buildConfig({ today_indicator: '⭐' });
+
+    for (const partial of ['mdi:c', 'mdi:cal', 'mdi:calendar']) {
       const { config, pending } = type(start, 'today_indicator_custom', [partial]);
 
       expect(config.today_indicator, partial).toBe('⭐');
@@ -2221,9 +2250,6 @@ describe('editor: fields that must survive being typed into', () => {
         partial,
       ).toContain('today_indicator_custom');
     }
-
-    const done = type(start, 'today_indicator_custom', ['s', 'st', 'star', 'star.pn', 'star.png']);
-    expect(done.config.today_indicator).toBe('star.png');
   });
 
   /**
@@ -4149,9 +4175,11 @@ describe('editor: exceptions for the union-typed options', () => {
   });
 
   /**
-   * The same hold the card-level control uses, and needed for the same reason: an
-   * unrecognised string classifies as a plain dot, so committing `star.pn` on the way to
-   * `star.png` would switch the shape, take this very field away and store the fragment.
+   * The same hold the card-level control uses, and needed for the same reason — but since
+   * #573 only for the values that would actually move the style. A word-shaped partial
+   * classifies as text and keeps the shape on Custom, so it commits and the field stands;
+   * an `mdi:` partial would switch the shape to Icon and take this very field away, so it
+   * is held until the user finishes.
    */
   it('holds a half-typed value instead of reclassifying the shape under the cursor', () => {
     const config = columnConfig({ column: { today_indicator: '⭐' } as Types.ColumnOverrides });
@@ -4159,7 +4187,7 @@ describe('editor: exceptions for the union-typed options', () => {
     let pending: Record<string, string> = {};
     let current = config;
 
-    for (const partial of ['s', 'st', 'star', 'star.pn']) {
+    for (const partial of ['mdi:c', 'mdi:cal', 'mdi:calendar']) {
       const applied = change(
         current,
         ['today_indicator'],

--- a/tests/today-indicator-image-address.test.ts
+++ b/tests/today-indicator-image-address.test.ts
@@ -60,7 +60,7 @@ const IMAGE_ADDRESSES: ReadonlyArray<readonly [string, string]> = [
 
 /** Values whose reading must not change, so the widened rule is not simply a wider net. */
 const KEEPS_ITS_SHAPE: ReadonlyArray<readonly [string, string, string]> = [
-  ['a plain word', 'Holiday', 'dot'],
+  ['the dot keyword', 'dot', 'dot'],
   ['the pulse keyword', 'pulse', 'pulse'],
   ['the glow keyword', 'glow', 'glow'],
   ['an mdi icon', 'mdi:star', 'mdi'],
@@ -74,8 +74,9 @@ const KEEPS_ITS_SHAPE: ReadonlyArray<readonly [string, string, string]> = [
  *
  * Each of these contains an image extension somewhere other than the end of a path, so the old
  * `includes` test called it an image and the card rendered `<img src="report.gifted">`. They are
- * dots now. Nothing here is an address the card could ever have loaded, which is the argument —
- * but it is a behavior change in the restrictive direction, so it is written down.
+ * drawn as their own characters now — `dot` when this was written, text since #573 made that
+ * the fallthrough. Nothing here is an address the card could ever have loaded, which is the
+ * argument; but it is a behavior change in the restrictive direction, so it is written down.
  */
 const NARROWED: ReadonlyArray<readonly [string, string]> = [
   ['an extension inside a sentence', 'Meeting.jpg tomorrow'],
@@ -120,7 +121,7 @@ describe('reading an image address off today_indicator', () => {
   });
 
   it.each(NARROWED)('no longer reads %s as an image', (_name, value) => {
-    expect(Helpers.getTodayIndicatorType(value), value).toBe('dot');
+    expect(Helpers.getTodayIndicatorType(value), value).toBe('emoji');
   });
 
   /**
@@ -189,11 +190,11 @@ describe('the editor and a today_indicator image address', () => {
     expect(result.changes).toHaveProperty('today_indicator', value);
   });
 
-  /** And a value that is genuinely not renderable is still held rather than committed. */
-  it('still refuses a word the card cannot draw', () => {
-    const result = custom.apply('Holiday', buildConfig({}) as Types.Config);
+  /** And a value that would move the style away from Custom is still held rather than committed. */
+  it('still refuses a value that would change the style', () => {
+    const result = custom.apply('mdi:calendar', buildConfig({}) as Types.Config);
 
     expect(result.changes).not.toHaveProperty('today_indicator');
-    expect(result.pending?.today_indicator_custom).toBe('Holiday');
+    expect(result.pending?.today_indicator_custom).toBe('mdi:calendar');
   });
 });

--- a/tests/today-indicator-text.test.ts
+++ b/tests/today-indicator-text.test.ts
@@ -1,0 +1,156 @@
+import { render as litRender } from 'lit';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import type * as Types from '../src/config/types';
+import { SYNTHETIC_FIELDS, todayIndicatorStyle } from '../src/rendering/editor/synthetic';
+import { renderTodayIndicator } from '../src/rendering/leaves';
+import * as Helpers from '../src/utils/helpers';
+
+/**
+ * `today_indicator` drawn as its own characters (#573).
+ *
+ * The branch that renders a value verbatim used to be guarded by `/[\p{Emoji}]/u`, which is
+ * not "is this a pictograph": the Unicode `Emoji` property is `Yes` for the ASCII digits, for
+ * `#` and for `*`, because those are the bases of keycap sequences. So the option already had
+ * a text mode — `Sprint 12` drew the words — gated on whether the text happened to contain a
+ * digit. `Sprint` drew a dot, and nothing in the config, the docs or the editor said why.
+ *
+ * Widening is the one direction that takes nothing away: everything that drew text before
+ * still draws text, and `true` / `dot` remain the way to ask for a plain dot. What it costs
+ * is the fallback that turned an unrecognized value into a dot, so a typo is now visible
+ * rather than looking deliberate.
+ */
+
+/** The keyword arm. Each of these must beat the text fallthrough below it. */
+const KEYWORDS: ReadonlyArray<readonly [string, string]> = [
+  ['dot', 'dot'],
+  ['pulse', 'pulse'],
+  ['glow', 'glow'],
+];
+
+/**
+ * Values that read as text, and the reason each is here.
+ *
+ * The first group already worked, by the accident this replaces; the second is what the
+ * accident excluded, and is the whole of the change.
+ */
+const TEXT: ReadonlyArray<readonly [string, string]> = [
+  ['a year', '2024'],
+  ['a quarter', 'Q4'],
+  ['a sprint number', 'Sprint 12'],
+  ['a German week number', 'KW 34'],
+  ['a hash-prefixed number', '#1'],
+
+  ['a bare word', 'Sprint'],
+  ['a word with no digit in it', 'heute'],
+  ['a capitalized word', 'Holiday'],
+  ['a non-Latin word', 'やすみ'],
+  ['an ASCII symbol', '!'],
+  ['a single letter', 'x'],
+];
+
+describe('a today_indicator drawn as its own characters', () => {
+  let host: HTMLElement;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+  });
+
+  /** Renders the indicator and reports which branch of the switch drew it. */
+  function drawn(value: string): { branch: string; text: string } {
+    const config = buildConfig({ today_indicator: value }) as Types.Config;
+    litRender(renderTodayIndicator(config, true), host);
+
+    const node = host.querySelector('.today-indicator');
+    if (node === null) return { branch: 'none', text: '' };
+
+    const tag = node.tagName.toLowerCase();
+    return {
+      branch: tag === 'img' ? 'image' : tag === 'span' ? 'emoji' : 'icon',
+      text: (node.textContent ?? '').trim(),
+    };
+  }
+
+  it.each(TEXT)('draws %s as the characters themselves', (_name, value) => {
+    expect(Helpers.getTodayIndicatorType(value), value).toBe('emoji');
+
+    const { branch, text } = drawn(value);
+    expect(branch, value).toBe('emoji');
+    expect(text, value).toBe(value);
+  });
+
+  /**
+   * 🚨 The regression the widening would have shipped without this.
+   *
+   * `dot` is a documented value and it is what the editor's own Dot option writes, but it
+   * used to reach `'dot'` through the fallthrough rather than through an arm of its own —
+   * it worked only because *every* unrecognized string did. Turning that fallthrough into
+   * text would have drawn the word "dot" on the card.
+   */
+  it.each(KEYWORDS)('still reads the %s keyword as a keyword', (value, expected) => {
+    expect(Helpers.getTodayIndicatorType(value)).toBe(expected);
+    expect(drawn(value).branch).toBe('icon');
+  });
+
+  it('still reads the boolean forms', () => {
+    expect(Helpers.getTodayIndicatorType(true)).toBe('dot');
+    expect(Helpers.getTodayIndicatorType(false)).toBe('none');
+  });
+
+  /**
+   * Everything above the text arm still wins, so the widening is not simply a wider net.
+   * These are the four classes that would be swallowed if the fallthrough ran too early.
+   */
+  it.each([
+    ['an mdi icon', 'mdi:star', 'mdi'],
+    ['a non-mdi icon prefix', 'phu:octopusenergy', 'mdi'],
+    ['an absolute path', '/local/today.png', 'image'],
+    ['an absolute URL', 'https://example.com/avatar', 'image'],
+    ['a relative image', 'today.svg', 'image'],
+    ['a real emoji', '🎯', 'emoji'],
+  ])('still reads %s as %s', (_name, value, expected) => {
+    expect(Helpers.getTodayIndicatorType(value), value).toBe(expected);
+  });
+
+  /**
+   * An empty value must not read as text. `renderTodayIndicator` short-circuits on a falsy
+   * value and never asks, but the editor does ask — without this it would open the Custom
+   * control on a field the user has not filled in.
+   */
+  it.each(['', ' ', '   '])('reads %j as a dot rather than empty text', (value) => {
+    expect(Helpers.getTodayIndicatorType(value)).toBe('dot');
+  });
+});
+
+/**
+ * What the editor does with a text indicator.
+ *
+ * `isCommittableIndicator` asks whether the card would render the value, which after the
+ * widening is the same question as "does this keep the style on Custom". So the values it
+ * commits are exactly the ones that do not move the style, and the ones it holds are exactly
+ * the ones that would take this field away mid-word.
+ */
+describe('the editor and a text indicator', () => {
+  const custom = SYNTHETIC_FIELDS.today_indicator_custom;
+
+  const commits = (value: string): boolean =>
+    Object.prototype.hasOwnProperty.call(
+      custom.apply(value, buildConfig({}) as Types.Config).changes,
+      'today_indicator',
+    );
+
+  it.each(['Sprint', 'Sprint 12', 'heute', 'Holiday'])('commits %s', (value) => {
+    expect(commits(value)).toBe(true);
+    expect(todayIndicatorStyle({ today_indicator: value } as Types.Config)).toBe('custom');
+  });
+
+  /**
+   * The hold that survives, and the reason it still has to. Each of these classifies as
+   * something other than text, so committing one mid-word would switch the style and replace
+   * the field the user is typing into.
+   */
+  it.each(['mdi:c', 'mdi:calendar', 'dot', 'pulse', '', ' '])('holds %j', (value) => {
+    expect(commits(value)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #573, widening as proposed in option 2 of that issue.

## What changed

`today_indicator` takes any text now. It half-worked already: the arm deciding whether a value could be drawn verbatim tested `/[\p{Emoji}]/u`, and Unicode's `Emoji` property is `Yes` for the ASCII digits, `#` and `*` — they are the keycap bases. So `Sprint 12` drew the words and `Sprint` drew a dot, with nothing anywhere explaining the difference. Measured at the parent commit: **14 of 14** ASCII values containing a digit, `#` or `*` classified as emoji; **0 of 8** plain words did.

## The regression this would have shipped

🚨 **`dot` reached its answer through the fallthrough, not through an arm of its own.** Only `pulse` and `glow` were explicit — `dot`, `true`, `none`, `''` all arrived at `'dot'` because *every* unrecognized string did. `dot` is documented, and it is what the editor's Dot option writes (`BUILT_IN_INDICATORS`), so turning the fallthrough into text would have drawn the word "dot" on the card.

It is an explicit keyword now. Removing it again fails **5 tests across 4 files**, `list-dom.test.ts` among them — so the regression would have shown up in a DOM snapshot, not just a unit test.

## Two consequences, stated rather than left to be found

**Text is sized by `today_indicator_size`, which ships at `6px`.** Right for an emoji, unreadable for a word. On the feature page, and in a new `today_indicator_custom.helper` string — additive, so none of the nine translated editor languages goes stale. I did not reword the two existing labels for exactly that reason: they are translated in all nine, and rewording them would strand 18 strings I cannot responsibly machine-translate.

**The image arms can now claim a value that would otherwise be drawn.** That was not true when the fallthrough was a dot, and it is the argument #569 rested on — so the comment on those arms is updated rather than left saying something that has stopped being true. `/dev` and a URL cannot be drawn as literal text, and there is no `today_indicator_type` to override it.

## The editor needed no change, and now computes something sharper

`isCommittableIndicator` asks whether the card would render the value, which after the widening is the same question as *does this keep the style on Custom*. So it commits exactly the values that do not move the style and holds exactly those that would:

| typed | commits | why |
| --- | --- | --- |
| `s`, `st`, `star`, `star.png` | yes | stays on Custom |
| `mdi:c`, `mdi:calendar` | no | would switch to Icon and replace the field mid-word |
| `dot`, `pulse` | no | would switch to a built-in style |
| `''`, `' '` | no | nothing to commit |

The two tests that pinned the old hold are updated to assert that, keeping the half that still bites. Their original rationale — "committing each keystroke would switch the style to Dot on the `s`, remove this field, and leave `s` in the configuration" — no longer applies to word-shaped partials, because those now keep the field standing by classification. It does still apply to `mdi:` partials, and that is what they test now.

The cost is that a fragment reaches the config while you type, which is what every other free-text field in the editor already does.

## Verification

- Widening alone, before the fix was complete: **8 failures across 2 files**, each read and resolved deliberately rather than updated wholesale.
- Falsifier on the `dot` keyword: 5 failures across 4 files.
- Full suite green at 143 files / 2955 tests, on Node 25 and under the `.nvmrc` pin, with identical bundle bytes on both.
- All nine gates pass.

Bundle: card `199375 → 199338` raw (the regex is gone), editor `350084 → 350162` (the helper string).
