### PR TITLE
test(dst): pin event times against the local zone, not UTC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,25 @@ fails loudly instead of silently proving nothing if it is ever run under UTC —
 `tests/week-number-dst.dst.test.ts` has one to copy. The `exclude` on the `unit` project is
 what stops those files running a fourth time under UTC; do not drop it.
 
+🚨 **The transition is the famous exposure; the plain offset is the bigger one, and it
+was uncovered until v4.1.** Everything above is about DST _transitions_, which touch two
+days a year. Under `TZ=UTC` a local clock reading and a UTC one are the **same number**
+on every day of the year, so any code reading `getHours()` is equally untested — and
+`formatTime`, which prints the time on every timed event, had no `.dst.test.ts` at all.
+Rewriting it to `getUTCHours()`/`getUTCMinutes()`, and rewriting `formatEventTime`'s
+single-day-versus-multi-day test to compare UTC calendar days instead of local ones, each
+left the **whole suite green** while misprinting the time for every user outside UTC.
+`tests/event-time-zone.dst.test.ts` closes that; the first now fails 5 assertions in each
+zone and the second 1–2.
+
+Two things that file is worth copying. Its oracle is `Intl.DateTimeFormat`, **not**
+`Date.prototype.getHours` — the code under test is built from the `Date` getters, so an
+expectation derived from those same getters restates the implementation instead of
+checking it. And it says plainly that **no zone is uniquely required there**: all three
+catch both mutations and any non-UTC zone would, which is a weaker claim than the
+week-number file's and the honest one. Do not assert a zone is the only one able to see a
+failure without planting it in the other two.
+
 **A snapshot diff you did not intend is usually a whitespace error, not a rendering
 change.** The serializer normalises whitespace _between tags only_; whitespace adjacent to
 a text node survives verbatim, so the literal source indentation inside an `html` template
@@ -296,10 +315,29 @@ the folded time/countdown spans — each added after `npm run format` reintroduc
 exact spaces a fix had just removed and turned five tests red. Locate them with
 `grep -n "prettier-ignore" src/rendering/leaves.ts` rather than by line number; two of
 the three moved the last time someone edited a comment above them. If you find one and
-wonder whether it is still needed, it is — delete it, **run `npm run format`**, then
-`npm test`. The format step is the whole experiment: without it the directive's removal
-changes nothing and the whole suite still passes, which reads as "safe to delete" and
-is not.
+wonder whether it is still needed, run the experiment rather than reasoning about it —
+delete it, **run `npm run format`**, then `npm test`. The format step is the whole
+experiment: without it the directive's removal changes nothing and the whole suite still
+passes, which reads as "safe to delete" and is not.
+
+🚨 **Run it per site, because the three no longer answer the same way.** This paragraph
+used to say "it is" — that all three are still load-bearing — and that is now true of
+two. Measured one at a time on the tip, each with the format step:
+
+| site                        | on removal + `npm run format` |
+| --------------------------- | ----------------------------- |
+| day-header weather badge    | 6 tests fail                  |
+| event weather badge         | 4 tests fail                  |
+| folded time/countdown spans | **suite stays green**         |
+
+The third is not a dead directive, and deleting it on that result would be the trap this
+section is about arriving from the other side. Prettier _does_ reformat that site — but
+it reformats it as `<span class="time-text"\n  >`, breaking **inside** the tag, which is
+the `</span\n><span` asymmetry two paragraphs up doing its job. No text node appears, so
+the DOM is identical and no snapshot moves. What the directive buys there is the source
+reading as the single line the browser sees, instead of the `>`-on-its-own-line form that
+is exactly what the comment above it is warning against. Keep it; it is documentation
+that happens to also be a guard, and the two other sites prove the guard is real.
 
 **Never resolve a snapshot failure with `vitest -u`.** It launders the change past review,
 and the gate's entire value is that it is the one artefact the person doing the refactor

--- a/src/rendering/styles.ts
+++ b/src/rendering/styles.ts
@@ -94,9 +94,13 @@ export function generateCustomPropertiesObject(config: Types.Config): Record<str
       config.weather?.date?.color || 'var(--primary-text-color)',
     '--calendar-card-weather-event-icon-size': config.weather?.event?.icon_size || '14px',
     '--calendar-card-weather-event-font-size': config.weather?.event?.font_size || '12px',
