### PR TITLE
chore(release): bump the version to 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calendar-card-pro",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calendar-card-pro",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@mdi/js": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar-card-pro",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Custom Home Assistant calendar card",
   "main": "dist/calendar-card-pro.js",
   "scripts": {


### PR DESCRIPTION
Prepares the v4.1.0 release. **No PR into `main` yet**, as requested.

## What changed

Two files, three lines: `package.json` and both version fields in `package-lock.json`.

Nothing else needed editing. `package.json` is the single source of truth, and rollup substitutes it into the bundle header and `constants.ts` via the `@version vPLACEHOLDER` / `CURRENT: 'vPLACEHOLDER'` replacements — so no source file names a version by hand.

The lockfile is **regenerated** with `npx npm@10.9.2 install --package-lock-only`, not hand-edited. `npm ci` validates dependencies but never the root version and exits 0 on a mismatch, which is how 8 of the 10 releases from v3.0.1 through v3.4.0 shipped with a stale lock version.

## Verified, not assumed

- **CI's own version gate, replicated locally** — `package.json`, `package-lock.json.version` and `.packages[""].version` all read `4.1.0`; `.nvmrc` and `.node-version` agree.
- **The lockfile installs under the deploy's npm, not just mine** — `npm@10.9.2 ci --dry-run` on a copy exits 0. This is the check added after a lockfile passed locally and broke the Cloudflare docs deploy.
- **Both production bundles stamp the version** — `4.1.0` exactly once in each, zero `4.0.0`, zero unsubstituted `PLACEHOLDER`. Checked after a real `npm run build`; my first grep for this returned nothing because the bundle is minified and my pattern was wrong, not because the substitution failed.
- **A dry run first.** I bumped and regenerated on a throwaway branch before doing it for real, to confirm npm rewrites exactly the two version fields and no dependencies.

## Gates

All nine pass: `tsc --noEmit`, `lint`, `check:format`, `test` (3075), `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`.

`check:docs` is the one that matters here — it reconciles `package.json` against the three release surfaces, and all three already name this version from earlier work: the `# Calendar Card Pro v4.1.0` heading in `RELEASE_NOTES.md`, the `## Latest Release: v4.1` entry in `whats-new.md`, and `v4.1` in the README's What's New. So the bump and the docs are consistent in the same commit rather than one release behind.