### PR TITLE
feat(check-i18n): reconcile every dropdown's options against the strings naming them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,35 @@ entry and an unexplained new one — fail. When sweeping for this, blank one lin
 run `npx tsc --noEmit` first as a cheap kill, and restore with `cp` from a backup, never
 `git checkout --`.
 
+🚨 **The same trap one level down, on the options a dropdown offers — and this family is
+now enforced by `check:i18n` rather than by the suite.** Measured across every card-wide
+option table: **9 of 15 lose an entry with the whole suite green**, `time_format` losing
+`12` and `start_date_mode` losing `offset` among them, which takes a documented setting out
+of the editor while its control, its helper text and its translations all stay put. Only 6
+were pinned, and one of those (`view`) only because `VIEWS` drives the renderer as well.
+
+`checkEditorOptions` closes it in both directions, and the interesting part is how it gets
+the key. It cannot be modelled: **four** shapes are live — the node's own name (`view`), its
+group-qualified name (`column.min_days_fallback`), the per-calendar prefix
+(`entity.show_time`), and a key that is not the node's name at all, because
+`unionPickerField` labels the picker for a union option through the synthetic mode field
+standing in for it, so a node _named_ `show_week_numbers` resolves `week_number_mode.option.*`.
+The built schema has thrown that key away. So the schema is built under a sentinel language
+that echoes every key back instead of resolving it, and each option's `label` is then
+literally the key the editor asked for. Reconciling on **keys** rather than on per-control
+sets of values is also what removes the need for an exception list: card-wide `event_type`
+deliberately offers no `inherit` where the per-calendar one does, and the two never meet
+because they resolve through `event_type.option.*` and `entity.event_type.option.*`.
+
+Two things to know before touching it. The sentinel is registered in
+`EDITOR_LANGUAGE_STRINGS` and removed in a `finally` — insurance, not a live guard, because
+`checkEditorTranslations` reconciles the entries it parses out of the index module's
+_source_ rather than the runtime object's keys, so a leaked entry is invisible to it, at 0
+errors when planted. And an option whose label is **not** an option-label key is an error
+rather than a skip — a dropdown labelled outside the string table is untranslatable, and
+treating it as out of scope is how a gate silently stops covering the thing it was written
+for.
+
 ### The suite runs as four projects, and the split is load-bearing
 
 `vitest.config.mjs` defines a `projects` array, so `npm test` runs the same files under
@@ -1054,6 +1083,14 @@ entry in the same edit.
 that one, and runs in CI. Run it before you claim a language is done — but note it
 verifies **wiring**, not translation quality, and it cannot tell you whether
 `pēc 2 dienām` is correct Latvian.
