### PR TITLE
docs(format): say the markup regex approximates the tokenizer, not that it is one

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -289,10 +289,19 @@ export function resolveLocationIcon(location: string, configured?: string): stri
  * has no idea what a tag is. Any description pairing a `<` with a later `>` lost everything
  * between them, so `alert if temp < 5 and pressure > 3 END` rendered as `alert if temp 3
  * END` on a real card. Requiring the character after the opening `<` to be the one that
- * starts a tag is what separates prose from markup, and it is the same test the HTML
- * tokenizer applies: an ASCII letter opens a tag, `/` an end tag, `!` and `?` a markup
+ * starts a tag is what separates prose from markup, and it is the HTML tokenizer's own
+ * opening rule: an ASCII letter opens a tag, `/` an end tag, `!` and `?` a markup
  * declaration, and **anything else makes the `<` ordinary text**. A space, a digit or a
  * hyphen therefore no longer opens anything, which is every shape the issue reported.
+ *
+ * That is the tokenizer's rule for what *opens* markup, and it is not the whole tokenizer.
+ * A 45-input differential against headless Chromium (#581) agrees on every realistic
+ * description — tags, attributes, comments, `<!DOCTYPE>`, processing instructions, Outlook
+ * conditionals, `<o:p>`, `<st1:place>` — and diverges on four degenerate shapes a browser
+ * discards as bogus comments and this keeps: `<!-->`, `<![CDATA[…]]>`, `<//p>` and
+ * `</ b >`. The predecessor dropped all four, so three changed silently here; the fourth
+ * is `</ b >`, kept deliberately and pinned as prose. Say "approximates the tokenizer",
+ * not "is the tokenizer", when reasoning about the next edge case.
  *
  * 🚨 **The regex is the only thing removing tags in production, so it is not optional and
  * it cannot be narrowed casually.** The `<textarea>` round-trip below decodes entities and


### PR DESCRIPTION
Comment-only. Acts on the one recommendation the delta audit left open in #581, before the release PR.

## The claim

`stripHtmlTags`'s docblock said the opening-character test "is the same test the HTML tokenizer applies". That is true of the tokenizer's rule for what *opens* markup, and not of the tokenizer as a whole — and the gap is the kind a future session inherits as an established fact rather than re-checks.

## Verified here, not taken from the report

Both regexes, run directly:

| shape | v4.0.0 | v4.1.0 |
| --- | --- | --- |
| `<!-->` | dropped | kept |
| `<![CDATA[x]]>` | dropped | kept |
| `<//p>` | dropped | kept |
| `</ b >` | dropped | kept |

A browser discards all four as bogus comments. So three changed silently in #579, and the fourth is `</ b >`, kept deliberately and pinned as prose by `tests/strip-html-tags.test.ts`. The 45-input Chromium differential behind this is in #581 and agrees on every realistic description.

## What is left alone

The last paragraph's claim that `if a<b and c>d` is flattened "the way a browser does" is **correct** — `b` is a letter, so it opens a tag for the tokenizer too. Checked rather than assumed, and untouched.

## Ships nothing

The production bundle is **byte-identical** to `dev` — `sha256 21577dcca1f6b76e…` before and after — which is the check that proves this is comment-only. esbuild strips the docblock, so the correction costs a reader everything and a user nothing.

All nine gates pass: `tsc`, `lint`, `check:format`, `test` (3078), `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`. No release-notes entry — nothing user-visible changed. Version untouched at 4.1.0. #581 stays open for the behavior question itself.