### PR TITLE
docs(release): track #581 and #582 for closure at the v4.1.0 release

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -175,6 +175,8 @@ Two things to know if you use it. Text is sized by `today_indicator_size`, which
 - [#569](https://github.com/alexpfau/calendar-card-pro/issues/569) - `today_indicator` silently fell back to a dot for image addresses its list did not name by @alexpfau
 - [#573](https://github.com/alexpfau/calendar-card-pro/issues/573) - `today_indicator` had an undocumented text mode, gated on whether the text contained a digit by @alexpfau
 - [#576](https://github.com/alexpfau/calendar-card-pro/issues/576) - A description pairing a `<` with a later `>` lost the prose between them by @alexpfau
+- [#581](https://github.com/alexpfau/calendar-card-pro/issues/581) - The description flattening kept 21 shapes a browser discards as a bogus comment, three of which v4.0.0 removed, by @alexpfau — found by the pre-release audit and fixed before shipping, so no user ever saw it. It also corrected this release's own claim that the new rule is "the same test a browser applies", which overstated it
+- [#582](https://github.com/alexpfau/calendar-card-pro/issues/582) - Nine of fifteen editor dropdowns could lose an option with every gate green, by @alexpfau — a gate rather than a user-visible fix: `check:i18n` now reconciles all 81 dropdown options against the strings naming them, in both directions
 
 ---
 


### PR DESCRIPTION
Two Related Issues lines. No other change.

#581 and #582 were found by the pre-release audit and fixed in #585 and #586, but neither appeared on the v4.1.0 close-list.

**Neither earned a release-notes entry, and both sessions were right about that.** #581's three silent regressions were introduced by #579 and repaired before shipping, so no released version ever had them; #582 is a gate, not a user-visible change.

**But Related Issues is a close-list, not a changelog.** It is what gets read at release time to decide what to close, and `AGENTS.md` names both failure modes as silent afterwards — an issue left out is forgotten, and an issue wrongly left in is closed on a request only half answered. These two are resolved in full, so the risk here was forgetting them.

Each line says plainly what shipped and why it is not in the notes proper, so a reader working the list does not have to reconstruct it.

Verified: `check:format`, `check:docs` and `docs:build` pass, and `extract-release-notes.mjs v4.1.0` — the script the release workflow runs, which fails *after* the tag is pushed — emits both new lines.