+
+**It also reconciles every dropdown option against the string that names it**, in both
+directions and across all 27 option tables, so adding a `select` whose values no string
+covers fails the gate rather than shipping a `humanize`d label in eleven languages, and
+dropping a value leaves its string orphaned and fails it too. See the table-walk trap under
+_Build commands_ for why that is a reconciliation and not a list. The practical consequence
+when adding a dropdown: write the `<key>.option.<value>.label` strings in `strings.ts` in
+the same edit, and let `check:i18n` tell you the exact keys it asked for.
 
 **The editor's termbase lives in [`scripts/editor-glossary.mjs`](./scripts/editor-glossary.mjs).**
 It records, per language, the decided form of each UI term and the forms rejected for it,

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -244,6 +244,126 @@ async function readEditorSchemaKeys() {
 }
 
 /**
+ * The language the option scan resolves under. Never a real language.
+ *
+ * Registering it mutates a module the rest of this file shares, so it is removed again in
+ * a `finally`. That is insurance rather than a live guard, and the difference is worth
+ * stating because the obvious justification is false: `checkEditorTranslations` reconciles
+ * the `EDITOR_LANGUAGE_STRINGS` entries it parses out of the **index module's source**, not
+ * the keys of the runtime object, so a leaked entry is invisible to it — planted and
+ * measured at 0 errors. Nothing today reads that object's key set, and nothing today
+ * resolves a string after this scan that could see the extra language. Both of those are
+ * facts about the current file rather than guarantees, which is exactly why the scan puts
+ * the module back the way it found it.
+ */
+const OPTION_KEY_ECHO_LANGUAGE = 'zz-option-key-echo';
+
+/** Escapes a literal for use inside a regular expression. */
+function escapeForRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Every option-label key the editor's dropdowns actually look up.
+ *
+ * 🚨 An option list is a table, and the assertions covering these dropdowns read them by
+ * walking them — the failure this repository has already paid for four times. Remove an
+ * entry and the walk runs one fewer time, so nothing counts and nothing notices. Measured
+ * rather than argued: of the 15 card-wide option tables, **9 lose an entry with the whole
+ * suite green**, among them `time_format` losing `12` and `start_date_mode` losing
+ * `offset` — a documented setting gone from the editor while its control, its helper text
+ * and its translations all stay put.
+ *
+ * The key is **taken from the editor rather than modelled**, because modelling it does not
+ * work. Four different shapes are in use: `view.option.list.label` from the node's own
+ * name, `column.min_days_fallback.option.list.label` from its group-qualified name,
+ * `entity.show_time.option.inherit.label` from the per-calendar prefix, and — the one that
+ * defeats any rule written from the schema — `week_number_mode.option.iso.label` for a node
+ * *named* `show_week_numbers`, because `unionPickerField` labels the picker for a union
+ * option through the synthetic mode field standing in for it. The built schema has thrown
+ * that key away by the time anything can read it.
+ *
+ * So the schema is built under a language that echoes every key back instead of resolving
+ * it. Each option's `label` is then literally the key the editor asked for, derived by the
+ * editor's own code. That also settles the subset problem a per-control comparison runs
+ * into — card-wide `event_type` deliberately offers no `inherit`, where the per-calendar
+ * one does — because the two resolve through *different* keys, `event_type.option.*` and
+ * `entity.event_type.option.*`, so there is nothing to except.
+ *
+ * @returns The keys asked for, each with the nodes that asked, and any option whose label
+ *   did not come from the string table at all
+ */
+async function readEditorOptionKeys() {
+  const editor = await loadEditor();
+  const { PANELS, walkSchema, panelSubforms, chassisSubforms, EDITOR_LANGUAGE_STRINGS } = editor;
+  const { DEFAULT_CONFIG, VIEWS } = editor;
+
+  assertFound(PANELS, 'any registered editor panels', PANELS_TS);
+
+  /** Option-label key -> the qualified node names that looked it up. */
+  const asked = new Map();
+  /**
+   * Options whose label is not an option-label key, so nothing can reconcile them.
+   *
+   * Keyed rather than listed, because every panel is built once per probe configuration
+   * and the same option would otherwise be reported dozens of times over.
+   */
+  const unresolved = new Map();
+
+  const collect = (schema, path) => {
+    for (const { node, path: nodePath } of walkSchema(schema, path)) {
+      if (!node.name || !('selector' in node) || !node.selector) continue;
+
+      const select = node.selector.select;
+      if (!select || !Array.isArray(select.options)) continue;
+
+      const where = [...nodePath, node.name].join('.');
+
+      for (const option of select.options) {
+        const value = typeof option === 'string' ? option : option.value;
+        const label = typeof option === 'string' ? '' : String(option.label ?? '');
+        const shape = new RegExp(`^.+\\.option\\.${escapeForRegExp(String(value))}\\.label$`);
+
+        if (!shape.test(label)) {
+          unresolved.set(`${where}\u0000${value}\u0000${label}`, {
+            where,
+            value: String(value),
+            label,
+          });
+          continue;
+        }
+
+        const nodes = asked.get(label) ?? new Set();
+        nodes.add(where);
+        asked.set(label, nodes);
+      }
+    }
+  };
+
+  EDITOR_LANGUAGE_STRINGS[OPTION_KEY_ECHO_LANGUAGE] = new Proxy(
+    {},
+    { get: (_target, key) => (typeof key === 'string' ? key : undefined) },
+  );
+
+  try {
+    for (const subform of chassisSubforms()) collect(subform.schema, subform.path);
+
+    for (const config of probeConfigs(DEFAULT_CONFIG, VIEWS)) {
+      for (const panel of PANELS) {
+        const ctx = { view: config.view, config, language: OPTION_KEY_ECHO_LANGUAGE };
+
+        collect(panel.build(ctx), []);
+        for (const subform of panelSubforms(panel, ctx)) collect(subform.schema, subform.path);
+      }
+    }
+  } finally {
+    delete EDITOR_LANGUAGE_STRINGS[OPTION_KEY_ECHO_LANGUAGE];
+  }
+
+  return { asked, unresolved };
+}
+
+/**
  * Configurations chosen to open every conditional branch in every panel.
  *
  * Defaults alone hide conditional fields, so booleans and view-derived modes are swept.
@@ -591,6 +711,64 @@ async function checkEditorStrings() {
   }
 
   return new Set(labels.keys()).size;
+}
+
+/**
+ * A dropdown offers exactly the options its strings name, and vice versa.
+ *
+ * Both directions matter and they fail differently. A key the editor asks for and no
+ * string defines renders `humanize`d — an untranslated, capitalized copy of the config
+ * value, in all eleven editor languages, which reads as a translation gap rather than as
+ * the missing string it is. A string nothing asks for is the far worse one: that is what a
+ * dropped table entry looks like from here, and the option has simply stopped existing in
+ * the editor while its control, its helper text and its translations all stay in place.
+ *
+ * Reconciled on the keys themselves rather than on per-control sets of values, which is
+ * what makes it need no exception list: two controls that share a *name* but not a key —
+ * card-wide `event_type` against per-calendar `entity.event_type` — never meet.
+ *
+ * @returns How many option-label keys the editor asked for
+ */
+async function checkEditorOptions() {
+  const { asked, unresolved } = await readEditorOptionKeys();
+  const { EDITOR_STRINGS } = await loadEditor();
+
+  // Neither surface may be empty, or an unwalked schema would agree with an unread table.
+  assertFound([...asked.keys()], 'any dropdown options in the editor panels', PANELS_TS);
+
+  const defined = Object.keys(EDITOR_STRINGS).filter((key) => /^.+\.option\..+\.label$/.test(key));
+  assertFound(defined, 'any option strings', STRINGS_TS);
+
+  for (const { where, value, label } of unresolved.values()) {
+    error(
+      'strings.ts',
+      `\`${where}\` labels its \`${value}\` option ${label === '' ? 'with no string at all' : `as \`${label}\``}, ` +
+        `which is not an option-label key — nothing can reconcile or translate it`,
+    );
+  }
+
+  for (const [key, nodes] of asked) {
+    if (!(key in EDITOR_STRINGS)) {
+      const value = key.slice(0, -'.label'.length).split('.option.').pop();
+      error(
+        'strings.ts',
+        `\`${key}\` has no string — ${[...nodes].sort().join(', ')} would offer it as ` +
+          `"${humanKey(value)}" in every language, including English`,
+      );
+    }
+  }
+
+  for (const key of defined) {
+    if (!asked.has(key)) {
+      error(
+        'strings.ts',
+        `\`${key}\` names an option no dropdown offers — the option is gone from the ` +
+          `editor while its string and every translation of it stay behind`,
+      );
+    }
+  }
+
+  return asked.size;
 }
 
 /**
@@ -1194,7 +1372,7 @@ function humanKey(key) {
 // Report
 // ---------------------------------------------------------------------------
 
-function report(languageCount, fieldCount) {
+function report(languageCount, fieldCount, optionCount) {
   const line = (kind, { where, msg }) => {
     if (IN_CI) console.log(`::${kind === 'error' ? 'error' : 'warning'}::${where}: ${msg}`);
     else console.log(`  ${kind === 'error' ? '✖' : '⚠'} ${where}: ${msg}`);
@@ -1220,7 +1398,8 @@ function report(languageCount, fieldCount) {
   }
 
   const summary =
-    `\n${languageCount} languages, ${fieldCount} editor fields — ` +
+    `\n${languageCount} languages, ${fieldCount} editor fields, ` +
+    `${optionCount} dropdown options — ` +
     `${errors.length} error(s), ${warnings.length} warning(s).`;
   console.log(summary);
 
@@ -1375,6 +1554,7 @@ async function main() {
   checkDayjsWiring(localize.entries, dayjsWiring);
 
   const fieldCount = await checkEditorStrings();
+  const optionCount = await checkEditorOptions();
   await checkEditorKeysUsedInCode();
   await checkEditorTranslations(languages);
   await checkEnGbDerivation();
@@ -1383,7 +1563,7 @@ async function main() {
   reportGlossaryReach(glossary, (await loadEditor()).EDITOR_STRINGS);
   await checkRunningTextWeekdayCase(languages);
 
-  process.exit(report(languages.size, fieldCount));
+  process.exit(report(languages.size, fieldCount, optionCount));
 }
 
 main();


### PR DESCRIPTION
Fixes #582.

An option list is a table, and the assertions covering these dropdowns read it by walking it — the failure `AGENTS.md` already records three times, and a fourth in #583. Remove an entry and the walk runs one fewer time; nothing counts it, so nothing notices.

## The denominator, re-measured

#582 sampled 8 card-wide option tables. The real number is **15**, and **9 of them lose an entry with the whole suite green**. All 8 of #582's samples reproduce exactly.

| card-wide option table | suite, on losing one option |
| --- | --- |
| `view` | pinned (14 failed) |
| `column.min_days_fallback` | pinned (1 failed) |
| `first_day_of_week` | pinned (1 failed) |
| `event_type` (card-wide) | pinned (1 failed) |
| `week_number_mode` | pinned (2 failed) |
| `weather` `position` | pinned (1 failed) |
| `height_mode` | **silent** |
| `start_date_mode` | **silent** |
| `language_mode` | **silent** |
| `time_format` | **silent** |
| `today_indicator_style` | **silent** |
| `date_vertical_alignment` | **silent** |
| `location_country_mode` | **silent** |
| `accent_color_mode` (card-wide) | **silent** |
| `event_icon_vertical_alignment` | **silent** |

The 7 tables #582 did not reach split 3 pinned and 4 silent. `view` is pinned only incidentally — `VIEWS` drives the renderer, so the 14 failures are about rendering rather than about the dropdown.

The sweep ran an unmutated control reporting **3096 passing, 0 failing**, plus a no-op that correctly survived, and the caught rows carry *differing* failure counts (14, 2, 1, 1, 1, 1) rather than one uniform verdict. An earlier run of the same sweep reported every row identically, including the control — `--reporter=basic` no longer exists in this vitest, so the harness was measuring itself. That is why the control now aborts the sweep unless it reports a real, non-trivial pass count.

## The fix

Option 2 of the three #582 offers. `check:i18n` already reconciles `strings.ts` against the fields the schemas reference, in both directions, by importing the schema modules — options are simply the family it did not cover. It now reports `81 dropdown options` beside the field count.

**The key is taken from the editor rather than modelled, because modelling it does not work.** Four shapes are live:

- `view.option.list.label` — the node's own name
- `column.min_days_fallback.option.list.label` — its group-qualified name
- `entity.show_time.option.inherit.label` — the per-calendar prefix
- `week_number_mode.option.iso.label` — for a node **named `show_week_numbers`**

That last one defeats any rule written from the schema: `unionPickerField` labels the picker for a union option through the synthetic mode field standing in for it, and the built schema has thrown the key away by the time anything can read it. It is also why the three union-picker nodes look like they have no option strings at all under a bare/qualified model — an artefact of the model, not a bug in the tree.

So the schema is built under a sentinel language that echoes every key back instead of resolving it. Each option's `label` is then literally the key the editor asked for, derived by the editor's own code.

**That also disposes of the subset problem #582 warns about, by construction rather than by exception.** Card-wide `event_type` deliberately offers no `inherit` where the per-calendar one does — but the two resolve through `event_type.option.*` and `entity.event_type.option.*` and never meet. Same for `accent_color_mode`. Reconciling on keys rather than on per-control sets of values needs no exception list, and covers a control nobody has written yet.

## Falsified in both directions

24 cases, **zero mismatches**. Every mutation was asserted to have actually changed the file before the run, and restored from a `cp` backup afterwards.

| case | before | after |
| --- | --- | --- |
| unmutated control | pass (81 options) | pass (81 options) |
| comment-only edit | pass | pass |
| pure reorder of one option list | pass | pass |
| drop an entry from any of the 15 card-wide tables | **silent** | caught, 15/15 |
| drop `person` from `LABEL_IMAGE_SOURCES` (per-calendar) | **silent** | caught |
| delete `entity.label_image_source.option.person.label` | **silent** | caught |
| delete `time_format.option.12.label` | caught¹ | caught |
| add an option value no string names | **silent** | caught |
| misspell an option string key | **silent** | caught, both directions |
| label an option outside the string table | **silent** | caught |

¹ The one honest exception, measured rather than assumed: deleting an English option string that nine translation files still carry was already caught — by the translation reachability check, not by anything about options. The direction genuinely closed is the option string no translation happens to hold, which is exactly the `entity.label_image_source.option.person.label` case #582 confirmed invisible.

The sentinel is removed in a `finally`. **The obvious justification for that is false, and the docblock says so**: `checkEditorTranslations` reconciles the entries it parses out of the index module's *source*, not the runtime object's keys, so a leaked entry is invisible to it — planted and measured at 0 errors. It restores the module it borrowed, and nothing more. I found that by running the falsifier for my own comment.

## Scope

Gate change only, no user-visible fix, so no release-notes entry and no Related Issues line — and no missing option turned up along the way (the tree reconciles at 81 = 81 in both directions). No `src/` change, so the bundle cannot move; `check:bundle` reports the same 199741 B / 351663 B.

The per-calendar reconciliation from #583 is left in place. It is now partly redundant with this one, but it pins per-control unions in vitest where feedback is faster, and removing a working gate for tidiness is how the next one gets lost.

## Gates

All nine pass, under Node 25 and under the `.nvmrc` pin (v22.23.2): `tsc --noEmit`, `lint`, `check:format`, `test` (148 files, 3096 tests), `check:i18n`, `check:docs`, `docs:build`, `build`, `check:bundle`.