### PR TITLE
docs: add German documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ always matches the latest release.
 | 💡 [Examples](https://calendar-card-pro.alexpfau.com/reference/examples)                   | Ready-made configurations to copy             |
 | 🆕 [Release Notes](https://calendar-card-pro.alexpfau.com/RELEASE_NOTES)                   | Full history of every release                 |
 
+### Unofficial German documentation
+
+An unofficial German documentation and practical guide is maintained externally by UGSo Software:
+
+- [Calendar Card Pro German documentation](https://opensource.ugso-software.de/sammlung/calendar-card-pro/)
+
 <p>&nbsp;</p>
 
 ## 1️⃣ Overview


### PR DESCRIPTION
This adds a small link to an externally maintained unofficial German documentation and practical guide for Calendar Card Pro.\n\nThe translation is hosted outside this repository so the original project does not need to maintain translated documentation files directly. The German page includes source attribution, tracked upstream commit information, release information, license attribution, and an automated upstream-change check in the external documentation repository.\n\nGerman documentation: https://opensource.ugso-software.de/sammlung/calendar-card-pro/