-    // Read with a fallback because this function is also called with configs that never
-    // went through setConfig — the editor's own preview objects, and tests — where a
-    // weather block can omit event.max_lines entirely.
+    // Read with a fallback because a `weather:` block can arrive without `event`, in
+    // which case `max_lines` is absent rather than 0. That is a defensive read rather
+    // than a live one: the single production caller is `getCustomStyles`, which passes
+    // the post-`setConfig` effective config, and `mergeConfig` fills the nested weather
+    // defaults in. Nothing in the editor reaches this function. Tests are what exercise
+    // the fallbacks today — see the note on WEATHER_FALLBACKS in
+    // `tests/custom-property-mapping.test.ts`, which measured that.
     '--calendar-card-weather-event-max-lines':
       (config.weather?.event?.max_lines ?? 0) > 0
         ? String(config.weather?.event?.max_lines)

--- a/tests/custom-property-mapping.test.ts
+++ b/tests/custom-property-mapping.test.ts
@@ -149,17 +149,26 @@ describe('custom property mapping', () => {
  *
  * v4 turned these into a real override surface: the badges used to carry their size and
  * colour as inline `style` attributes that no theme could reach, and `theming.md` now
- * publishes all six properties with defaults. The defaults are the half that matters,
- * because this function is reached with configs that never went through `setConfig` — the
- * editor's own preview objects, and tests — where a `weather:` block naming only `entity`
- * carries no `date` or `event` at all, so every one of these reads its fallback.
+ * publishes all six properties with defaults.
  *
- * All five unconditional fallbacks survived a mutation sweep of `styles.ts`: rewriting
- * `?? '14px'` so the fallback is dropped emits `undefined` into the property, and both
- * `npm test` and `check:docs` stayed green. Each pair below asserts the fallback and a
- * distinct override, so a mapping that ignores its config and a mapping that has lost its
- * default both fail — and the override values are unique, so two crossed properties fail
- * as well.
+ * 🚨 The pairs below do **not** pin the `|| '14px'` fallbacks in `styles.ts`, and an
+ * earlier version of this comment claimed they did. `propsFor` goes through
+ * `buildConfig`, which deep-merges `DEFAULT_CONFIG` — and that already carries
+ * `weather.date.icon_size: '14px'`. So `{ weather: { entity } }` does not arrive with
+ * `date` absent; it arrives fully populated, and the assertion reads the merged
+ * *default* rather than the fallback beside it. Measured both ways: changing the
+ * fallback to `'99px'`, and dropping it entirely behind a cast, each left `tsc` and the
+ * whole suite green.
+ *
+ * That is not a hole worth plugging here, because the fallback is unreachable in
+ * production anyway. `generateCustomPropertiesObject` has exactly one production caller
+ * — `getCustomStyles` in `calendar-card-pro.ts`, passing `this.effectiveConfig`, which
+ * is always post-`setConfig` and therefore always merged. Nothing in the editor calls
+ * it. The fallbacks are defensive code whose only live caller is a test.
+ *
+ * What these pairs *do* catch is the half that reaches users: a property wired to the
+ * wrong option, or to a constant. The override values are unique, so two crossed
+ * properties fail as well.
  */
 const WEATHER_FALLBACKS = [
   ['icon_size', '--calendar-card-weather-date-icon-size', '14px', '31px', 'date'],

--- a/tests/event-time-zone.dst.test.ts
+++ b/tests/event-time-zone.dst.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FROZEN_NOW } from './fixtures';
+import { DEFAULT_CONFIG } from '../src/config/config';
+import type * as Types from '../src/config/types';
+import { formatEventTime, formatTime } from '../src/utils/format';
+
+/**
+ * Event times under a real time zone.
+ *
+ * The `unit` project pins `TZ: 'UTC'`, which is right for everything that formats a
+ * date and is also why this file has to exist separately. Under UTC a local clock
+ * reading and a UTC one are the *same number*, so every assertion about the time on an
+ * event passes whether the code reads `getHours()` or `getUTCHours()` — and the whole
+ * suite agrees with either.
+ *
+ * That blind spot was measured rather than assumed. Rewriting `formatTime` to read
+ * `getUTCHours()`/`getUTCMinutes()`, and rewriting `formatEventTime`'s single-day versus
+ * multi-day test to compare UTC calendar days, each left the whole suite green. Both
+ * would misprint the time on every timed event for every user outside UTC, which is most
+ * of them. With this file present the first fails 5 assertions in each of the three
+ * zones and the second fails 1 in Berlin, 2 in Sydney and 1 in New York.
+ *
+ * Unlike the week-number file next door this pins no DST *transition* — it pins the
+ * offset itself, which is the larger of the two exposures because it applies on every
+ * day of the year rather than around two of them. That also means no zone here is the
+ * only one able to see a given failure, which is the honest position: all three catch
+ * both mutations above, and any non-UTC zone would. What the set buys is that the
+ * fixture is read at both offset signs. At `23:30Z` Berlin and Sydney sit ahead of UTC,
+ * so their local date has already rolled over to the 18th while the UTC date is still
+ * the 17th; New York sits behind, so it reads the 17th like UTC does but at a different
+ * hour. An implementation correct for one sign and wrong for the other cannot pass all
+ * three.
+ *
+ * The oracle is deliberately `Intl.DateTimeFormat`, not `Date.prototype.getHours`. The
+ * code under test is built from the `Date` getters, so deriving the expectation from
+ * those same getters would restate the implementation instead of checking it.
+ */
+
+const ZONE = process.env.TZ ?? 'UTC';
+
+/** The wall clock in the runner's zone, derived independently of the `Date` getters. */
+function wallClock(date: Date): { day: string; time: string } {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+
+  const get = (type: string) => parts.find((part) => part.type === type)?.value ?? '';
+
+  return {
+    day: `${get('year')}-${get('month')}-${get('day')}`,
+    // Intl always pads the hour; the card pads only under `time_two_digit_hours`,
+    // which is off by default. Strip it here so the two spell the same clock.
+    time: `${Number(get('hour'))}:${get('minute')}`,
+  };
+}
+
+/** The same instant read as UTC, i.e. what a zone-blind implementation would print. */
+function utcClock(date: Date): { day: string; time: string } {
+  const iso = date.toISOString();
+
+  return {
+    day: iso.slice(0, 10),
+    time: `${Number(iso.slice(11, 13))}:${iso.slice(14, 16)}`,
+  };
+}
+
+function timedEvent(start: Date, end: Date): Types.CalendarEventData {
+  return {
+    start: { dateTime: start.toISOString() },
+    end: { dateTime: end.toISOString() },
+    summary: 'Rehearsal',
+    _entityId: 'calendar.personal',
+  };
+}
+
+const config = { ...DEFAULT_CONFIG, time_24h: true } as unknown as Types.Config;
+
+describe('event times follow the local zone, not UTC', () => {
+  // `formatEventTime` compares the event against today, so an unfrozen clock decides
+  // which multi-day wording it reaches and the assertions below would drift by date.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Guard. Without it this file would still pass under UTC while proving nothing,
+  // which is the exact failure it was written to close.
+  it('runs under a zone that observes DST', () => {
+    expect(new Date(2026, 0, 15).getTimezoneOffset()).not.toBe(
+      new Date(2026, 6, 15).getTimezoneOffset(),
+    );
+  });
+
+  describe('formatTime', () => {
+    // 23:30 UTC: behind UTC (New York) this is still the same UTC day, ahead of it
+    // (Berlin, Sydney) the local day has already rolled over.
+    const instant = new Date('2026-06-17T23:30:00.000Z');
+
+    it('reads a different clock than UTC, so the assertions below are not vacuous', () => {
+      expect(wallClock(instant).time).not.toBe(utcClock(instant).time);
+    });
+
+    it('prints the local wall clock', () => {
+      expect(formatTime(instant, true)).toBe(wallClock(instant).time);
+    });
+
+    it('does not print the UTC clock', () => {
+      expect(formatTime(instant, true)).not.toBe(utcClock(instant).time);
+    });
+
+    it('prints the local wall clock in 12-hour form too', () => {
+      const { time } = wallClock(instant);
+      const [hour, minute] = time.split(':').map(Number);
+      const suffix = hour >= 12 ? 'PM' : 'AM';
+      const twelve = hour % 12 || 12;
+
+      expect(formatTime(instant, false)).toBe(
+        `${twelve}:${String(minute).padStart(2, '0')} ${suffix}`,
+      );
+    });
+  });
+
+  describe('formatEventTime', () => {
+    /*
+     * Built from local components on purpose. 23:30 to 00:30 *local* crosses local
+     * midnight in every zone, while both instants land on one UTC date in all three —
+     * so local and UTC disagree about whether this event spans two days, and they
+     * disagree in the same direction everywhere. Comparing UTC days would take the
+     * single-day branch and print a bare start time instead of naming the end day.
+     */
+    const localStart = new Date(2026, 5, 17, 23, 30);
+    const localEnd = new Date(2026, 5, 18, 0, 30);
+
+    it('straddles local midnight while staying inside one UTC day', () => {
+      expect(wallClock(localStart).day).not.toBe(wallClock(localEnd).day);
+      expect(utcClock(localStart).day).toBe(utcClock(localEnd).day);
+    });
+
+    it('treats an event across local midnight as spanning two days', () => {
+      const formatted = formatEventTime(timedEvent(localStart, localEnd), config, 'en');
+
+      // `until` is the multi-day marker and the single-day branch cannot emit it:
+      // that branch produces a bare `start - end` and nothing else. Comparing UTC days
+      // would take it and print `23:30 - 0:30`.
+      expect(formatted).toContain('until');
+      expect(formatted).toContain(wallClock(localStart).time);
+      expect(formatted).not.toBe(`${wallClock(localStart).time} - ${wallClock(localEnd).time}`);
+    });
+
+    it('treats an event inside one local day as a single day', () => {
+      const start = new Date(2026, 5, 17, 9, 0);
+      const end = new Date(2026, 5, 17, 10, 0);
+      const formatted = formatEventTime(timedEvent(start, end), config, 'en');
+
+      expect(formatted).toBe(`${wallClock(start).time} - ${wallClock(end).time}`);
+    });
+
+    it('prints an all-day event without a clock in any zone', () => {
+      const allDay: Types.CalendarEventData = {
+        start: { date: '2026-06-17' },
+        end: { date: '2026-06-18' },
+        summary: 'Public holiday',
+        _entityId: 'calendar.personal',
+      };
+
+      expect(formatEventTime(allDay, config, 'en')).toBe('All day');
+    });
+  });
+});

--- a/tests/weather-condition-language.test.ts
+++ b/tests/weather-condition-language.test.ts
@@ -415,6 +415,49 @@ describe('weather conditions follow the card language', () => {
       expect([...knownConditions()].sort()).toEqual(Object.keys(CONDITION_ICON_MAP).sort());
     });
 
+    /**
+     * The reconciliation above is over *keys*, so it says nothing about which icon each
+     * condition draws — and nothing else did either. Rewriting `hail` to
+     * `mdi:weather-hurricane`, `fog` to `mdi:weather-tornado` and `pouring` to
+     * `mdi:weather-snowy` each left the whole suite green: ten of the fifteen values
+     * appeared in no assertion anywhere, and a wrong one is silent by nature, because a
+     * plausible weather glyph in a 14px badge does not read as a defect.
+     *
+     * Pinned whole rather than sampled, so an entry that changes value, an entry that
+     * disappears and an entry nobody expected all fail here — the three directions a
+     * loop over the table's own keys cannot see.
+     */
+    it('draws each condition with its own icon', () => {
+      expect({ ...CONDITION_ICON_MAP }).toEqual({
+        'clear-night': 'mdi:weather-night',
+        cloudy: 'mdi:weather-cloudy',
+        fog: 'mdi:weather-fog',
+        hail: 'mdi:weather-hail',
+        lightning: 'mdi:weather-lightning',
+        'lightning-rainy': 'mdi:weather-lightning-rainy',
+        partlycloudy: 'mdi:weather-partly-cloudy',
+        pouring: 'mdi:weather-pouring',
+        rainy: 'mdi:weather-rainy',
+        snowy: 'mdi:weather-snowy',
+        'snowy-rainy': 'mdi:weather-snowy-rainy',
+        sunny: 'mdi:weather-sunny',
+        windy: 'mdi:weather-windy',
+        'windy-variant': 'mdi:weather-windy-variant',
+        exceptional: 'mdi:weather-cloudy-alert',
+      });
+    });
+
+    /**
+     * The fallback for a condition the map does not carry. It shares its icon with
+     * `exceptional`, so asserting the map alone cannot tell the two apart, and reaching
+     * the real fallback means going through `getWeatherIcon`, which is not exported —
+     * `weather-night-icons.test.ts` drives it through the subscription path instead.
+     * What is pinned here is only that the map has no entry to hit.
+     */
+    it('has no entry for a condition Home Assistant does not define', () => {
+      expect(CONDITION_ICON_MAP['not-a-condition']).toBeUndefined();
+    });
+
     it('is the fifteen Home Assistant defines', () => {
       // Verified against a live instance (2026.8.1): `frontend/get_translations` returns
       // exactly these for every language, English-filled where untranslated.


### PR DESCRIPTION
Round 5 of the v4.1 pre-release audit. Scope was the rendering path and the formatting utilities — `styles.ts`, `leaves.ts`, `render.ts`, `column.ts`, `format.ts`, `weather.ts`, `weather-i18n.ts`, about 4,100 lines.

**Headline: the scope is in good shape. Two coverage holes, both measured and both closed here; one behavior question filed as #576; no shipped defect found.** The bundles are byte-identical to `dev` (`sha256 a780a914…` / `e53a59ce…`) — the only `src/` edit is a comment.

## What is in the diff

**1. `tests/event-time-zone.dst.test.ts` — the offset blind spot.**

The `unit` project pins `TZ=UTC`, where a local clock reading and a UTC one are the *same number* on every day of the year. Everything the DST projects existed for was about *transitions*, which touch two days a year. The plain offset applies always, and it was uncovered: `formatTime` — which prints the time on every timed event — had no `.dst.test.ts` at all.

Measured on the tip, each left the **whole suite green**:

| mutation | before | after |
| --- | --- | --- |
| `formatTime` reads `getUTCHours()`/`getUTCMinutes()` | survived | 5 failures per zone |
| `formatEventTime` compares UTC calendar days, not local | survived | 1 Berlin / 2 Sydney / 1 New York |

Both would misprint the time for every user outside UTC. The oracle is `Intl.DateTimeFormat`, not `Date.prototype.getHours` — the code under test is built from those getters, so deriving the expectation from them would restate the implementation. The January/July offset guard is there so the file fails loudly rather than silently proving nothing if it is ever run under UTC.

The file states plainly that **no zone is uniquely required here** — all three catch both mutations and any non-UTC zone would. That is weaker than the week-number file's claim and it is the one I could actually measure; I planted each mutation in all three zones rather than asserting uniqueness.

**2. `CONDITION_ICON_MAP` pinned by value.**

The existing reconciliation against `knownConditions()` covers keys in both directions but says nothing about which icon each condition draws. Ten of the fifteen values appeared in no assertion anywhere — rewriting `hail`, `fog` and `pouring` to other glyphs each left the suite green. Now pinned whole, so a changed value, a dropped entry and an unexplained new one all fail (verified: 1, 2 and 2 failures respectively).

**3. Two comment corrections, no code change.**

`custom-property-mapping.test.ts` claimed its `WEATHER_FALLBACKS` pairs catch "a mapping that has lost its default". They do not: `buildConfig` deep-merges `DEFAULT_CONFIG`, which already carries `weather.date.icon_size: '14px'`, so the assertion reads the merged default rather than the `|| '14px'` fallback beside it. Changing the fallback to `'99px'`, and dropping it entirely behind a cast, each passed `tsc` and all 2,984 tests. Not worth plugging — `generateCustomPropertiesObject` has exactly one production caller (`getCustomStyles`, always post-`setConfig`), so the fallback is unreachable in production. The `styles.ts` comment justifying it by "the editor's own preview objects" is also wrong; nothing in the editor calls that function. Both comments now say what is actually true.

**4. `AGENTS.md`** records the offset finding, and corrects one falsifier whose stated outcome no longer holds — see below.

## The `prettier-ignore` falsifier no longer answers the same way

`AGENTS.md` said that if you wonder whether one of the three directives in `leaves.ts` is still needed, "it is". Run per site with the format step, that is now true of two:

| site | remove + `npm run format` + `npm test` |
| --- | --- |
| day-header weather badge | 6 tests fail |
| event weather badge | 4 tests fail |
| folded time/countdown spans | **suite stays green** |

The third is not dead. Prettier *does* reformat it, but as `<span class="time-text"\n  >` — breaking inside the tag, which is the `</span\n><span` asymmetry the document already describes. No text node appears, so no snapshot moves. It should stay; the note now says why rather than asserting an outcome that does not reproduce.

## Nulls, with their denominators

**Length units — clean, 0 losses in 1,635 assertions.** A self-calibrating probe: for each option it first found which rendered declarations actually respond to it (by diffing a `137px` render against a `911px` one), then checked those survive `em` / `rem` / `%` / `calc()` / `var()`. 31 options × 5 forms across both views, 327 sensitive declarations, 0 options where the probe was blind. Two controls prove it can report a loss: restoring the pre-v4 `parseFloat`-and-append-`px` `scaleLength` reported 40, and breaking the column separator's gutter offset reported 435 including the column path specifically.

The lint rule's blind spot is real but owned elsewhere. `no-restricted-syntax` catches `parseFloat`/`parseInt` and their `Number.` forms, not `Number(x)` or unary `+x`. Planting a `Number()`-based unit-discarding read in `render.ts`: `lint` and `tsc` both pass, and `spacing-units.test.ts` fails 3 assertions. That surface has a gate; it just is not the linter.

`src/utils/` coerces no CSS length at all — every numeric operation in `format.ts` and `weather.ts` is on a temperature, UV index, hour or day count.

**Mutation sweep — 93 + 12 mutations, 82 caught.** Unmutated control 0 failed / 2,955 passed; no-op mutation SURVIVED, so the harness can report survival; failure counts differ per mutation, so it is detecting rather than measuring itself. Verdicts came from parsing vitest's stdout, never from exit codes.

Every survivor was chased to a cause, and most were equivalent mutants rather than gaps:

- **Removing the exact-hour lookup in `findForecastForEvent` survives, and that is correct** — the closest-hour scan returns the identical entry at diff 0, so it is a pure fast path. Removing the closest-hour fallback alone is caught (5 failures, matching what `AGENTS.md` records); genuinely removing both is caught (29). The separation documented there holds. My first "both paths" mutation only removed the fast path despite its name — caught by reading what it did to the source rather than trusting the label.
- **Dropping the malformed-pattern guard in `formatLocation` survives because `'…'.replace(null, '')` is a no-op** — JS coerces `null` to the literal string `"null"`, which is not present. The mutation never reached the built-in country list, so it proves nothing about the documented behavior.
- **`endsWith` → `includes` survives because the fixture cannot distinguish them** — `'Hauptstrasse 1, Berlin, Germany'` yields exactly one hit either way, across all 18 country names.
- **Dropping the base-language fallback in `getFirstDayForLocale` survives because nothing reaches it** — 0 of the 64 Home Assistant languages need it; every one is either a full-tag entry or a base entry. Defensive branch, not a gap. I would have filed this as a finding without checking.
- **`stripHtmlTags` losing its regex survives because happy-dom does the regex's job** — it parses markup assigned to `textarea.innerHTML`, which a real browser does not (RCDATA, per the parsing spec — I did not run a browser to confirm). Of 12 inputs, 10 are identical with and without the regex. The two that differ are a genuine behavior question, filed as #576 rather than decided here, because pinning the current behavior would enshrine `5 < 10 and 20 > 3` rendering as `5  3`.

**Not found:** any shipped defect in scope. Countdown arithmetic is DST-robust (dayjs rounds day counts, and a ±1h drift never crosses a `Math.round` boundary for whole-day spans). The weather hourly-key collision on a fall-back day is a one-hour-a-year overwrite between near-identical forecasts and unavoidable without storing offsets.

## Gates

All nine green on Node 25 **and** under the `.nvmrc` pin (Node v22.23.2, the newest 22.x, which is what `setup-node` resolves — the CLDR-sensitive locale suite and the zlib-sensitive bundle gate both pass there). 146 files / 2,984 tests. No scratch or probe files left; `git diff --name-only origin/dev...HEAD | grep '^docs/development/'` is empty.

No `RELEASE_NOTES.md` entry: nothing user-visible changed.