### PR TITLE
test(editor): reconcile per-calendar dropdown options against the strings naming them

### DIFF
--- a/tests/editor-derived-field-mapping.test.ts
+++ b/tests/editor-derived-field-mapping.test.ts
@@ -24,6 +24,7 @@ import * as Types from '../src/config/types';
 import { type HaFormSchema, isGroupSchema } from '../src/rendering/editor/ha-form';
 import { walkSchema } from '../src/rendering/editor/panels';
 import { buildEntitySchema, entityConfigKeys } from '../src/rendering/editor/schemas/entity';
+import { EDITOR_STRINGS } from '../src/rendering/editor/strings';
 
 /**
  * The members of `EntityConfig`, read from the source.
@@ -59,6 +60,61 @@ function entityFieldNames(): string[] {
   }
 
   return names;
+}
+
+/**
+ * Every value the per-calendar dropdowns offer, by control.
+ *
+ * Unioned across both views, because a control the column view alone renders is still a
+ * control, and a union can only widen what the reconciliation below has to account for.
+ *
+ * @returns Option values per control name, sorted
+ */
+function offeredOptions(): Map<string, string[]> {
+  const found = new Map<string, Set<string>>();
+
+  for (const view of ['list', 'column'] as const) {
+    const config = { ...DEFAULT_CONFIG, view, entities: ['calendar.a'] } as Types.Config;
+
+    for (const { node } of walkSchema(buildEntitySchema({ view, config, language: 'en' }))) {
+      if (isGroupSchema(node) || !('selector' in node)) continue;
+      if (!('select' in node.selector)) continue;
+
+      const options = node.selector.select?.options;
+      if (!options) continue;
+
+      const values = found.get(node.name) ?? new Set<string>();
+      for (const option of options) values.add(typeof option === 'string' ? option : option.value);
+      found.set(node.name, values);
+    }
+  }
+
+  return new Map([...found].map(([name, values]) => [name, [...values].sort()]));
+}
+
+/**
+ * Every option the per-calendar strings name, by control.
+ *
+ * The `entity.` prefix is what makes this the right second surface and not a coincidence:
+ * a per-calendar dropdown resolves its labels through `entity.<name>.option.<value>.label`,
+ * where the card-wide controls use an unprefixed key of their own. So the two sets are
+ * exactly the per-calendar options, and reconciling them needs no list of exceptions.
+ *
+ * @returns Option values per control name, sorted
+ */
+function namedOptions(): Map<string, string[]> {
+  const found = new Map<string, Set<string>>();
+
+  for (const key of Object.keys(EDITOR_STRINGS)) {
+    const match = /^entity\.([a-z0-9_]+)\.option\.([a-z0-9_]+)\.label$/.exec(key);
+    if (!match) continue;
+
+    const values = found.get(match[1]) ?? new Set<string>();
+    values.add(match[2]);
+    found.set(match[1], values);
+  }
+
+  return new Map([...found].map(([name, values]) => [name, [...values].sort()]));
 }
 
 describe('per-calendar derived controls are mapped to the keys they decide', () => {
@@ -102,6 +158,57 @@ describe('per-calendar derived controls are mapped to the keys they decide', () 
           true,
         );
       }
+    }
+  });
+});
+
+/**
+ * The same lesson one level down, on the options a per-calendar dropdown offers.
+ *
+ * 🚨 An option list is a table, and every assertion in the suite reads it by walking it —
+ * which is the failure this repository has already paid for three times. Remove an entry
+ * and the walk runs one fewer time; nothing counts, so nothing notices. Measured rather
+ * than argued: dropping `person` from `LABEL_IMAGE_SOURCES` takes a person's picture out
+ * of the editor's Image Source dropdown altogether, leaving the feature reachable only by
+ * writing YAML by hand — and **all nine gates stay green**, this suite among them, with
+ * no test failing anywhere. Every existing assertion covers whether the control is
+ * *there* and which picker it renders, both of which survive, because the mode is derived
+ * from the stored label rather than read back off the list.
+ *
+ * Reconciled against the strings that name the options rather than against a second copy
+ * of the list, for the reason the block above gives: a second list is one more thing to
+ * forget, and forgetting is the bug. This one fails on a dropdown nobody has written yet.
+ */
+describe('per-calendar dropdowns and the strings naming their options agree', () => {
+  it('finds both surfaces, so an empty walk cannot agree with an empty string table', () => {
+    expect(offeredOptions().size, 'the schema walk found no dropdowns').toBeGreaterThan(5);
+    expect(namedOptions().size, 'no per-calendar option strings were found').toBeGreaterThan(5);
+  });
+
+  /**
+   * A string naming an option no dropdown offers. That is what a dropped table entry looks
+   * like from here, and it is the direction with teeth: the option simply stops existing in
+   * the editor, while the control, its helper text and its translations all stay put.
+   */
+  it('offers every option its strings name', () => {
+    const offered = offeredOptions();
+
+    for (const [name, values] of namedOptions()) {
+      expect(offered.get(name) ?? [], `${name} names options it does not offer`).toEqual(values);
+    }
+  });
+
+  /**
+   * The other direction. An option with no string of its own still renders — `lookup` falls
+   * back to `humanize` — so it appears in the dropdown as an untranslated, capitalized
+   * version of its own value, in all eleven editor languages. That reads as a translation
+   * gap rather than as the missing string it is.
+   */
+  it('names every option it offers', () => {
+    const named = namedOptions();
+
+    for (const [name, values] of offeredOptions()) {
+      expect(named.get(name) ?? [], `${name} offers options nothing names`).toEqual(values);
     }
   });
 });


### PR DESCRIPTION
Final pre-release audit of the v4.1.0 delta, scoped to the code that landed after round 5 started and that no audit had seen: `f9c7609..30860e8`, 373 insertions across 9 source files, from #575 (person picture, unreviewed by any human), #579 (the #576 fix) and #577 (the DST time-zone test).

## Verdict

**No live defect found.** One real test gap in the new code, fixed here. Two design questions filed rather than settled: #581 and #582.

The scope came back clean on behavior, and the denominators are below.

## What is in this PR

One test file, 107 insertions, **no shipped code changes**.

`LABEL_IMAGE_SOURCES` — the `['custom', 'person']` table backing #575's new Image Source dropdown — can lose an entry with **all nine gates green**, measured rather than assumed. Dropping `person` takes a person's picture out of the editor entirely, leaving the feature reachable only by hand-writing YAML. The existing tests assert that the control is present and which picker it renders; both survive, because the mode derives from the stored label rather than from the list. The two released siblings, `LABEL_ICON_SOURCES` and `ACCENT_COLOR_MODES`, are removable the same way.

This is the failure class `AGENTS.md` records three times over, so the fix takes the form that file prescribes: a **reconciliation against a second surface**, not a second copy of the list. The per-calendar option strings (`entity.<name>.option.<value>.label`) are exactly that surface — card-wide controls resolve through an unprefixed key of their own, so the two sets are precisely the per-calendar options and no exception list is needed. It covers **12 dropdowns and 36 option values** today and fails on a dropdown nobody has written yet.

Falsified in both directions, with two controls that must pass:

| planted | result |
| --- | --- |
| drop `person` from `LABEL_IMAGE_SOURCES` | caught |
| drop `custom` from `LABEL_IMAGE_SOURCES` | caught |
| add an option no string names | caught |
| drop `home_assistant` from `LABEL_ICON_SOURCES` | caught |
| drop `home_assistant` from `ACCENT_COLOR_MODES` | caught |
| delete the `person` option string | caught |
| misspell the `person` option string key | caught |
| no-op comment edit | passes |
| reorder `LABEL_IMAGE_SOURCES` | passes — order is not this pin's business |

`tsc` caught a narrowing gap in the first draft that vitest alone would have shipped, which is the "run the gate that would actually catch it" rule earning its place. The falsifiers were re-run after that change rather than quoted.

## What was probed and came back clean

Every mutation below was verified as applied by printing its diff, run against an unmutated control reporting a real pass, and restored with `cp`. Counts are from vitest stdout.

**Person picture (#575) — 16 of 17 mutations caught, failure counts 1–14, all differing.** The `label`-not-`entityId` swap fails 10. Dropping the `getLabelType` person arm fails 7. Inverting `labelImageSourceOf` fails 13. The seed, the cross-mode label guard, the `entityConfigKeys` arm, the `toEntityFormData` projection, the person-picker domain filter, both `isPersonEntityId` anchors and the empty-string guard are each individually pinned.

**The `entitySchemaFor` positional-argument hole is closed.** The brief asked whether the other arguments share it. Dropping any of the four — `accentColorModeOf`, `labelIconSourceOf`, `showsLocation`, `labelImageSourceOf` — is caught. The one survivor was flipping the `imageSource` *default*, and mutating its siblings together shows `accentMode` and `showsLocation` survive the same way: production passes all six positionally, so the defaults are test-only. Consistent and pre-existing, not a new gap.

**The arm-ordering claim re-derives exactly.** `getLabelType`'s person arm and its extension arm overlap on exactly ten strings (`person.` plus each of nine extension alternatives, `jpe?g` yielding two), all answering `image`. Across all 50,653 three-character legal person ids, zero reach the slash/URL arm and zero reach the icon arm — structurally, since `[a-z0-9_]` admits no `/`, no scheme and no colon. Controls confirm each arm can return true.

**Seeding behaves as documented, checked against the real functions.** No person has a picture → falls back to the alphabetically first. No people at all, or `hass` absent → seeds nothing and the dropdown re-derives to `custom`, the stated honest outcome. That path stores a bare `label_type: image` with no `label` — and the same is true of `icon` and `text` on released code, so it is pre-existing, not something #575 introduced.

**`stripHtmlTags` (#579) is load-bearing and fully pinned.** The brief's own falsifier holds: deleting the regex fails 11 tests, so `tests/strip-html-tags.test.ts` pins the card and not happy-dom. Reverting to the released pattern fails 13, dropping the comment branch 3, dropping `[!?/]` 6, making it greedy 1. A 45-input differential in real headless Chromium found every realistic input — `<p>`, `<b>`, `<a href=…>`, `<br>`, comments, `<!DOCTYPE>`, `<?xml?>`, Outlook conditionals, `<o:p>`, `<st1:place>` — agreeing across old regex, new regex and the browser's own parser. The nine divergences are in #581.

**#577's DST file reproduces its own stated counts exactly.** Rewriting `formatTime` to `getUTCHours`/`getUTCMinutes` fails 15 (5 per zone × 3), and comparing `formatEventTime`'s day test in UTC fails 4 (1 Berlin, 2 Sydney, 1 New York). `unit` stays green in both, which is the point of the file.

**Claims made by comments in the delta, re-tested rather than read.** `styles.ts`'s new note — single production caller `getCustomStyles`, passing the post-`setConfig` config, editor never reaches it — holds. `label_type` is per-calendar only and `getEntitySetting` has no card-wide fallback, so `resolveEntityLabel` and `renderEventTitle` cannot disagree about it. `_matchedConfig` is `undefined` only for bare-string entries, which carry no `label`, so that window is closed. `.label-image` is sized `height: font-size; width: auto`, so a 512×512 person picture renders square at the reserved hanging-indent width. The column view shares the one label path through `presentation.ts`.

## Gates

All nine pass, locally on Node v25.8.0 **and** under the `.nvmrc` pin (v22.23.2, npm 11.11.0), with the same result: **148 files, 3078 tests**, up from 3075 on the base.

`git diff --name-only origin/dev...HEAD | grep '^docs/development/'` returns nothing. No probe files left behind. No release-notes entry, because nothing user-visible changed. Neither "What's New" surface touched, and the version is untouched at 4.1.0.

## Filed rather than fixed

- #581 — `stripHtmlTags` leaves four shapes a browser's tokenizer would drop (`<!-->`, `<![CDATA[…]]>`, `<//p>`, `</ b >`), three of which v4.0.0 removed. Every one is implausible in a real description and one is deliberately pinned as prose, so this is a claim-versus-behavior question rather than a release blocker. Fixing it means re-widening what a `<` can swallow, which is the axis #576 was about.
- #582 — the same table-removal property on the card-wide dropdowns: 5 of 8 sampled lose an option silently, 3 are pinned. The reconciliation added here cannot be pointed at them, because their string keys use three different shapes and two controls deliberately offer a subset.

Both are out of the delta's scope and want deciding rather than patching before a release.