### PR TITLE
Give list view its own block, and make the top level shared

### DIFF
--- a/docs/features/actions.md
+++ b/docs/features/actions.md
@@ -7,8 +7,9 @@ Calendar Card Pro is interactive: you can let users expand a compact card to rev
 One of Calendar Card Pro's most powerful features is the ability to toggle between compact and expanded mode:
 
 ```yaml
-# Limit events in compact mode
-compact_events_to_show: 5
+list:
+  # Limit events in compact mode
+  compact_events_to_show: 5
 
 # Enable expand/collapse with tap
 tap_action:
@@ -49,8 +50,9 @@ entities:
   - entity: calendar.holidays
     compact_events_to_show: 1
     # At most 1 holiday event while compact
-compact_events_to_show: 4
-# Show at most 4 events total in compact mode
+list:
+  compact_events_to_show: 4
+  # Show at most 4 events total in compact mode
 
 tap_action:
   action: expand

--- a/docs/features/core-settings.md
+++ b/docs/features/core-settings.md
@@ -936,14 +936,15 @@ Calendar Card Pro offers powerful controls for managing what appears in compact 
 # Total days to fetch from API and display when expanded
 days_to_show: 7
 
-# Event limit for compact mode
-compact_events_to_show: 5 # Preferred: New option name
+list:
+  # Event limit for compact mode
+  compact_events_to_show: 5 # Preferred: New option name
 
-# Day limit in compact mode
-compact_days_to_show: 2 # Fewer days to display in compact mode
+  # Day limit in compact mode
+  compact_days_to_show: 2 # Fewer days to display in compact mode
 
-# Ensure complete days are shown
-compact_events_complete_days: true # Never cut off a day's events mid-day
+  # Ensure complete days are shown
+  compact_events_complete_days: true # Never cut off a day's events mid-day
 ```
 
 ::: warning Compact Mode Applies to List View Only
@@ -987,7 +988,8 @@ The `compact_days_to_show` option lets you display fewer days in compact mode:
 
 ```yaml
 days_to_show: 7 # Show 7 days when expanded
-compact_days_to_show: 2 # Show only the next 2 days with events in compact mode
+list:
+  compact_days_to_show: 2 # Show only the next 2 days with events in compact mode
 ```
 
 This is useful for dashboards where you want an initial view showing just the most immediate events, with the ability to expand to view the entire week.
@@ -997,8 +999,9 @@ This is useful for dashboards where you want an initial view showing just the mo
 When using event limits, the `compact_events_complete_days` option ensures that partial days are never shown:
 
 ```yaml
-compact_events_to_show: 5
-compact_events_complete_days: true
+list:
+  compact_events_to_show: 5
+  compact_events_complete_days: true
 ```
 
 When enabled, this feature ensures that if at least one event from a day is shown, all events from that day will be displayed. This prevents confusion that might arise when some events from a day are visible but others are hidden.
@@ -1018,10 +1021,45 @@ These flexible controls allow you to:
 - **Provide complete context**: Ensure users can see all events for any shown day
 - **Support easy expansion**: Allow users to see the full calendar with a single tap
 
+## 🧱 Per-View Options
+
+Calendar Card Pro renders in three layouts, and each has a block of its own: `list:`,
+`column:` and `time_grid:`. Everything at the top level is the **shared base** — write an
+option there once and all three layouts use it.
+
+```yaml
+# Shared by every layout
+event_font_size: 14px
+show_location: true
+
+column:
+  event_font_size: 11px # Column view only — narrower columns, smaller type
+```
+
+A block names only what should differ. Anything it does not mention keeps the top-level
+value, so the example above shows locations in all three layouts and shrinks the type in
+just one.
+
+Each block also holds the options only that layout has — the compact caps and date-cell
+settings in `list:`, the column widths in `column:`, the time axis in `time_grid:`. Those
+have no shared meaning, so there is nothing at the top level for them to fall back to.
+
+::: tip Older Configurations Keep Working
+Before v5 there was no `list:` block, so list options were written at the top level. They
+still are read there, permanently — nothing needs changing by hand. The visual editor
+writes the new arrangement the next time you save a card.
+:::
+
+**→ [Column View](/features/column-view)** — what column may override, and what it ignores.
+**→ [Grid View](/features/grid-view)** — the same for the time grid.
+**→ [List-Only Options in the configuration reference](/reference/configuration#list-only-options)** — the five options only list reads.
+
 ## 🧭 Column View
 
 Column view moved to its own page — it outgrew this one.
 
 **→ [Column View](/features/column-view)** — the layout, per-view overrides, spacing and the responsive fallbacks.
+
+**→ [List-Only Options in the configuration reference](/reference/configuration#list-only-options)** — the compact options and the two date-cell ones, which live inside `list:`.
 
 **→ [Core Settings in the configuration reference](/reference/configuration#core-settings)** — the full option table for everything on this page.

--- a/docs/features/editor.md
+++ b/docs/features/editor.md
@@ -30,11 +30,15 @@ The longer panels are divided further by sub-headings, which name what the optio
 
 Two controls sit together above search. **Card Displays** chooses the card's starting
 layout and writes the existing `view` option. **Editing Settings For** selects an
-editor workspace: **List**, **Column**, or **Grid**. It starts by following
-Card Displays, then stays independent once you choose a workspace. The workspace is
-never saved to YAML; opening the editor again starts from the card's displayed view.
+editor workspace: **All Layouts**, **List**, **Column**, or **Grid**. It starts by
+following Card Displays, then stays independent once you choose a workspace. The workspace
+is never saved to YAML; opening the editor again starts from the card's displayed view.
 
-Each workspace omits controls that cannot affect that view, including
+**All Layouts** edits the shared base — the top level, which every layout falls back to.
+It offers only the options that have a shared meaning, so the layout-specific ones are
+absent there rather than being written somewhere only one view reads.
+
+Each of the other three omits controls that cannot affect that view, including
 their per-calendar forms. Compact-mode controls appear in List.
 Multi-day splitting also appears in Column, but not Grid, which arranges
 multi-day events itself. Grid omits empty-day text and color because it draws blank
@@ -50,11 +54,16 @@ Search and **Customized Only** do not bring back controls for another workspace.
 To edit a list-only option used by a responsive fallback, choose List under
 Editing Settings For; Card Displays stays unchanged.
 
+Editing a card written before v5 moves its list options into `list:` on the first save.
+Nothing else changes, and configurations left alone keep working exactly as they are —
+see [Per-View Options](/features/core-settings#per-view-options).
+
 Presentation controls show the value used by the selected workspace and write directly
-to its scope: top-level options for List, `column:` for Column, and `time_grid:` for Grid.
-Column and Grid can also use List values when they do not have their own value for an
-option, so editing List can affect those layouts too. Card-wide options such as calendars,
-title, language, and actions stay card-wide in every workspace.
+to its scope: the top level for All Layouts, then `list:`, `column:` and `time_grid:` for
+the three views. A view block holds only what should differ there; anything it does not
+mention comes from the shared base, so editing All Layouts moves every layout that has not
+overridden the option. Card-wide options such as calendars, title, language, and actions
+stay card-wide in every workspace.
 
 Hiding a control does not delete its stored value. For example, these empty-day options
 remain available to the list fallback, even though their controls are absent while

--- a/docs/features/layout-appearance.md
+++ b/docs/features/layout-appearance.md
@@ -124,8 +124,9 @@ Fine-tune the spacing and alignment of your calendar elements:
 day_spacing: '8px' # Space between different calendar days
 event_spacing: '6px' # Internal padding within each event
 
-# Date column alignment
-date_vertical_alignment: 'top' # Options: 'top', 'middle', 'bottom'
+list:
+  # Date column alignment
+  date_vertical_alignment: 'top' # Options: 'top', 'middle', 'bottom'
 
 # Event icon alignment
 event_icon_vertical_alignment: 'middle' # Options: 'top', 'middle', 'bottom'
@@ -308,9 +309,10 @@ today_indicator: /local/custom-indicator.png # Image path
 today_indicator: https://example.com/today.png # Or any image URL
 
 # Position the indicator precisely with CSS-like coordinates
-today_indicator_position: "15% 50%" # Centered left in the date column (default)
-today_indicator_position: "15% 15%" # Top left
-today_indicator_position: "85% 15%" # Top right
+list:
+  today_indicator_position: "15% 50%" # Centered left in the date column (default)
+  today_indicator_position: "15% 15%" # Top left
+  today_indicator_position: "85% 15%" # Top right
 
 # Restyle the indicator
 today_indicator_color: "#03a9f4" # Color — applies to the dot and to MDI icons (default)
@@ -341,4 +343,4 @@ The `today_indicator_position` option accepts CSS-like position values in the fo
 
 `today_indicator_size` scales every indicator type — it sets the icon size, the font size for emoji and text, and the image width. `today_indicator_color` colors the icon-based types (the dot, `pulse`, `glow` and any `mdi:` icon) and is also the color of the glow itself; emojis and images keep their own colors, and text takes the color it inherits.
 
-The options on this page are grouped in the reference under [Layout & Spacing](/reference/configuration#layout-spacing), [Week Numbers & Horizontal Separators](/reference/configuration#week-numbers-horizontal-separators), [Today Indicator](/reference/configuration#today-indicator) and [Date Column](/reference/configuration#date-column).
+The options on this page are grouped in the reference under [Layout & Spacing](/reference/configuration#layout-spacing), [Week Numbers & Horizontal Separators](/reference/configuration#week-numbers-horizontal-separators), [Today Indicator](/reference/configuration#today-indicator) and [Date Column](/reference/configuration#date-column). Two of them — `date_vertical_alignment` and `today_indicator_position` — are list-only and belong inside `list:`; they are listed under [List-Only Options](/reference/configuration#list-only-options).

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -60,7 +60,7 @@ question. HACS does all of this for you, which is why it is the recommended rout
 ::: tip Optional: Compress The Files Yourself
 Home Assistant serves a pre-compressed `.gz` beside a file when it finds one, and does not
 compress on the fly. Neither install route ships one, so the card transfers at its full
-249 KB and the editor at 446 KB — once per version, then the browser caches both.
+249 KB and the editor at 448 KB — once per version, then the browser caches both.
 
 If you want the smaller transfer, create the companions yourself and keep them beside the
 originals:

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -59,7 +59,8 @@ entities:
   - entity: calendar.personal
     color: '#c2ffb3' # Green for personal events
 days_to_show: 7
-compact_events_to_show: 3 # Always only show 3 events
+list:
+  compact_events_to_show: 3 # Always only show 3 events
 tap_action:
   action: expand # Tap to expand/collapse
 ```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -32,6 +32,7 @@ cards.
 | `split_multiday_events`        | boolean | `false`                       | Display multi-day events on each day they cover. Column view defaults this to `true` and does not inherit the top-level value — a column is a day, so a spanning event belongs in each one it covers. See [Options That Start From a Different Default](/features/column-view#options-that-start-from-a-different-default)                                                                                                                                       |
 | `event_type`                   | string  | `all`                         | Which class of event the card keeps — `all` shows every event, `timed` keeps only those with a clock time, and `all_day` keeps only all-day ones. It describes the kind of event, not how long it lasts. Setting it per calendar, on a calendar listed twice, is how one calendar's all-day events get their own color. See [Separating All-Day From Timed Events](/features/core-settings#separating-all-day-from-timed-events)                                 |
 | `language`                     | string  | `System`, fallback `en`       | Interface language (auto-detects from HA). Governs every string the card renders, including the weather condition words — see [Weather](/features/weather#weather-in-the-column-layout)                                                                                                                                                                                                                                                                          |
+| `list`                         | object  | Inherits the top-level values | Options that should take a different value in list view, plus the five that only list reads. Only presentation options may appear here — see [Per-View Options](/features/core-settings#per-view-options)                                                                                                                                                                                                                                                        |
 | `column`                       | object  | Inherits the top-level values | Options that should take a different value in column view. Only presentation options may appear here — see [Column View](/features/column-view)                                                                                                                                                                                                                                                                                                                  |
 | `time_grid`                    | object  | Inherits the top-level values | Options that should take a different value in grid view, plus the time axis's own settings. Only presentation options may appear here — see [Grid View](/features/grid-view)                                                                                                                                                                                                                                                                                     |
 
@@ -83,6 +84,29 @@ describe the shared day header, the time axis and the grid's responsive width fa
 | `time_grid → allday_band_max_rows`       | number  | `3`                                                             | Rows the all-day band may grow to before remaining banners are dropped                                                                          |
 
 **→ [Grid View](/features/grid-view)** — worked examples.
+
+### List-Only Options
+
+These five apply in list view and nowhere else, because they describe a date cell or a
+compact budget that neither of the other layouts has. They belong inside `list:`, which is
+where the visual editor writes them.
+
+| Option                                | Type    | Default   | Description                                                                  |
+| ------------------------------------- | ------- | --------- | ---------------------------------------------------------------------------- |
+| `list → date_vertical_alignment`      | string  | `middle`  | How the date aligns with its events: `top`, `middle` or `bottom`             |
+| `list → today_indicator_position`     | string  | `15% 50%` | Where the indicator sits in the date column, as CSS-like coordinates         |
+| `list → compact_events_to_show`       | number  | -         | Most events shown while the card is compact; unset shows them all            |
+| `list → compact_days_to_show`         | number  | -         | Most days shown while the card is compact; unset shows every day in range    |
+| `list → compact_events_complete_days` | boolean | `false`   | Never cut a day off part-way: if one of its events is shown, all of them are |
+
+::: tip Older Configurations Keep Working
+Written at the top level they behave exactly as they always did, so nothing needs changing
+by hand. The editor moves them into `list:` the next time you save.
+:::
+
+**→ [Compact Mode & Event Limits](/features/core-settings#compact-mode-event-limits)** — the three compact options, worked through.
+**→ [Spacing & Alignment](/features/layout-appearance#spacing-alignment)** — `date_vertical_alignment`.
+**→ [Today Indicator](/features/layout-appearance#today-indicator)** — `today_indicator_position`.
 
 ### Options With No Effect in Column View
 

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -42,7 +42,8 @@ entities:
   - entity: calendar.personal
     color: '#c2ffb3' # Green for personal events
 days_to_show: 7
-compact_events_to_show: 3 # Always only show 3 events
+list:
+  compact_events_to_show: 3 # Always only show 3 events
 tap_action:
   action: expand # Tap to expand/collapse
 ```
@@ -63,7 +64,8 @@ entities:
   - entity: calendar.personal
     accent_color: '#43a047'
 days_to_show: 5
-compact_events_to_show: 5
+list:
+  compact_events_to_show: 5
 event_background_opacity: 20
 vertical_line_width: 5px
 event_spacing: 6px
@@ -83,7 +85,8 @@ entities:
   - entity: calendar.family
     accent_color: '#ff6c92'
 days_to_show: 5
-compact_events_to_show: 6
+list:
+  compact_events_to_show: 6
 vertical_line_width: 5px
 event_spacing: 5px
 show_week_numbers: iso
@@ -171,7 +174,8 @@ entities:
     color: '#b3ffd9'
 start_date: today
 days_to_show: 10
-compact_events_to_show: 10
+list:
+  compact_events_to_show: 10
 language: en
 
 # Header
@@ -191,7 +195,8 @@ day_separator_width: 2px
 day_separator_color: '#baf1ff80'
 
 # Date Column
-date_vertical_alignment: middle
+list:
+  date_vertical_alignment: middle
 weekday_font_size: 14px
 weekday_color: '#baf1ff'
 day_font_size: 32px

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1668,6 +1668,7 @@ function report(counts) {
       `${counts.reachable} pages reachable from the navigation, ` +
       `${counts.themed} theme defaults documented, ` +
       `${counts.citations} line citations checked, ` +
+      `${counts.listFences} YAML examples checked for list-only keys, ` +
       `${counts.languages} language counts checked, ` +
       `${counts.readmeAnchors} README anchor links checked, ` +
       `release surfaces checked against v${counts.version}.\n`,
@@ -2899,6 +2900,79 @@ function checkReadmeFragmentLinks() {
 }
 
 // ---------------------------------------------------------------------------
+// Check 30 — no example writes a list-only option at the top level
+// ---------------------------------------------------------------------------
+
+/**
+ * The five keys `VIEW_SCOPE` scopes to list alone, read from the source rather than
+ * listed here. A hand-written copy would silently stop covering the next one somebody
+ * scopes to list, which is the failure this project has already had in several tables.
+ *
+ * @returns The list-only config keys
+ */
+function readListOnlyKeys() {
+  const src = readFileSync(VIEW_TS, 'utf8');
+  const block = src.match(/VIEW_SCOPE[^=]*=\s*\{([\s\S]*?)\n\};/);
+  if (!block) {
+    console.error(`\n✗ FATAL: could not locate VIEW_SCOPE in ${relative(ROOT, VIEW_TS)}.\n`);
+    process.exit(2);
+  }
+  const keys = new Set();
+  for (const line of block[1].split('\n')) {
+    const m = line.match(/^ {2}([a-z0-9_]+):\s*new Set<[^>]*>\(\[([^\]]*)\]\)/);
+    if (m && m[2].replace(/['\s]/g, '') === 'list') keys.add(m[1]);
+  }
+  assertFound(keys, 'list-only VIEW_SCOPE keys', VIEW_TS);
+  return keys;
+}
+
+/**
+ * Since v5 these belong inside `list:`. Writing one at the top level still *works* —
+ * that compatibility is permanent, because a YAML-mode user never opens the editor that
+ * would move it — but an example teaching the old arrangement teaches a reader to write
+ * a config the editor will silently rewrite under them.
+ *
+ * `RELEASE_NOTES.md` is exempt for the reason `AGENTS.md` gives: it records what was
+ * announced at the time and is not rewritten. `whats-new.md` is exempt on the same
+ * grounds.
+ *
+ * The check reads column 0 only, so a per-calendar `compact_events_to_show` under
+ * `entities:` is untouched — that one is an entity option and has no `list:` home.
+ *
+ * @param {string[]} docs - Every published page
+ * @param {Set<string>} listOnly - Keys from `readListOnlyKeys`
+ * @returns The number of fences inspected, so a short corpus is visible in the report
+ */
+function checkListBlockExamples(docs, listOnly) {
+  const exempt = ['RELEASE_NOTES.md', 'guide/whats-new.md'];
+  let fences = 0;
+  for (const file of [...docs, ...ROOT_PROSE]) {
+    if (isExcluded(file, exempt)) continue;
+    const rel = relative(ROOT, file);
+    const text = readFileSync(file, 'utf8');
+    // The language group is deliberately not optional: an optional one skips a `json`
+    // opener and then runs the lazy body on to the wrong closing delimiter.
+    const re = /```([a-z]*)\n([\s\S]*?)```/g;
+    let m;
+    while ((m = re.exec(text))) {
+      if (m[1] !== 'yaml' && m[1] !== 'yml') continue;
+      fences++;
+      const line0 = text.slice(0, m.index).split('\n').length;
+      m[2].split('\n').forEach((line, i) => {
+        const key = line.match(/^([a-z0-9_]+):/);
+        if (key && listOnly.has(key[1])) {
+          error(
+            `${rel}:${line0 + 1 + i}: \`${key[1]}\` is list-only and sits at the top level — ` +
+              'move it inside a `list:` block',
+          );
+        }
+      });
+    }
+  }
+  return fences;
+}
+
+// ---------------------------------------------------------------------------
 // Check 29 — absolute links into the docs site resolve to a real page and heading
 // ---------------------------------------------------------------------------
 
@@ -3026,6 +3100,7 @@ function main() {
   const removed = checkDeprecatedTable(readDeprecatedMaps());
   const reachable = checkPageReachability(docs, readNavRoutes());
   const themed = checkThemeDefaults(readThemeTable());
+  const listFences = checkListBlockExamples(docs, readListOnlyKeys());
   const citations = checkCitations();
   const languages = checkLanguageCounts();
 
@@ -3048,6 +3123,7 @@ function main() {
       reachable,
       themed,
       citations,
+      listFences,
       languages,
       readmeAnchors,
       version,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -150,6 +150,7 @@ export const DEFAULT_CONFIG: Types.Config = {
   refresh_interval: Constants.CACHE.DEFAULT_DATA_REFRESH_MINUTES,
   refresh_on_navigate: true,
 
+  list: undefined,
   column: undefined,
   time_grid: undefined,
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -145,6 +145,9 @@ export interface Config {
   refresh_interval: number;
   refresh_on_navigate: boolean;
 
+  // List view
+  list?: ListOverrides;
+
   // Column view
   column?: ColumnOverrides;
 
@@ -331,6 +334,25 @@ export interface SharedViewOverrides {
   week_separator_color?: string;
   month_separator_width?: string;
   month_separator_color?: string;
+}
+
+/**
+ * The `list:` block — every shared override, plus list's own presentation keys.
+ *
+ * List has no key of its own without a top-level counterpart, so unlike the other two
+ * views it declares no view-only members: everything here is an override of a card-level
+ * key. The five below are list-only in `VIEW_SCOPE`, which is why no other view can
+ * override them and why they never entered the shared set.
+ */
+export interface ListOverrides extends SharedViewOverrides {
+  // Compact mode. Nothing outside list view reads these.
+  compact_days_to_show?: number;
+  compact_events_to_show?: number;
+  compact_events_complete_days?: boolean;
+
+  // List-row layout.
+  date_vertical_alignment?: string;
+  today_indicator_position?: string;
 }
 
 /**

--- a/src/config/view.ts
+++ b/src/config/view.ts
@@ -156,6 +156,38 @@ export const TIME_GRID_ONLY_KEYS = [
 ] as const;
 
 /**
+ * Every option that may appear inside the `list:` block.
+ *
+ * The shared set plus the five keys `VIEW_SCOPE` marks list-only. Those five sat at the
+ * top level through v4 for a reason that stopped being true when column view arrived:
+ * as long as list was the only view, the top level *was* the list block. They are
+ * override keys rather than only-keys because each has a `Types.Config` counterpart —
+ * `OnlyKeysWithCounterpart` rejects the other classification, which is the assertion
+ * doing the deciding rather than this comment.
+ *
+ * 🚨 Spread, not filtered. The spread of a tuple is still a tuple, so the partition
+ * assertions below stay literal; the `.filter()` hazard documented on
+ * `TIME_GRID_OVERRIDE_KEYS` applies here too.
+ */
+export const LIST_OVERRIDE_KEYS = [
+  ...COLUMN_OVERRIDE_KEYS,
+  'compact_days_to_show',
+  'compact_events_to_show',
+  'compact_events_complete_days',
+  'date_vertical_alignment',
+  'today_indicator_position',
+] as const;
+
+/**
+ * List has no option without a top-level counterpart.
+ *
+ * Empty by construction rather than by omission: every list-only key is an override of
+ * a card-level key, so classifying any of them here would fail
+ * `_AssertListOnlyKeysHaveNoCounterpart`.
+ */
+export const LIST_ONLY_KEYS = [] as const;
+
+/**
  * Compile-time partition check for a view's two key arrays.
  *
  * The arrays are the only thing that decides whether an override reaches the renderer:
@@ -231,6 +263,16 @@ export type _AssertEveryGridOverrideKeyHoistable = AssertNever<
 >;
 export type _AssertGridOnlyKeysHaveNoCounterpart = AssertNever<
   OnlyKeysWithCounterpart<typeof TIME_GRID_ONLY_KEYS>
+>;
+
+export type _AssertEveryListKeyClassified = AssertNever<
+  UnclassifiedKeys<Types.ListOverrides, typeof LIST_OVERRIDE_KEYS, typeof LIST_ONLY_KEYS>
+>;
+export type _AssertEveryListOverrideKeyHoistable = AssertNever<
+  OverrideKeysWithoutCounterpart<Types.ListOverrides, typeof LIST_OVERRIDE_KEYS>
+>;
+export type _AssertListOnlyKeysHaveNoCounterpart = AssertNever<
+  OnlyKeysWithCounterpart<typeof LIST_ONLY_KEYS>
 >;
 
 export const VIEWS: ReadonlyArray<Types.EffectiveView> = ['list', 'column', 'grid'];
@@ -323,6 +365,41 @@ export const ENTITY_VIEW_SCOPE: Readonly<Record<string, ReadonlySet<Types.Effect
 export function appliesToView(key: string, view: Types.EffectiveView): boolean {
   const scope = Object.prototype.hasOwnProperty.call(VIEW_SCOPE, key) ? VIEW_SCOPE[key] : undefined;
   return scope === undefined || scope.has(view);
+}
+
+/**
+ * Whether an option is worth setting on the shared base rather than in a view block.
+ *
+ * 🚨 The answer is *more than one view*, not *any view*. The shared workspace exists to
+ * set a value once for every layout that reads it, so a key only one layout reads has no
+ * business there — putting `today_indicator_position` on the shared base would offer the
+ * user a control that is, by construction, list's alone.
+ *
+ * This is why widening the workspace type is not enough on its own. The obvious repair
+ * for the compiler error this answers is `scope.has(workspace)`, which is `false` for
+ * every scoped key when the workspace is `'shared'` — so the shared base would withhold
+ * precisely the keys it is for, silently and while typechecking.
+ *
+ * 🚨 An unscoped key is *not* automatically shared, which is where this parts company with
+ * `appliesToView`. A block-only key such as `hour_height` or `min_day_width` has no
+ * `VIEW_SCOPE` entry because it has no top-level home at all — it exists only inside a
+ * block. Treating "unscoped" as "shared" there offered the control on the shared base and
+ * would have written the value to the top level, where nothing ever reads it: the exact
+ * silent-wrong-destination bug the view-first editor was built to remove.
+ *
+ * @param key - Config key to test
+ * @param scopeFor - How to look the key's scope up; defaults to the card-level scope
+ * @returns Whether more than one view reads it at the top level
+ */
+export function appliesToSharedBase(
+  key: string,
+  scopeFor: (key: string) => ReadonlySet<Types.EffectiveView> | undefined = (candidate) =>
+    Object.prototype.hasOwnProperty.call(VIEW_SCOPE, candidate) ? VIEW_SCOPE[candidate] : undefined,
+): boolean {
+  if (BLOCK_ONLY_KEYS.has(key)) return false;
+
+  const scope = scopeFor(key);
+  return scope === undefined || scope.size > 1;
 }
 
 /**
@@ -914,6 +991,16 @@ interface ViewBlock {
 }
 
 export const VIEW_BLOCKS: Readonly<Partial<Record<Types.EffectiveView, ViewBlock>>> = {
+  list: {
+    blockKey: 'list',
+    overrideKeys: LIST_OVERRIDE_KEYS,
+    onlyKeys: LIST_ONLY_KEYS,
+    onlyDefaults: {},
+    // Empty by definition, not by omission. A divergent default is a view disagreeing
+    // with the shipped card-level value, and the card-level values *are* list's — every
+    // `DEFAULT_CONFIG` entry was written for the only view that existed when it landed.
+    defaultOverrides: {},
+  },
   column: {
     blockKey: 'column',
     overrideKeys: COLUMN_OVERRIDE_KEYS,
@@ -952,6 +1039,18 @@ export const OVERRIDE_BLOCK_BY_VIEW: Readonly<
 > = Object.fromEntries(
   Object.entries(VIEW_BLOCKS).map(([view, block]) => [view, block.blockKey]),
 ) as Readonly<Partial<Record<Types.EffectiveView, keyof Types.Config>>>;
+
+/**
+ * Every key that exists only inside a view block, with no top-level counterpart.
+ *
+ * Derived from {@link VIEW_BLOCKS} rather than written out, so a view registered with new
+ * `onlyKeys` is covered the day it lands. Read by {@link appliesToSharedBase}, which must
+ * refuse these: they have no top level to be set at, so offering one on the shared base
+ * would write a key nothing reads.
+ */
+const BLOCK_ONLY_KEYS: ReadonlySet<string> = new Set(
+  Object.values(VIEW_BLOCKS).flatMap((block) => block.onlyKeys as ReadonlyArray<string>),
+);
 
 /**
  * Where an edit to an option belongs when the editor is configuring a given view.
@@ -1177,7 +1276,11 @@ export function resolveEffectiveConfig(
     }
   }
 
-  return { ...config, ...applied } as Types.Config;
+  // Identity on the no-op path. List's block has no divergent defaults, so an unpopulated
+  // `list:` leaves nothing to apply — and the card memoizes on configuration identity and
+  // hands the result to caches that compare by reference. A fresh equal object would still
+  // render correctly and quietly turn every one of those comparisons into a miss.
+  return Object.keys(applied).length === 0 ? config : ({ ...config, ...applied } as Types.Config);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/rendering/editor/element.ts
+++ b/src/rendering/editor/element.ts
@@ -113,8 +113,11 @@ export class CalendarCardProEditor extends LitElement {
   private get _ctx(): SchemaCtx {
     const rawConfig = this._config!;
     const workspace = this._workspace;
-    const view = workspace;
     const config = Routing.workspaceConfig(rawConfig, workspace);
+    // Shared has no layout of its own, so its panels are built as list — the base every
+    // other view widens. `config.view` stays the card's real displayed view, because that
+    // is the value the Card Displays control edits; see `baseViewForWorkspace`.
+    const view = Workspace.baseViewForWorkspace(workspace);
 
     return {
       view,
@@ -210,6 +213,13 @@ export class CalendarCardProEditor extends LitElement {
    */
   private _report(config: Types.Config): void {
     const stored = Value.toStoredConfig(config);
+
+    // The v5 migration, run at the one place a save happens rather than inside
+    // `toStoredConfig` — that function is also the diff baseline and the filter's
+    // customized-only projection, and neither wants a migration applied to what it reads.
+    // Shared writes at root by design, so a save from there must not relocate the keys it
+    // exists to author; see `relocateListKeys`.
+    Value.relocateListKeys(stored, config.view, this._workspace !== 'shared');
 
     if (Value.equalConfigs(stored, this._lastDispatched ?? {})) {
       return;

--- a/src/rendering/editor/element.ts
+++ b/src/rendering/editor/element.ts
@@ -429,7 +429,7 @@ export class CalendarCardProEditor extends LitElement {
             Entities.labelTypeOf(entry),
             accentColorModeOf(Entities.asEntityConfig(entry).accent_color),
             labelIconSourceOf(Entities.asEntityConfig(entry).label),
-            Entities.showsLocation(entry, ctx.config, ctx.view),
+            Entities.showsLocation(entry, ctx.config, this._destinationView(ctx)),
             labelImageSourceOf(Entities.asEntityConfig(entry).label),
           ),
           entry,
@@ -649,6 +649,23 @@ export class CalendarCardProEditor extends LitElement {
   }
 
   /**
+   * The view whose layer this context writes into, or `undefined` for the shared base.
+   *
+   * 🚨 Not `ctx.view`, and the difference only appears under the shared workspace. Panels
+   * there are built as a view — see {@link Workspace.baseViewForWorkspace} — so `ctx.view`
+   * answers *what this looks like*, which is the wrong question for anything that resolves
+   * a value or writes one. Both callers below reach a block by view name, and a name sends
+   * them into that block; the shared base has none. `ctx.workspace` is absent for callers
+   * that build a context by hand, where the two questions still coincide.
+   *
+   * @param ctx - Editing context
+   * @returns The view being written, or `undefined` when the shared base is
+   */
+  private _destinationView(ctx: SchemaCtx): Types.EffectiveView | undefined {
+    return ctx.workspace === undefined ? ctx.view : Workspace.viewForWorkspace(ctx.workspace);
+  }
+
+  /**
    * Offers reset actions for explicit values, without duplicating the editing controls.
    *
    * 🚨 Guards on where the *workspace writes*, never on `ctx.view`. Those agreed while list
@@ -671,7 +688,7 @@ export class CalendarCardProEditor extends LitElement {
     schema: ReadonlyArray<HaFormSchema>,
     ctx: SchemaCtx,
   ): TemplateResult | typeof nothing {
-    const view = ctx.workspace === undefined ? ctx.view : Workspace.viewForWorkspace(ctx.workspace);
+    const view = this._destinationView(ctx);
     if (view === undefined) return nothing;
     const blockKey = ViewConfig.OVERRIDE_BLOCK_BY_VIEW[view];
     if (blockKey === undefined) return nothing;

--- a/src/rendering/editor/element.ts
+++ b/src/rendering/editor/element.ts
@@ -651,6 +651,18 @@ export class CalendarCardProEditor extends LitElement {
   /**
    * Offers reset actions for explicit values, without duplicating the editing controls.
    *
+   * 🚨 Guards on where the *workspace writes*, never on `ctx.view`. Those agreed while list
+   * was blockless, so `ctx.view` read as a destination for free. It stopped being one the
+   * moment `list:` was registered: the shared workspace builds its panels as list — see
+   * {@link Workspace.baseViewForWorkspace} — so `ctx.view` is `'list'` there, and guarding on
+   * it offered Shared the reset buttons for `list:`. Clicking one deleted a List override
+   * from a workspace that cannot write to `list:` at all, leaving root untouched.
+   *
+   * Shared therefore offers none, which is the answer the reset *means* rather than a
+   * special case: {@link _resetViewValues} returns a value to what it inherits, and the
+   * shared base inherits from nothing. It is also what the root-writing workspace did
+   * before `list:` existed, so this restores that behavior rather than inventing one.
+   *
    * @param schema - Fields currently shown
    * @param ctx - Editing context
    * @returns Per-option reset buttons, or nothing
@@ -659,7 +671,9 @@ export class CalendarCardProEditor extends LitElement {
     schema: ReadonlyArray<HaFormSchema>,
     ctx: SchemaCtx,
   ): TemplateResult | typeof nothing {
-    const blockKey = ViewConfig.OVERRIDE_BLOCK_BY_VIEW[ctx.view];
+    const view = ctx.workspace === undefined ? ctx.view : Workspace.viewForWorkspace(ctx.workspace);
+    if (view === undefined) return nothing;
+    const blockKey = ViewConfig.OVERRIDE_BLOCK_BY_VIEW[view];
     if (blockKey === undefined) return nothing;
     const stored = Value.toStoredConfig(this._config!)[blockKey];
     if (!stored || typeof stored !== 'object') return nothing;
@@ -670,7 +684,7 @@ export class CalendarCardProEditor extends LitElement {
           ? [node.name]
           : path.length === 0
             ? Synthetic.configKeysForField(node.name).filter(
-                (key) => Routing.destination(key, ctx.view) === blockKey,
+                (key) => Routing.destination(key, view) === blockKey,
               )
             : []
       ).filter((key) => Object.prototype.hasOwnProperty.call(stored, key) && !seen.has(key));
@@ -687,7 +701,7 @@ export class CalendarCardProEditor extends LitElement {
               type="button"
               class="text-button"
               data-reset-keys=${keys.join(' ')}
-              @click=${() => this._resetViewValues(blockKey, ctx.view, keys)}
+              @click=${() => this._resetViewValues(blockKey, view, keys)}
             >
               ${interpolate(this._string(ctx, 'value_source.reset'), {
                 option: label,

--- a/src/rendering/editor/entities.ts
+++ b/src/rendering/editor/entities.ts
@@ -200,18 +200,31 @@ export function asEntityConfig(entry: string | Types.EntityConfig): Types.Entity
  * replaces the marker on a row that is not being drawn, so offering it there is the editor
  * claiming to control something it does not.
  *
+ * 🚨 `undefined` means the shared base, and it is not the same as picking a view. A view
+ * name sends {@link ViewConfig.resolveViewOption} into that view's block, so answering the
+ * shared workspace with a view would consult a block the workspace cannot write to — and
+ * once `list:` existed, passing the built view read `list:` and hid `location_icon` for a
+ * card that had turned locations off in list alone, while column and grid still drew them.
+ * The shared base's own answer is the top-level value, with no block over it.
+ *
+ * Residual, and deliberate: a card whose base says no locations but whose `column:` turns
+ * them back on hides the control here. That is the shared base answering for itself, and
+ * the control is still offered in the workspace that overrode it.
+ *
  * @param entry - Entry as stored
  * @param config - Merged configuration
- * @param view - View the card is configured to render
+ * @param view - View being edited, or `undefined` for the shared base
  * @returns `true` when this calendar's events can show a location
  */
 export function showsLocation(
   entry: string | Types.EntityConfig,
   config: Readonly<Types.Config>,
-  view: Types.EffectiveView,
+  view: Types.EffectiveView | undefined,
 ): boolean {
   const own = asEntityConfig(entry).show_location;
   if (typeof own === 'boolean') return own;
+
+  if (view === undefined) return Boolean(config.show_location);
 
   return Boolean(ViewConfig.resolveViewOption(config as Types.Config, 'show_location', view));
 }

--- a/src/rendering/editor/filter.ts
+++ b/src/rendering/editor/filter.ts
@@ -10,7 +10,7 @@ import * as Routing from './routing';
 import { entityConfigKeys } from './schemas/entity';
 import { deriveSyntheticData, isSyntheticKey } from './synthetic';
 import { deepEqual, toStoredConfig } from './value';
-import type { EditorWorkspace } from './workspace';
+import { type EditorWorkspace, viewForWorkspace } from './workspace';
 import * as Config from '../../config/config';
 import * as Types from '../../config/types';
 import * as ViewConfig from '../../config/view';
@@ -433,6 +433,8 @@ export function withholdInertFields(
   view: EditorWorkspace,
   scope: 'card' | 'entity' = 'card',
 ): HaFormSchema[] {
+  const effectiveView = viewForWorkspace(view);
+
   return pruneLoneHeadings(
     filterNodes(
       schema,
@@ -441,11 +443,18 @@ export function withholdInertFields(
         if (isHeading(node)) return true;
 
         if (dataPath.length === 0) {
-          if (scope === 'card') return ViewConfig.appliesToView(node.name, view);
+          if (scope === 'card') {
+            return effectiveView === undefined
+              ? ViewConfig.appliesToSharedBase(node.name)
+              : ViewConfig.appliesToView(node.name, effectiveView);
+          }
 
           return entityConfigKeys(node.name).some((key) => {
             const views = ViewConfig.entityScopeFor(key);
-            return views === undefined || views.has(view);
+            if (effectiveView === undefined) {
+              return ViewConfig.appliesToSharedBase(key, ViewConfig.entityScopeFor);
+            }
+            return views === undefined || views.has(effectiveView);
           });
         }
 

--- a/src/rendering/editor/panels.ts
+++ b/src/rendering/editor/panels.ts
@@ -20,10 +20,12 @@ import * as Types from '../../config/types';
 /**
  * Everything a schema builder is allowed to read.
  *
- * 🚨 `view` and `workspace` carry the same value in the live editor and are still two
- * fields. `_ctx` in `element.ts` sets `const view = workspace`, so every call site's
- * `ctx.workspace ?? ctx.view` resolves to the workspace there whichever half it reads —
- * which makes the pair look like a redundancy to delete, and it is not.
+ * 🚨 The two carry the same value for the three view workspaces and differ for Shared,
+ * and they are two fields for that reason. `_ctx` in `element.ts` sets
+ * `view = baseViewForWorkspace(workspace)`, which is the identity everywhere except
+ * Shared, where it is `list` — so for a view workspace every call site's
+ * `ctx.workspace ?? ctx.view` resolves to the same thing whichever half it reads, which
+ * makes the pair look like a redundancy to delete, and it is not.
  *
  * `view` is what the card renders and is the only thing a builder can rely on, because it
  * is the only one that is required. `check:i18n` builds every schema from
@@ -34,8 +36,12 @@ import * as Types from '../../config/types';
  * `workspace` is what the editor is being *pointed at*, and it is optional because only
  * the live editor knows it. The two were genuinely different before the workspace
  * selector: the editor configured whatever the card displayed, so a user could not reach
- * a grid option without switching the card to grid. They are equal today because the
- * selector made pointing the editor the only way to change which view you configure.
+ * a grid option without switching the card to grid. Shared reopened that gap on purpose —
+ * it edits the base every view reads, so it has no view of its own and its panels are
+ * built as `list`, the one view that declares neither an only-key nor a divergent
+ * default and therefore makes no view-specific claim. Building them as whatever the card
+ * happened to display would have made a shared option appear and disappear from Shared as
+ * the user switched the card.
  *
  * So read `ctx.workspace ?? ctx.view` when you want the view whose values are being
  * edited — the storage destination, `withholdInertFields`, `valueSource` — and read

--- a/src/rendering/editor/routing.ts
+++ b/src/rendering/editor/routing.ts
@@ -6,7 +6,7 @@ import type { HaFormSchema, SelectorSchema } from './ha-form';
 import { normalizeFieldValue, normalizeRootValue } from './normalize';
 import * as Synthetic from './synthetic';
 import * as Value from './value';
-import { type EditorWorkspace, WORKSPACE_FIELD } from './workspace';
+import { type EditorWorkspace, WORKSPACE_FIELD, viewForWorkspace } from './workspace';
 import * as Config from '../../config/config';
 import type * as Types from '../../config/types';
 import * as ViewConfig from '../../config/view';
@@ -59,8 +59,13 @@ export function destination(
   key: string,
   workspace: EditorWorkspace,
 ): keyof Types.Config | undefined {
-  return ViewConfig.routeForKey(key, workspace) === 'block'
-    ? ViewConfig.viewBlockFor(workspace)?.blockKey
+  const view = viewForWorkspace(workspace);
+  // Shared *is* the root. Every key edited there is written at the top level, which is
+  // what makes it the one workspace that can still author a value for all three views.
+  if (view === undefined) return undefined;
+
+  return ViewConfig.routeForKey(key, view) === 'block'
+    ? ViewConfig.viewBlockFor(view)?.blockKey
     : undefined;
 }
 
@@ -74,14 +79,19 @@ const storedConfig = Helpers.memoizeLast((config: Readonly<Types.Config>) =>
  * @param config - Raw merged configuration
  * @param workspace - Editing workspace
  * @param name - Schema field name
- * @returns The source category, omitted for List and editor navigation
+ * @returns The source category, omitted for Shared and editor navigation
  */
 export function valueSource(
   config: Readonly<Types.Config>,
   workspace: EditorWorkspace,
   name: string,
 ): 'card' | 'inherited' | 'default' | 'own' | undefined {
-  const block = ViewConfig.viewBlockFor(workspace);
+  const view = viewForWorkspace(workspace);
+  // Shared has nothing to be sourced *from*: it is the base every other answer refers to,
+  // so labelling its controls would say "this value comes from here" on every row.
+  if (view === undefined) return undefined;
+
+  const block = ViewConfig.viewBlockFor(view);
   if (!block || name === 'view' || name === WORKSPACE_FIELD) return undefined;
   const keys = Synthetic.configKeysForField(name);
   if (!keys.some((key) => destination(key, workspace) === block.blockKey)) return 'card';
@@ -92,7 +102,7 @@ export function valueSource(
   )
     return 'own';
   return keys.some(
-    (key) => block.onlyKeys.includes(key) || ViewConfig.hasDivergentDefault(key, workspace),
+    (key) => block.onlyKeys.includes(key) || ViewConfig.hasDivergentDefault(key, view),
   )
     ? 'default'
     : 'inherited';
@@ -136,12 +146,15 @@ export function workspaceConfig(
       ...config,
     }),
   );
-  const view = workspace;
-  const effective = ViewConfig.resolveEffectiveConfig(root, view);
+  // Shared shows the base itself, so no block is resolved over it and `view` keeps the
+  // card's own value — the schema builders read that to decide what a preview looks like,
+  // and the shared base does not have a layout of its own to claim.
+  const view = viewForWorkspace(workspace);
+  const effective = view === undefined ? root : ViewConfig.resolveEffectiveConfig(root, view);
   const normalized = Object.fromEntries(
     Object.entries(effective).map(([key, value]) => [key, normalizeRootValue(key, value)]),
   );
-  return { ...effective, ...normalized, view };
+  return { ...effective, ...normalized, view: view ?? root.view };
 }
 
 /**
@@ -162,8 +175,8 @@ export function workspaceFormData(
     ViewConfig.VIEWS.flatMap((view) => {
       const block = ViewConfig.viewBlockFor(view);
       if (!block) return [];
-      const values =
-        view === 'grid' ? Value.timeGridFormBlock(config) : Value.columnFormBlock(config);
+      const values = Value.VIEW_FORM_BLOCKS[view]?.(config);
+      if (!values) return [];
       return [
         [
           block.blockKey,

--- a/src/rendering/editor/strings.ts
+++ b/src/rendering/editor/strings.ts
@@ -36,13 +36,14 @@ export const EDITOR_STRINGS: Readonly<Record<string, string>> = {
     'The card’s starting layout. Side-by-side layouts can fall back to List when space is tight.',
   editing_workspace: 'Editing Settings For',
   'editing_workspace.helper': 'Choose which layout to edit without changing Card Displays.',
-  'editing_workspace.list_note':
-    'Column and Grid may use these values too, unless that view has its own value for the option.',
+  'editing_workspace.shared_note':
+    'Every layout uses these values, unless that layout has its own value for the option.',
   'value_source.card': 'Applies to the whole card.',
   'value_source.inherited': 'Uses the card-wide value unless you change it here.',
   'value_source.default': 'Uses this layout’s default until you change it here.',
   'value_source.own': 'Set for this layout.',
   'value_source.reset': 'Reset {option}',
+  'editing_workspace.option.shared.label': 'All Layouts',
   'editing_workspace.option.list.label': 'List',
   'editing_workspace.option.column.label': 'Columns',
   'editing_workspace.option.grid.label': 'Grid',

--- a/src/rendering/editor/value.ts
+++ b/src/rendering/editor/value.ts
@@ -222,6 +222,49 @@ export function stripTimeGridDefaults(
 }
 
 /**
+ * Strips a `list:` block to what the user actually authored.
+ *
+ * 🚨 Presence *is* authorship here, so unlike `stripColumnDefaults` this keeps a value
+ * that equals what the key would inherit. That is deliberate and it is the one line that
+ * makes `list:` worth having beyond symmetry.
+ *
+ * `Helpers.filterDefaultValues` makes an authored root value equal to the shipped default
+ * unrepresentable — `event_font_size: '14px'` is indistinguishable from not having set it,
+ * which is why the editor carries an in-memory `_authoredRootKeys` set that dies with the
+ * dialog. A block entry has no such problem: nothing puts a key inside `list:` except a
+ * user editing List, so the key being there is the record. `stripTimeGridDefaults` already
+ * relies on this for grid's divergent-default keys; this generalizes it to the block.
+ *
+ * The cost is that a `list:` block can hold a line that changes nothing today. That is the
+ * point — it changes something the moment the shared root value beside it moves.
+ *
+ * @param config - Merged configuration, defaults already applied
+ * @returns The authored block, or `undefined` when it holds nothing
+ */
+export function stripListDefaults(
+  config: Readonly<Types.Config>,
+): Record<string, unknown> | undefined {
+  const block = config.list;
+
+  if (!Helpers.isConfigBlock(block)) {
+    return undefined;
+  }
+
+  const overrideKeys = new Set<string>(ViewConfig.LIST_OVERRIDE_KEYS);
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(block as Record<string, unknown>)) {
+    if (value === undefined) continue;
+    if (isSyntheticKey(key)) continue;
+    if (!overrideKeys.has(key)) continue;
+
+    result[key] = value;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
  * Removes the config keys that v3.0.0 deleted from the runtime.
  *
  * @param draft - Config being prepared for writing, mutated in place
@@ -245,6 +288,106 @@ function pruneDeprecatedKeys(draft: Record<string, unknown>): void {
 }
 
 /**
+ * Keys a v5 save moves out of the top level and into `list:`.
+ *
+ * Derived, never written out. Two groups, for two different reasons:
+ *
+ * 1. **List-only keys.** `VIEW_SCOPE` says no other view reads them, so the top level is
+ *    making a claim ("this is shared") that the card itself contradicts. Relocating them
+ *    corrects a factual error in the format and cannot change any view's rendering.
+ * 2. **Divergent-default keys.** Every view that disagrees with the shipped card-level
+ *    value does so because that value was written for list, back when list was the only
+ *    view. Recording them as list's is what lets a later change treat a *root* value as
+ *    genuinely shared instead of guessing whether it was meant for list.
+ *
+ * 🚨 Group 2 narrows a key's scope, so {@link relocateListKeys} applies it only to a card
+ * whose view is already `list`. See the guard there.
+ *
+ * @returns The two relocation groups
+ */
+/**
+ * The registry entry the v5 migration relocates into.
+ *
+ * Held as the block object rather than the view's name so the two comparisons below are
+ * identity checks. `tests/editor-schema.test.ts` forbids comparing against a view by name
+ * anywhere in this directory, and the reason is worth more than the rule: a fourth view
+ * must cost a registry entry and a string, not a hunt for string comparisons.
+ */
+const TARGET_BLOCK = ViewConfig.VIEW_BLOCKS.list;
+
+function listRelocationKeys(): { readonly listOnly: string[]; readonly divergent: string[] } {
+  const listOnly: string[] = [];
+  const divergent = new Set<string>();
+
+  for (const key of ViewConfig.LIST_OVERRIDE_KEYS) {
+    const scope = ViewConfig.VIEW_SCOPE[key];
+    if (scope && scope.size === 1 && scope.has('list')) listOnly.push(key);
+  }
+
+  for (const view of ViewConfig.VIEWS) {
+    const block = ViewConfig.viewBlockFor(view);
+    // Identity against the registry entry, never a comparison on the view's name. The
+    // target is *the block the migration writes into*, so a fourth view needs no edit
+    // here — and `tests/editor-schema.test.ts` forbids naming a view in this directory.
+    if (!block || block === TARGET_BLOCK) continue;
+    for (const key of Object.keys(block.defaultOverrides)) divergent.add(key);
+  }
+
+  return { listOnly, divergent: [...divergent].sort() };
+}
+
+/**
+ * Moves top-level values that were only ever list's into the `list:` block.
+ *
+ * Silent and on save, the shape `pruneDeprecatedKeys` already established. It runs on the
+ * stored shape, after defaults have been filtered out, so it can only ever see values the
+ * user authored.
+ *
+ * 🚨 Never changes what any view renders at the moment it runs. The list-only group is
+ * inert outside list by `VIEW_SCOPE`. The divergent group is guarded on `view === 'list'`
+ * because a `column:` card *inherits* most of those keys from the top level — relocating
+ * `event_font_size` out from under a column card would drop it from 18px to the shipped
+ * 14px with nothing on screen to explain why.
+ *
+ * 🚨 `includeDivergent` is what keeps the migration from eating the Shared workspace. Root
+ * is where Shared writes, and on a list card most divergent keys are exactly what a user
+ * goes to Shared to set once — so relocating them on the same save would silently move the
+ * value into `list:` and leave the other two views on the shipped default. Pass `false`
+ * whenever the edit came from Shared; the list-only half still moves, because no view but
+ * list can read it either way.
+ *
+ * @param stored - Stored configuration, mutated in place
+ * @param view - The card's configured view
+ * @param includeDivergent - Whether to move keys another view would inherit from root
+ */
+export function relocateListKeys(
+  stored: Record<string, unknown>,
+  view: Types.EffectiveView,
+  includeDivergent = true,
+): void {
+  const { listOnly, divergent } = listRelocationKeys();
+  const onTargetView = ViewConfig.viewBlockFor(view) === TARGET_BLOCK;
+  const moving = onTargetView && includeDivergent ? [...listOnly, ...divergent] : listOnly;
+
+  const block: Record<string, unknown> = Helpers.isConfigBlock(stored.list)
+    ? { ...(stored.list as Record<string, unknown>) }
+    : {};
+
+  let moved = false;
+  for (const key of moving) {
+    if (!Object.prototype.hasOwnProperty.call(stored, key)) continue;
+    // An existing block entry is the user's newer answer; the root value is the older one.
+    if (!Object.prototype.hasOwnProperty.call(block, key)) block[key] = stored[key];
+    delete stored[key];
+    moved = true;
+  }
+
+  if (!moved && !Helpers.isConfigBlock(stored.list)) return;
+  if (Object.keys(block).length > 0) stored.list = block;
+  else delete stored.list;
+}
+
+/**
  * Reduces a merged configuration to the smallest one that renders identically.
  *
  * @param config - Merged configuration as the form sees it
@@ -261,6 +404,9 @@ export function toStoredConfig(config: Readonly<Types.Config>): Record<string, u
 
   const atomic = ATOMIC_KEYS.map((key) => [key, draft[key]] as const);
   for (const [key] of atomic) delete draft[key];
+
+  const list = stripListDefaults(config);
+  delete draft.list;
 
   const column = stripColumnDefaults(config);
   delete draft.column;
@@ -280,6 +426,10 @@ export function toStoredConfig(config: Readonly<Types.Config>): Record<string, u
     if (value !== undefined && !deepEqual(value, Config.DEFAULT_CONFIG[key])) {
       stored[key] = value;
     }
+  }
+
+  if (list !== undefined) {
+    stored.list = list;
   }
 
   if (column !== undefined) {
@@ -482,6 +632,39 @@ export function timeGridFormBlock(config: Readonly<Types.Config>): Record<string
     ...(config.time_grid ?? {}),
   };
 }
+
+/**
+ * Builds the `list:` block as the form should show it.
+ *
+ * One layer where {@link columnFormBlock} has two, and the asymmetry is the point: list
+ * registers no keys of its own and no divergent defaults, so there is nothing to project.
+ * The card-level value *is* what list would use, and it is already bound as its own field
+ * at the top level — projecting it in here too would show the same number twice and make
+ * every unset option look authored.
+ *
+ * @param config - Merged configuration, defaults already applied
+ * @returns The stored block, unprojected
+ */
+export function listFormBlock(config: Readonly<Types.Config>): Record<string, unknown> {
+  return { ...((config.list ?? {}) as Record<string, unknown>) };
+}
+
+/**
+ * The form block builder for each view that owns one.
+ *
+ * A record rather than a conditional, because the conditional it replaces read
+ * `view === 'grid' ? grid : column` — correct while two views were registered and silently
+ * wrong the moment a third arrived, handing list the column projection and with it every
+ * `COLUMN_DEFAULTS` value. `tests/editor-value-round-trip.test.ts` reconciles this against
+ * `VIEW_BLOCKS`, so a view registered without a builder fails rather than inheriting one.
+ */
+export const VIEW_FORM_BLOCKS: Readonly<
+  Partial<Record<Types.EffectiveView, (config: Readonly<Types.Config>) => Record<string, unknown>>>
+> = {
+  list: listFormBlock,
+  column: columnFormBlock,
+  grid: timeGridFormBlock,
+};
 
 /**
  * Builds the `weather:` block as the form should show it.

--- a/src/rendering/editor/workspace.ts
+++ b/src/rendering/editor/workspace.ts
@@ -5,13 +5,60 @@
 import type { HaFormSchema } from './ha-form';
 import { select } from './schemas/common';
 import type * as Types from '../../config/types';
-import { VIEWS, viewBlockFor } from '../../config/view';
+import { VIEWS } from '../../config/view';
 
-export type EditorWorkspace = Types.EffectiveView;
+/**
+ * A workspace is a place values are written, which is not the same thing as a view.
+ *
+ * Three of the four name a view and write into that view's block. `'shared'` names the
+ * top level — the base every view reads when its own block is silent — so it is a real
+ * destination with no view behind it. It was deleted once, in the editor rework's Stage 5,
+ * on the correct finding that it was byte-identical to List; that was true only because
+ * list's keys lived at the top level. `list:` is what gives it a job.
+ */
+export type EditorWorkspace = Types.EffectiveView | 'shared';
 
 export const WORKSPACE_FIELD = 'editing_workspace';
 
-export const WORKSPACES: ReadonlyArray<EditorWorkspace> = VIEWS;
+export const WORKSPACES: ReadonlyArray<EditorWorkspace> = ['shared', ...VIEWS];
+
+/**
+ * The view a workspace edits, or `undefined` for the shared top level.
+ *
+ * 🚨 The one function every workspace-to-view decision goes through. Widening
+ * `EditorWorkspace` makes the compiler name each place `'shared'` cannot flow, but it is
+ * silent about the places that merely *read* a workspace and happen to typecheck — so the
+ * answer to a compiler error here is a decision about what Shared means, never a cast.
+ *
+ * @param workspace - Editing workspace
+ * @returns The view being edited, or `undefined` when the shared base is
+ */
+export function viewForWorkspace(workspace: EditorWorkspace): Types.EffectiveView | undefined {
+  return workspace === 'shared' ? undefined : workspace;
+}
+
+/**
+ * The view a workspace's *panels* are built as. Never `undefined`.
+ *
+ * Distinct from {@link viewForWorkspace} because a schema builder needs a view even where
+ * a destination does not exist. Shared answers `'list'`, and the choice is load-bearing
+ * rather than arbitrary: list is the base every other view widens — it registers no
+ * divergent defaults and no keys of its own — so building as list yields the panel shape
+ * that makes no view-specific claim. `appliesToSharedBase` then narrows the fields to the
+ * ones more than one view reads.
+ *
+ * 🚨 Do not answer this with the card's displayed view. Panel builders branch on it —
+ * `layoutSchema` drops the whole day/event spacing row for grid — so Shared would offer a
+ * different set of shared options depending on what the card happened to be displaying,
+ * and a value the user set on a list card would vanish from the surface that set it the
+ * moment they switched the card to grid.
+ *
+ * @param workspace - Editing workspace
+ * @returns The view its schema is built as
+ */
+export function baseViewForWorkspace(workspace: EditorWorkspace): Types.EffectiveView {
+  return workspace === 'shared' ? 'list' : workspace;
+}
 
 /**
  * Whether a form value names an editor workspace.
@@ -30,7 +77,7 @@ export function isWorkspace(value: unknown): value is EditorWorkspace {
  * @returns A note key when its values can also be used by other layouts
  */
 export function workspaceNote(workspace: EditorWorkspace): string | undefined {
-  return viewBlockFor(workspace) === undefined ? 'editing_workspace.list_note' : undefined;
+  return workspace === 'shared' ? 'editing_workspace.shared_note' : undefined;
 }
 
 /**

--- a/tests/accent-event-text.test.ts
+++ b/tests/accent-event-text.test.ts
@@ -585,6 +585,24 @@ describe('the editor toggle', () => {
     return Routing.workspaceFormData(config, config.view).accent_event_text as boolean;
   }
 
+  /**
+   * Reads a governed option the way the card does, through the view's own block.
+   *
+   * List's edits land in `list:` in v5 exactly as Column's land in `column:`, so reading
+   * the top level here would report `undefined` for a switch that is working — and the
+   * docblock above already says a view substituting its own default must write its own
+   * block. List is now such a view.
+   *
+   * @param config - Configuration to read
+   * @param key - Governed option
+   * @returns The value the view resolves
+   */
+  function effective(config: Types.Config, key: string): unknown {
+    return (
+      ViewConfig.resolveEffectiveConfig(config, config.view) as unknown as Record<string, unknown>
+    )[key];
+  }
+
   function toggle(config: Types.Config, value: boolean): Types.Config {
     const before = Routing.workspaceFormData(config, config.view);
     return Routing.applyWorkspaceChange(
@@ -629,16 +647,14 @@ describe('the editor toggle', () => {
     const on = toggle(buildConfig({ view: 'list' }), true);
 
     for (const key of governed) {
-      expect((on as unknown as Record<string, unknown>)[key]).toBe(ACCENT_TEXT_SENTINEL);
+      expect(effective(on, key)).toBe(ACCENT_TEXT_SENTINEL);
     }
     expect(form(on)).toBe(true);
 
     const off = toggle(on, false);
 
     for (const key of governed) {
-      expect((off as unknown as Record<string, unknown>)[key]).toBe(
-        DEFAULT_CONFIG[key as keyof Types.Config],
-      );
+      expect(effective(off, key)).toBe(DEFAULT_CONFIG[key as keyof Types.Config]);
     }
     expect(form(off)).toBe(false);
   });

--- a/tests/config-list-block.test.ts
+++ b/tests/config-list-block.test.ts
@@ -1,0 +1,274 @@
+/**
+ * The v5 `list:` block, and the one-way migration that fills it.
+ *
+ * Three separate contracts share this file because they only make sense together:
+ * the block is a peer of `column:` and `time_grid:` in the registry, the top level is
+ * now a shared base rather than list's storage, and an old configuration is relocated
+ * onto that arrangement the first time its owner saves from the editor.
+ *
+ * 🚨 The migration is deliberately asymmetric and the asymmetry is the whole safety
+ * argument, so it is asserted from both sides here. A key that is list-only by
+ * `VIEW_SCOPE` moves on any card, because no other view reads it either way. A key whose
+ * column or grid default *diverges* from the top-level one moves only on a card that is
+ * displaying list — moving it on a column card would hand column its own divergent
+ * default in place of the value the user had been seeing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConfig } from './fixtures';
+import { DEFAULT_CONFIG } from '../src/config/config';
+import type * as Types from '../src/config/types';
+import * as ViewConfig from '../src/config/view';
+import * as Value from '../src/rendering/editor/value';
+import * as Logger from '../src/utils/logger';
+
+/** The five keys `VIEW_SCOPE` restricts to list, derived rather than written out. */
+const LIST_ONLY = Object.keys(ViewConfig.VIEW_SCOPE).filter((key) => {
+  const scope = ViewConfig.VIEW_SCOPE[key];
+  return scope !== undefined && scope.size === 1 && scope.has('list');
+});
+
+/** Keys a registered view gives a different default from the top level. */
+const DIVERGENT = [
+  ...new Set(
+    Object.values(ViewConfig.VIEW_BLOCKS).flatMap((block) => Object.keys(block.defaultOverrides)),
+  ),
+];
+
+/**
+ * The registry entry, asserted present rather than assumed.
+ *
+ * @returns The list view's block
+ */
+function listBlock(): NonNullable<(typeof ViewConfig.VIEW_BLOCKS)['list']> {
+  const block = ViewConfig.VIEW_BLOCKS.list;
+  if (block === undefined) {
+    throw new Error('No list block registered — the whole of this file now proves nothing');
+  }
+  return block;
+}
+
+describe('the list block is a registered peer', () => {
+  it('registers alongside the other views and claims the `list` key', () => {
+    expect(Object.keys(ViewConfig.VIEW_BLOCKS).sort()).toEqual(['column', 'grid', 'list']);
+    expect(listBlock().blockKey).toBe('list');
+  });
+
+  it('makes no view-specific claim of its own', () => {
+    // Load-bearing rather than incidental. `baseViewForWorkspace` builds the Shared
+    // workspace's panels as list precisely because list adds no only-keys and no
+    // divergent defaults, so building as list asserts nothing about any view.
+    expect(listBlock().onlyKeys).toHaveLength(0);
+    expect(listBlock().defaultOverrides).toEqual({});
+  });
+
+  it('carries every key column can override, plus the five list-only ones', () => {
+    expect(new Set(ViewConfig.LIST_OVERRIDE_KEYS)).toEqual(
+      new Set([...ViewConfig.COLUMN_OVERRIDE_KEYS, ...LIST_ONLY]),
+    );
+    expect(LIST_ONLY).toHaveLength(5);
+  });
+
+  it('resolves a list override over the shared base', () => {
+    const config = buildConfig({
+      view: 'list',
+      event_font_size: '20px',
+      list: { event_font_size: '30px' },
+    } as unknown as Partial<Types.Config>);
+
+    expect(ViewConfig.resolveEffectiveConfig(config, 'list').event_font_size).toBe('30px');
+    expect(ViewConfig.resolveEffectiveConfig(config, 'column').event_font_size).toBe('20px');
+  });
+
+  it('leaves a configuration with no list block identical rather than copied', () => {
+    // The card memoizes on configuration identity and hands the result to caches that
+    // compare by reference, so allocating here would render correctly and turn every
+    // downstream comparison into a miss.
+    const config = buildConfig({ view: 'list' });
+
+    expect(ViewConfig.resolveEffectiveConfig(config, 'list')).toBe(config);
+  });
+});
+
+describe('validation reaches the list block', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  function messages(block: Record<string, unknown>): string[] {
+    ViewConfig.validateColumnOverrides(
+      buildConfig({ view: 'list', list: block } as unknown as Partial<Types.Config>),
+    );
+    return warn.mock.calls.map((call) => String(call[0]));
+  }
+
+  it('accepts an option the block may carry', () => {
+    expect(messages({ event_font_size: '20px' })).toEqual([]);
+  });
+
+  it('gives a fetch-time option its tailored diagnostic', () => {
+    expect(messages({ days_to_show: 7 }).join('\n')).toContain(
+      'it determines which events are loaded',
+    );
+  });
+
+  it('rejects another view\u2019s only-key', () => {
+    expect(messages({ hour_height: 40 }).join('\n')).toContain('Ignoring "list.hour_height"');
+  });
+});
+
+describe('the shared base refuses what has no top-level home', () => {
+  it('offers a key more than one view reads', () => {
+    expect(ViewConfig.appliesToSharedBase('event_font_size')).toBe(true);
+    expect(ViewConfig.appliesToSharedBase('empty_day_color')).toBe(true);
+  });
+
+  it('withholds a key only one view reads', () => {
+    for (const key of LIST_ONLY) {
+      expect(ViewConfig.appliesToSharedBase(key), key).toBe(false);
+    }
+  });
+
+  it('withholds a block-only key, which is unscoped for the opposite reason', () => {
+    // 🚨 The trap this guards. `hour_height` and `min_day_width` are absent from
+    // `VIEW_SCOPE` not because every view reads them but because they have no top-level
+    // home at all, so the unscoped-means-shared reading offers a control whose edits
+    // would be written where nothing reads them.
+    for (const key of ['hour_height', 'min_day_width']) {
+      expect(ViewConfig.appliesToSharedBase(key), key).toBe(false);
+    }
+  });
+});
+
+describe('empty_day_color is overridable per view', () => {
+  it('joins the routable set alongside the rest of its family', () => {
+    // It was the one member of the empty-day family stranded at the top level, so a
+    // column card could restyle the text and not the color it sits on.
+    expect(ViewConfig.COLUMN_OVERRIDE_KEYS).toContain('empty_day_color');
+
+    const config = buildConfig({
+      view: 'column',
+      empty_day_color: '#111111',
+      column: { empty_day_color: '#222222' },
+    } as unknown as Partial<Types.Config>);
+
+    expect(ViewConfig.resolveEffectiveConfig(config, 'column').empty_day_color).toBe('#222222');
+  });
+});
+
+describe('the migration relocates an old configuration', () => {
+  function relocate(
+    stored: Record<string, unknown>,
+    view: Types.EffectiveView,
+    includeDivergent = true,
+  ): Record<string, unknown> {
+    const copy = structuredClone(stored);
+    Value.relocateListKeys(copy, view, includeDivergent);
+    return copy;
+  }
+
+  it('moves a list-only key on a card displaying any view', () => {
+    for (const view of ['list', 'column', 'grid'] as Types.EffectiveView[]) {
+      const moved = relocate(
+        { entities: ['calendar.anna'], today_indicator_position: 'left' },
+        view,
+      );
+
+      expect(moved, view).toEqual({
+        entities: ['calendar.anna'],
+        list: { today_indicator_position: 'left' },
+      });
+    }
+  });
+
+  it('moves a divergent key only on a card displaying list', () => {
+    const stored = { entities: ['calendar.anna'], event_font_size: '18px' };
+
+    expect(relocate(stored, 'list')).toEqual({
+      entities: ['calendar.anna'],
+      list: { event_font_size: '18px' },
+    });
+
+    for (const view of ['column', 'grid'] as Types.EffectiveView[]) {
+      // Relocating here would replace the value column had been inheriting with column's
+      // own divergent default, changing what the user sees on a save they did not intend
+      // as a restyle.
+      expect(relocate(stored, view), view).toEqual(stored);
+    }
+  });
+
+  it('leaves a divergent key at the top level when the edit came from Shared', () => {
+    // The user is authoring the shared base at that moment, so moving what they just
+    // wrote into `list:` would undo the edit as it was saved.
+    expect(relocate({ event_font_size: '18px' }, 'list', false)).toEqual({
+      event_font_size: '18px',
+    });
+
+    // The list-only half still moves, because no other view reads it either way.
+    expect(relocate({ today_indicator_position: 'left' }, 'list', false)).toEqual({
+      list: { today_indicator_position: 'left' },
+    });
+  });
+
+  it('keeps an existing block entry, which is the newer answer of the two', () => {
+    expect(
+      relocate({ event_font_size: '18px', list: { event_font_size: '22px' } }, 'list'),
+    ).toEqual({ list: { event_font_size: '22px' } });
+  });
+
+  it('leaves a configuration that needs nothing moved untouched', () => {
+    const stored = { entities: ['calendar.anna'], days_to_show: 7, column: { columns: 3 } };
+
+    expect(relocate(stored, 'column')).toEqual(stored);
+    expect(relocate(stored, 'list')).toEqual(stored);
+  });
+
+  it('covers every relocatable key and nothing else', () => {
+    // Reconciled against the two sets rather than spot-checked, so a key leaving either
+    // one fails here instead of quietly narrowing what the migration reaches.
+    const listCard = relocate(
+      Object.fromEntries([...LIST_ONLY, ...DIVERGENT].map((key) => [key, 'x'])),
+      'list',
+    );
+
+    expect(Object.keys(listCard)).toEqual(['list']);
+    expect(new Set(Object.keys(listCard.list as object))).toEqual(
+      new Set([...LIST_ONLY, ...DIVERGENT]),
+    );
+  });
+});
+
+describe('presence in the list block is authorship', () => {
+  it('keeps a value equal to the shipped default rather than stripping it', () => {
+    // The point of the block. A value equal to the default is indistinguishable from an
+    // absent one at the top level, which is what made a renderer unable to tell an
+    // authored `false` from a defaulted one; inside `list:` its presence says it was
+    // chosen.
+    const stored = Value.toStoredConfig(
+      buildConfig({
+        view: 'list',
+        list: { show_past_events: DEFAULT_CONFIG.show_past_events },
+      } as unknown as Partial<Types.Config>),
+    );
+
+    expect(stored.list).toHaveProperty('show_past_events', DEFAULT_CONFIG.show_past_events);
+  });
+
+  it('still drops a key the block may not carry', () => {
+    const stored = Value.toStoredConfig(
+      buildConfig({
+        view: 'list',
+        list: { event_font_size: '20px', days_to_show: 7 },
+      } as unknown as Partial<Types.Config>),
+    );
+
+    expect(stored.list).toEqual({ event_font_size: '20px' });
+  });
+});

--- a/tests/config-partition.test.ts
+++ b/tests/config-partition.test.ts
@@ -31,7 +31,9 @@ import { describe, expect, it } from 'vitest';
 import {
   COLUMN_OVERRIDE_KEYS,
   FETCH_TIME_KEYS,
+  LIST_OVERRIDE_KEYS,
   VIEWS,
+  VIEW_BLOCKS,
   VIEW_SCOPE,
   routeForKey,
 } from '../src/config/view';
@@ -41,8 +43,11 @@ import { ATOMIC_KEYS } from '../src/rendering/editor/value';
  * The declared members of `Config`, read from the source.
  *
  * Read as text because an interface leaves nothing behind at runtime, and reading the
- * runtime `DEFAULT_CONFIG` instead would measure the defaults rather than the type —
- * `progress_bar_width` is a declared option with no default and would vanish.
+ * runtime `DEFAULT_CONFIG` instead would measure the defaults rather than the type. The
+ * two agree today only because every declared option without a real default is written
+ * out explicitly as `undefined` — `progress_bar_width` and `list` among them, and nothing
+ * enforces that habit. A member added to `Config` and forgotten in `DEFAULT_CONFIG` would
+ * be invisible to a runtime scan and is exactly what this file exists to catch.
  * `tests/editor-derived-field-mapping.test.ts` backs its own scan the same way.
  *
  * @returns Every top-level config key, in declaration order
@@ -57,7 +62,7 @@ function declaredConfigKeys(): string[] {
 }
 
 /** Options holding a nested block rather than a value of their own. */
-const CONTAINER_KEYS = ['weather', 'column', 'time_grid'] as const;
+const CONTAINER_KEYS = ['weather', 'list', 'column', 'time_grid'] as const;
 
 /**
  * Why an option is decided at card level rather than routed into a view's block.
@@ -88,15 +93,6 @@ const CARD_LEVEL_REASONS = {
 
   /** Stored whole rather than option by option; reconciled against `ATOMIC_KEYS` below. */
   action: ['tap_action', 'hold_action'],
-
-  /** Declared list-only in `VIEW_SCOPE`; reconciled against it below. */
-  'list-only': [
-    'compact_days_to_show',
-    'compact_events_to_show',
-    'compact_events_complete_days',
-    'today_indicator_position',
-    'date_vertical_alignment',
-  ],
 
   /**
    * The date column's ink. Every view draws a date, and none of them has ever offered to
@@ -130,8 +126,32 @@ const CARD_LEVEL_REASONS = {
 
 const CARD_LEVEL_KEYS = Object.values(CARD_LEVEL_REASONS).flat();
 
+/**
+ * Every key some registered view can hold in its block, derived from the registry.
+ *
+ * Deliberately *not* `LIST_OVERRIDE_KEYS` even though the two must agree: that constant is
+ * one of the things under test, so using it as the bucket would let a key vanish from the
+ * registry and the partition together. The reconciliation between the two is its own
+ * assertion below.
+ *
+ * `onlyKeys` are deliberately excluded: those live only inside a block and are not members
+ * of `Config` at all, so they were never part of this partition and would read as phantom.
+ *
+ * @returns Sorted union of every registered block's `overrideKeys`
+ */
+function routableKeys(): string[] {
+  const keys = new Set<string>();
+
+  for (const block of Object.values(VIEW_BLOCKS)) {
+    for (const key of block.overrideKeys) keys.add(key as string);
+  }
+
+  return [...keys].sort();
+}
+
 describe('config partition', () => {
   const declared = declaredConfigKeys();
+  const routable = routableKeys();
 
   it('reads a plausible number of options from the type', () => {
     expect(declared.length).toBeGreaterThan(90);
@@ -140,7 +160,7 @@ describe('config partition', () => {
 
   it('places every declared option in exactly one bucket', () => {
     const buckets: Record<string, ReadonlyArray<string>> = {
-      routable: COLUMN_OVERRIDE_KEYS,
+      routable,
       container: CONTAINER_KEYS,
       fetchTime: [...FETCH_TIME_KEYS].filter(
         (key) => !(CONTAINER_KEYS as ReadonlyArray<string>).includes(key),
@@ -164,7 +184,7 @@ describe('config partition', () => {
   it('names no option the type does not declare', () => {
     const known = new Set(declared);
     const phantom = [
-      ...COLUMN_OVERRIDE_KEYS,
+      ...routable,
       ...CONTAINER_KEYS,
       ...CARD_LEVEL_KEYS,
       ...[...FETCH_TIME_KEYS].filter(
@@ -181,11 +201,25 @@ describe('config partition', () => {
     );
 
     expect(
-      COLUMN_OVERRIDE_KEYS.length +
-        CONTAINER_KEYS.length +
-        fetchTime.length +
-        CARD_LEVEL_KEYS.length,
+      routable.length + CONTAINER_KEYS.length + fetchTime.length + CARD_LEVEL_KEYS.length,
     ).toBe(declared.length);
+  });
+
+  // The registry walk above and the declared constant have to agree, and neither is
+  // derived from the other — the constant is written as `COLUMN_OVERRIDE_KEYS` plus the
+  // list-only keys, the walk reads what every block actually carries. A block registered
+  // with the wrong key set fails here rather than shifting the partition unnoticed.
+  it('agrees with the widest declared override set', () => {
+    expect(routable).toEqual([...LIST_OVERRIDE_KEYS].sort());
+  });
+
+  // Every view widens the same base, so `COLUMN_OVERRIDE_KEYS` must remain a subset. It is
+  // the shared seed; list adds its own five on top and nothing may be dropped from it.
+  it('keeps the shared base a subset of the routable set', () => {
+    const missing = COLUMN_OVERRIDE_KEYS.filter((key) => !routable.includes(key));
+
+    expect(missing).toEqual([]);
+    expect(routable.length).toBeGreaterThan(COLUMN_OVERRIDE_KEYS.length);
   });
 });
 
@@ -202,14 +236,23 @@ describe('card-level reasons', () => {
     expect([...CARD_LEVEL_REASONS.action].sort()).toEqual([...ATOMIC_KEYS].sort());
   });
 
-  it('matches VIEW_SCOPE on the options declared list-only', () => {
+  // Since v5 list owns a block like the other two, so an option declared list-only in
+  // `VIEW_SCOPE` is routable into `list:` rather than stranded at card level. Asserted as
+  // an emptiness in both directions: no list-only key may be card-level, and every one
+  // must be routable. Before v5 this same set was a named card-level bucket.
+  it('routes every list-only option rather than deciding it at card level', () => {
     const declaredListOnly = Object.entries(VIEW_SCOPE)
       .filter(([, views]) => views.size === 1 && views.has('list'))
       .map(([key]) => key)
-      .filter((key) => CARD_LEVEL_KEYS.includes(key))
       .sort();
 
-    expect([...CARD_LEVEL_REASONS['list-only']].sort()).toEqual(declaredListOnly);
+    expect(declaredListOnly.length).toBeGreaterThan(0);
+    expect(declaredListOnly.filter((key) => CARD_LEVEL_KEYS.includes(key))).toEqual([]);
+    expect(
+      declaredListOnly.filter(
+        (key) => !(LIST_OVERRIDE_KEYS as ReadonlyArray<string>).includes(key),
+      ),
+    ).toEqual([]);
   });
 
   it('leaves no known scope gap unresolved', () => {
@@ -236,22 +279,31 @@ describe('card-level reasons', () => {
       .sort();
 
     expect(listAndColumn).toEqual([]);
+
+    // Reachability is the point, so say where they are reachable from as well as where
+    // they are not: both members of the pair carry through into `list:` too.
+    for (const key of ['empty_day_text', 'empty_day_color']) {
+      expect((LIST_OVERRIDE_KEYS as ReadonlyArray<string>).includes(key), key).toBe(true);
+    }
   });
 });
 
 describe('routeForKey', () => {
-  it('sends everything to the top level for a view with no block', () => {
+  // Since v5 every view owns a block, so there is no longer a view for which everything
+  // goes to the top level. What survives of that invariant is the half that still holds:
+  // a key no block carries is top-level *in every view*, list included.
+  it('sends an option no block carries to the top level in every view', () => {
     const routes = new Set(
-      [...COLUMN_OVERRIDE_KEYS, ...CARD_LEVEL_KEYS].map((key) => routeForKey(key, 'list')),
+      VIEWS.flatMap((view) => CARD_LEVEL_KEYS.map((key) => routeForKey(key, view))),
     );
 
     expect(routes).toEqual(new Set(['top-level']));
   });
 
   it('sends an overridable option into the block of a view that has one', () => {
-    const blockViews = VIEWS.filter((view) => view !== 'list');
+    const blockViews = VIEWS.filter((view) => VIEW_BLOCKS[view] !== undefined);
 
-    expect(blockViews.length).toBeGreaterThan(0);
+    expect(blockViews.length).toBe(VIEWS.length);
 
     for (const view of blockViews) {
       expect({ view, route: routeForKey('event_background_opacity', view) }).toEqual({

--- a/tests/editor-form-wiring.test.ts
+++ b/tests/editor-form-wiring.test.ts
@@ -178,9 +178,12 @@ describe('editor panel option forms', () => {
     change(lines, { ...formData(lines), title_max_lines: 3 });
     await element.updateComplete;
 
+    // Located by name rather than by position: `days_to_show` is fetch-time and stays at
+    // the top level, `title_max_lines` is a list override and lands in `list:` in v5. The
+    // subject is that both survive one report, not where either sits.
     expect(seen).toHaveLength(2);
     expect(seen[1].days_to_show).toBe(7);
-    expect(seen[1].title_max_lines).toBe(3);
+    expect(seen[1].list).toHaveProperty('title_max_lines', 3);
   });
 
   it('keeps the panel event inside the editor', async () => {

--- a/tests/editor-grid-reconciliation.test.ts
+++ b/tests/editor-grid-reconciliation.test.ts
@@ -62,6 +62,27 @@ async function change(editor: EditorHost, key: string, value: unknown): Promise<
   await editor.updateComplete;
 }
 
+/**
+ * Authors a value at the top level, then returns to the workspace the test was in.
+ *
+ * 🚨 The venue moved in v5 and the tests below would otherwise have gone on passing while
+ * testing nothing. Reconciliation copies a *root* value into a view's block on the first
+ * switch, so it only has a subject when root is where the value was authored. Root used to
+ * be list's storage, so an ordinary edit reached it; with `list:` registered an edit made
+ * in the List workspace is a list override, and grid inheriting it would be the leak this
+ * arrangement exists to close. Shared is where the shared base is authored now.
+ *
+ * @param editor - Mounted editor
+ * @param key - Option to author
+ * @param value - Value to author
+ */
+async function authorAtRoot(editor: EditorHost, key: string, value: unknown): Promise<void> {
+  const previous = formFor(editor, 'editing_workspace').data.editing_workspace;
+  await change(editor, 'editing_workspace', 'shared');
+  await change(editor, key, value);
+  await change(editor, 'editing_workspace', previous);
+}
+
 function notice(editor: EditorHost): HTMLElement | null {
   return editor.shadowRoot!.querySelector('[data-grid-reconciliation]');
 }
@@ -113,7 +134,7 @@ describe('first-switch reconciliation regressions', () => {
 
   it('tracks an authored root value introduced after the editor opened', async () => {
     const { editor, reports } = await mount();
-    await change(editor, 'event_font_size', '18px');
+    await authorAtRoot(editor, 'event_font_size', '18px');
     editor.setConfig(reports.at(-1)!);
     await editor.updateComplete;
     await change(editor, 'view', 'grid');
@@ -129,8 +150,8 @@ describe('first-switch reconciliation regressions', () => {
 
   it('tracks a newly authored suppression returned to its root default', async () => {
     const { editor, reports } = await mount();
-    await change(editor, 'show_past_events', true);
-    await change(editor, 'show_past_events', false);
+    await authorAtRoot(editor, 'show_past_events', true);
+    await authorAtRoot(editor, 'show_past_events', false);
     expect(reports.at(-1)).not.toHaveProperty('show_past_events');
     editor.setConfig(reports.at(-1)!);
     await editor.updateComplete;
@@ -223,7 +244,7 @@ describe('first-switch reconciliation regressions', () => {
     await change(editor, 'view', 'grid');
     expect(reports.at(-1)).toHaveProperty('time_grid.event_background_opacity', 5);
     await change(editor, 'view', 'list');
-    await change(editor, 'event_background_opacity', 65);
+    await authorAtRoot(editor, 'event_background_opacity', 65);
     await change(editor, 'view', 'grid');
     expect(reports.at(-1)).toHaveProperty('event_background_opacity', 65);
     expect(reports.at(-1)).toHaveProperty('time_grid.event_background_opacity', 5);
@@ -262,7 +283,12 @@ describe('first-switch reconciliation regressions', () => {
 
   it('forgets root authorship when an option is cleared and echoed without it', async () => {
     const { editor, reports } = await mount({ event_font_size: '18px' });
-    await change(editor, 'event_font_size', undefined);
+    // Cleared from Shared, because a view workspace cannot clear the shared base. Left on
+    // List this passed for the wrong reason: the clear was a no-op against an absent
+    // `list:` override, and the migration then moved root's value into `list:` — so the
+    // key had indeed left root, and the assertion below could not tell that apart from the
+    // clear it was written to check.
+    await authorAtRoot(editor, 'event_font_size', undefined);
     // Feeding a missing report back as setConfig(undefined) made the old control pass
     // without deleting anything. The emitted change is a necessary positive control.
     expect(reports).toHaveLength(1);
@@ -271,6 +297,11 @@ describe('first-switch reconciliation regressions', () => {
     await editor.updateComplete;
     await change(editor, 'view', 'grid');
     expect(reports.at(-1)).not.toHaveProperty('time_grid');
+
+    // Asked of Grid explicitly. Choosing a workspace pins it, and `authorAtRoot` chooses
+    // one — so the workspace no longer follows Card Displays here, and reading the control
+    // without saying which workspace would report List's value and look like a regression.
+    await change(editor, 'editing_workspace', 'grid');
     expect(formFor(editor, 'event_font_size').data.event_font_size).toBe('12px');
     expect(notice(editor)).toBeNull();
   });

--- a/tests/editor-layout-structure.test.ts
+++ b/tests/editor-layout-structure.test.ts
@@ -6,6 +6,11 @@ import * as Filter from '../src/rendering/editor/filter';
 import type { HaFormSchema } from '../src/rendering/editor/ha-form';
 import * as EditorLocalize from '../src/rendering/editor/localize';
 import { PANELS, type SchemaCtx } from '../src/rendering/editor/panels';
+import {
+  type EditorWorkspace,
+  WORKSPACES,
+  baseViewForWorkspace,
+} from '../src/rendering/editor/workspace';
 
 /**
  * The Layout panel's rendered order, flattened the way a reader sees it.
@@ -61,6 +66,47 @@ function renderedSubform(
     ...ctx,
     criteria: Filter.NO_FILTER,
   });
+}
+
+/**
+ * A schema context for one workspace, built the way the element builds it.
+ *
+ * 🚨 `view` is `baseViewForWorkspace(workspace)`, not the workspace. They coincide for
+ * the three view workspaces and diverge for Shared, which has no view of its own and
+ * builds as list. Passing `'shared'` as the view would not compile, and passing the
+ * card's displayed view would make Shared's contents follow whatever the card happened
+ * to show.
+ *
+ * @param workspace - Workspace being rendered
+ * @returns Context for the panel builders
+ */
+function ctxFor(workspace: EditorWorkspace): SchemaCtx {
+  const view = baseViewForWorkspace(workspace);
+  return {
+    config: buildConfig({ view, entities: [{ entity: 'calendar.anna' }] }),
+    view,
+    workspace,
+    language: 'en',
+  };
+}
+
+/**
+ * One panel's schema as the element renders it.
+ *
+ * 🚨 Mirrors `_renderPanel`, which withholds inert fields before anything else touches
+ * the schema. Walking `panel.build(ctx)` raw would make every workspace identical — and
+ * Shared exists precisely because withholding is what distinguishes it, so a test reading
+ * the declaration would report Shared as covered while measuring list four times.
+ *
+ * @param panel - Panel definition
+ * @param ctx - Schema context, whose workspace decides the withholding
+ * @returns The nodes the element hands to `ha-form`
+ */
+function renderedPanel(
+  panel: (typeof PANELS)[number],
+  ctx: SchemaCtx,
+): ReadonlyArray<HaFormSchema> {
+  return Filter.withholdInertFields(panel.build(ctx), ctx.workspace ?? ctx.view);
 }
 
 function layoutOutline(view: Types.EffectiveView): string[] {
@@ -139,13 +185,10 @@ describe('Collapsibles come last in every panel', () => {
   // Stated as a property, not as a list: nothing after the first collapsible may be
   // anything other than a collapsible. That covers panels nobody has written yet, which a
   // per-panel expectation would not.
-  const views = ['list', 'column', 'grid'] as const;
-
-  for (const view of views) {
+  for (const workspace of WORKSPACES) {
     for (const panel of PANELS) {
-      it(`${panel.id} in ${view}`, () => {
-        const config = buildConfig({ view, entities: [{ entity: 'calendar.anna' }] });
-        const entries = outline(panel.build({ config, view, language: 'en' }));
+      it(`${panel.id} in ${workspace}`, () => {
+        const entries = outline(renderedPanel(panel, ctxFor(workspace)));
         const first = entries.findIndex((entry) => entry.startsWith('['));
         if (first === -1) {
           return;
@@ -175,8 +218,6 @@ describe('No collapsible opens onto fewer than two controls', () => {
   //
   // Default config, because that is the state a new user meets; a group that fills up once
   // its switch is on was never the problem.
-  const views = ['list', 'column', 'grid'] as const;
-
   /** Every operable control below a node, across rows and nested groups alike. */
   function controls(schema: ReadonlyArray<HaFormSchema>): number {
     return schema.reduce(
@@ -200,34 +241,57 @@ describe('No collapsible opens onto fewer than two controls', () => {
     }
   }
 
-  for (const view of views) {
-    it(`${view} has no one-control disclosure`, () => {
-      const config = buildConfig({ view, entities: [{ entity: 'calendar.anna' }] });
-      const ctx: SchemaCtx = { config, view, language: 'en' };
+  /** Operable controls a workspace shows, panels and per-calendar sub-forms alike. */
+  const reach = new Map<EditorWorkspace, number>();
+
+  for (const workspace of WORKSPACES) {
+    it(`${workspace} has no one-control disclosure`, () => {
+      const ctx = ctxFor(workspace);
       const found: string[] = [];
       let seen = 0;
 
       for (const panel of PANELS) {
-        const schema = panel.build(ctx);
+        const schema = renderedPanel(panel, ctx);
         seen += controls(schema);
-        thin(schema, `${view}/${panel.id}`, found);
+        thin(schema, `${workspace}/${panel.id}`, found);
 
         // The per-calendar subform is reached through `subforms`, not through `build`, so
         // a walk of the panels alone never sees its thirty-odd fields. It is flat today;
         // this is what notices if it stops being.
         for (const sub of panel.subforms?.(ctx) ?? []) {
-          seen += controls(sub.schema);
-          thin(sub.schema, `${view}/${panel.id}:subform`, found);
+          const rendered = renderedSubform(sub, ctx);
+          seen += controls(rendered);
+          thin(rendered, `${workspace}/${panel.id}:subform`, found);
         }
       }
 
       // The denominator, beside the verdict rather than in a step of its own: an empty
       // `found` proves nothing if the walk reached nothing, and a walk that silently
       // stopped covering the editor is exactly the failure this file already had once.
-      expect(seen, 'the walk found no controls at all').toBeGreaterThan(100);
+      //
+      // Ninety rather than a hundred because Shared withholds every view-scoped key by
+      // design and legitimately walks fewer controls than any single view. The constant
+      // is only a floor under "did the walk reach the editor"; the test below carries the
+      // part that used to be implied in it.
+      reach.set(workspace, seen);
+      expect(seen, 'the walk found no controls at all').toBeGreaterThan(90);
       expect(found).toEqual([]);
     });
   }
+
+  it('shows Shared strictly fewer controls than List, and not far fewer', () => {
+    // 🚨 The failure this replaces a magic number with. A Shared workspace that stopped
+    // withholding would be byte-identical to List — which is what an earlier Shared
+    // actually was, measured across 63 configurations, and why it was deleted. Equality
+    // here is the whole feature quietly doing nothing, and no count-against-a-constant
+    // can see it because both numbers would be comfortably above any floor.
+    const shared = reach.get('shared');
+    const list = reach.get('list');
+
+    expect({ shared, list }).toEqual({ shared: expect.any(Number), list: expect.any(Number) });
+    expect(shared!).toBeLessThan(list!);
+    expect(list! - shared!).toBeLessThan(20);
+  });
 });
 
 describe('The card and the per-calendar subform caption the same switches alike', () => {
@@ -297,9 +361,8 @@ describe('The card and the per-calendar subform caption the same switches alike'
  * and this fails until the list matches again.
  */
 describe('No two adjacent fields share a label', () => {
-  function adjacentDuplicates(view: Types.EffectiveView): string[] {
-    const config = buildConfig({ view, entities: [{ entity: 'calendar.anna' }] });
-    const ctx: SchemaCtx = { config, view, language: 'en' };
+  function adjacentDuplicates(workspace: EditorWorkspace): string[] {
+    const ctx = ctxFor(workspace);
     const found: string[] = [];
 
     for (const panel of PANELS) {
@@ -363,9 +426,9 @@ describe('No two adjacent fields share a label', () => {
     'events: "Accent Color" = accent_color_mode + accent_color',
   ];
 
-  for (const view of ['list', 'column', 'grid'] as Types.EffectiveView[]) {
-    it(`has only the known pair in the ${view} workspace`, () => {
-      expect(adjacentDuplicates(view)).toEqual(KNOWN);
+  for (const workspace of WORKSPACES) {
+    it(`has only the known pair in the ${workspace} workspace`, () => {
+      expect(adjacentDuplicates(workspace)).toEqual(KNOWN);
     });
   }
 });
@@ -394,10 +457,9 @@ describe('Sub-forms are view-scoped like the panels above them', () => {
     });
   }
 
-  for (const view of ['list', 'column', 'grid'] as Types.EffectiveView[]) {
-    it(`renders the sub-form scoped to ${view}`, () => {
-      const config = buildConfig({ view, entities: [{ entity: 'calendar.anna' }] });
-      const ctx: SchemaCtx = { config, view, language: 'en' };
+  for (const workspace of WORKSPACES) {
+    it(`renders the sub-form scoped to ${workspace}`, () => {
+      const ctx = ctxFor(workspace);
       let seen = 0;
       let subforms = 0;
 
@@ -415,9 +477,9 @@ describe('Sub-forms are view-scoped like the panels above them', () => {
             where,
             offered: fieldNames(subform.schema).filter(
               (name) =>
-                !fieldNames(Filter.withholdInertFields(subform.schema, view, 'entity')).includes(
-                  name,
-                ),
+                !fieldNames(
+                  Filter.withholdInertFields(subform.schema, ctx.workspace ?? ctx.view, 'entity'),
+                ).includes(name),
             ),
           });
         }
@@ -448,10 +510,9 @@ describe('No sub-form heading is left captioning nothing', () => {
     });
   }
 
-  for (const view of ['list', 'column', 'grid'] as Types.EffectiveView[]) {
-    it(`captions at least one field per heading in ${view}`, () => {
-      const config = buildConfig({ view, entities: [{ entity: 'calendar.anna' }] });
-      const ctx: SchemaCtx = { config, view, language: 'en' };
+  for (const workspace of WORKSPACES) {
+    it(`captions at least one field per heading in ${workspace}`, () => {
+      const ctx = ctxFor(workspace);
       let headings = 0;
 
       for (const panel of PANELS) {

--- a/tests/editor-routing.test.ts
+++ b/tests/editor-routing.test.ts
@@ -727,3 +727,56 @@ describe('reset controls follow the workspace destination, not the built view', 
     expect(seen).toHaveLength(0);
   });
 });
+
+/**
+ * 🚨 The companion to the reset guard: `showsLocation` reaches a block by view name, so
+ * naming a view for the shared workspace consults a block that workspace cannot write to.
+ * Once `list:` existed, a card that turned locations off in list alone hid `location_icon`
+ * in Shared, while column and grid still drew locations.
+ *
+ * The List arm is the control. Without it a gate that hides the field everywhere passes.
+ */
+describe('entity subforms resolve show_location against the layer being edited', () => {
+  const hasLocationIcon = (editor: CalendarCardProEditor) =>
+    [...editor.shadowRoot!.querySelectorAll<Form>('ha-form')].some((form) =>
+      JSON.stringify((form as unknown as { schema?: unknown }).schema ?? []).includes(
+        'location_icon',
+      ),
+    );
+
+  const openWorkspace = async (editor: CalendarCardProEditor, workspace: string) => {
+    emit(editor.shadowRoot!.querySelector<Form>('ha-form.workspace-form')!, {
+      editing_workspace: workspace,
+    });
+    await editor.updateComplete;
+  };
+
+  const mountLocationCard = async () =>
+    mount({
+      view: 'list',
+      show_location: true,
+      list: { show_location: false },
+      column: {},
+      time_grid: {},
+    });
+
+  it('hides the location icon in the workspace whose block turned locations off', async () => {
+    const { editor } = await mountLocationCard();
+    await openWorkspace(editor, 'list');
+    expect(hasLocationIcon(editor)).toBe(false);
+  });
+
+  it('keeps the location icon in the shared workspace, which no block covers', async () => {
+    const { editor } = await mountLocationCard();
+    await openWorkspace(editor, 'shared');
+    expect(hasLocationIcon(editor)).toBe(true);
+  });
+
+  it('keeps the location icon in workspaces that still draw locations', async () => {
+    const { editor } = await mountLocationCard();
+    await openWorkspace(editor, 'column');
+    expect(hasLocationIcon(editor)).toBe(true);
+    await openWorkspace(editor, 'grid');
+    expect(hasLocationIcon(editor)).toBe(true);
+  });
+});

--- a/tests/editor-routing.test.ts
+++ b/tests/editor-routing.test.ts
@@ -41,43 +41,49 @@ const lengthKeys = View.COLUMN_OVERRIDE_KEYS.filter(
 );
 
 describe('workspace routing uses the actual destination', () => {
-  it.each(['column', 'grid'] as const)(
-    'writes %s presentation options only into its block',
-    (workspace) => {
-      const config = buildConfig({
-        view: 'list',
-        event_font_size: '17px',
-        column: { event_spacing: '3em' },
-        time_grid: { day_spacing: '2px' },
-      });
-      const past = !Routing.workspaceFormData(config, workspace).show_past_events;
-      const result = apply(config, workspace, { event_font_size: '23px', show_past_events: past });
-      const key = View.OVERRIDE_BLOCK_BY_VIEW[workspace]!;
-      expect(result.config[key]).toMatchObject({ event_font_size: '23px', show_past_events: past });
-      expect(result.config.event_font_size).toBe('17px');
-      expect(result.config.view).toBe('list');
-      expect(result.config[workspace === 'grid' ? 'column' : 'time_grid']).toEqual(
-        config[workspace === 'grid' ? 'column' : 'time_grid'],
-      );
-    },
-  );
-
-  it('keeps List and card-wide edits at root while preserving explicit view values', () => {
+  // Driven off `VIEWS` rather than the `['column', 'grid']` pair this replaced. That pair
+  // was written when list had no block and root was list's storage, so it stated the
+  // asymmetry as a fact; with `list:` registered it would have gone on passing while
+  // saying nothing about the view most cards use.
+  it.each(View.VIEWS)('writes %s presentation options only into its block', (workspace) => {
     const config = buildConfig({
-      view: 'grid',
-      day_spacing: '10px',
-      column: { day_spacing: '4px' },
+      view: 'list',
+      event_font_size: '17px',
+      list: { day_spacing: '7px' },
+      column: { event_spacing: '3em' },
       time_grid: { day_spacing: '2px' },
     });
-    const list = apply(config, 'list', { day_spacing: '3em' }).config;
-    expect(list.day_spacing).toBe('3em');
-    expect(list.column).toEqual(config.column);
-    expect(list.time_grid).toEqual(config.time_grid);
-    const global = apply(list, 'grid', { title: 'Example', days_to_show: 9 }).config;
-    expect(global.title).toBe('Example');
-    expect(global.days_to_show).toBe(9);
-    expect(global.time_grid).not.toHaveProperty('title');
-    expect(global.time_grid).not.toHaveProperty('days_to_show');
+    const past = !Routing.workspaceFormData(config, workspace).show_past_events;
+    const result = apply(config, workspace, { event_font_size: '23px', show_past_events: past });
+    const key = View.OVERRIDE_BLOCK_BY_VIEW[workspace]!;
+
+    expect(result.config[key]).toMatchObject({ event_font_size: '23px', show_past_events: past });
+    expect(result.config.event_font_size).toBe('17px');
+    expect(result.config.view).toBe('list');
+
+    // Every other registered block, found rather than named — the `grid ? column :
+    // time_grid` conditional this replaces could only ever check one of two.
+    for (const other of View.VIEWS) {
+      const otherKey = View.OVERRIDE_BLOCK_BY_VIEW[other]!;
+      if (otherKey === key) continue;
+      expect(result.config[otherKey], otherKey).toEqual(config[otherKey]);
+    }
+  });
+
+  it('keeps a card-wide edit at root from every workspace', () => {
+    // The layered arrangement's other half. Presentation options route into the
+    // workspace's block; a card-wide option has no per-view meaning and must stay at root
+    // wherever it was edited, or a title set in Grid would vanish on switching to List.
+    for (const workspace of View.VIEWS) {
+      const config = buildConfig({ view: 'grid', column: { day_spacing: '4px' } });
+      const result = apply(config, workspace, { title: 'Example', days_to_show: 9 }).config;
+      const key = View.OVERRIDE_BLOCK_BY_VIEW[workspace]!;
+
+      expect(result.title, workspace).toBe('Example');
+      expect(result.days_to_show, workspace).toBe(9);
+      expect(result[key] ?? {}, workspace).not.toHaveProperty('title');
+      expect(result[key] ?? {}, workspace).not.toHaveProperty('days_to_show');
+    }
   });
 
   it('projects each view rather than the card’s displayed view', () => {
@@ -407,7 +413,7 @@ function emit(form: Form, data: Record<string, unknown>): void {
     new CustomEvent('value-changed', { detail: { value: data }, bubbles: true, composed: true }),
   );
 }
-async function mount() {
+async function mount(extra: Record<string, unknown> = {}) {
   const editor = new CalendarCardProEditor();
   editor.hass = {
     states: {},
@@ -421,6 +427,7 @@ async function mount() {
       event_font_size: '17px',
       column: { event_font_size: '19px' },
       time_grid: { event_font_size: '23px' },
+      ...extra,
     }),
   );
   document.body.appendChild(editor);
@@ -437,10 +444,18 @@ afterEach(() => {
 });
 
 describe('rendered form frames preserve edit intent', () => {
+  /**
+   * 🚨 Shared, not List, and the move is the whole point of the layered arrangement.
+   * Root used to be list's storage, so clearing a value from the List workspace cleared
+   * root. With `list:` registered, List writes into its own block and root is the shared
+   * base — so this case had to follow root to the workspace that now owns it. Left on
+   * List it would have gone on passing the moment anything put a `list:` value in the
+   * fixture, while testing something else entirely.
+   */
   it('clears a root option without restoring it from the previous object', async () => {
     const { editor, seen } = await mount();
     emit(editor.shadowRoot!.querySelector<Form>('ha-form.workspace-form')!, {
-      editing_workspace: 'list',
+      editing_workspace: 'shared',
     });
     await editor.updateComplete;
     const form = owner(editor, 'event_font_size');
@@ -451,6 +466,30 @@ describe('rendered form frames preserve edit intent', () => {
     expect(seen[0].column).toEqual({ event_font_size: '19px' });
     expect(seen[0].time_grid).toEqual({ event_font_size: '23px' });
     expect(owner(editor, 'event_font_size').data.event_font_size).toBe('14px');
+  });
+
+  /**
+   * The other half, and the one that is new. Clearing from List drops the *list* override
+   * and leaves the shared base standing — so the control falls back to root rather than to
+   * the shipped default, which is what distinguishes layered from three parallel views.
+   */
+  it('clears a list override back to the shared base rather than to the default', async () => {
+    const { editor, seen } = await mount({ list: { event_font_size: '21px' } });
+    emit(editor.shadowRoot!.querySelector<Form>('ha-form.workspace-form')!, {
+      editing_workspace: 'list',
+    });
+    await editor.updateComplete;
+
+    expect(owner(editor, 'event_font_size').data.event_font_size).toBe('21px');
+
+    const form = owner(editor, 'event_font_size');
+    emit(form, { ...form.data, event_font_size: undefined });
+    await editor.updateComplete;
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).not.toHaveProperty('list');
+    expect(seen[0].event_font_size).toBe('17px');
+    expect(owner(editor, 'event_font_size').data.event_font_size).toBe('17px');
   });
 
   it('clears root values written by a synthetic mode control', async () => {

--- a/tests/editor-routing.test.ts
+++ b/tests/editor-routing.test.ts
@@ -675,3 +675,55 @@ describe('rendered form frames preserve edit intent', () => {
     expect(owner(editor, 'event_font_size').data.event_font_size).toBe('12px');
   });
 });
+
+/**
+ * 🚨 The reset controls are the one place a workspace's *destination* is asked for, and
+ * `ctx.view` stopped being able to answer it when `list:` gained a block. The shared
+ * workspace builds its panels as list, so `ctx.view` reads `'list'` there — a guard on it
+ * offered Shared the reset buttons belonging to `list:`, and clicking one deleted a List
+ * override from a workspace that cannot write to `list:` at all.
+ *
+ * Both directions are pinned. Dropping the shared case lets the regression back in
+ * silently; dropping the list case lets a guard that returns nothing everywhere pass.
+ */
+describe('reset controls follow the workspace destination, not the built view', () => {
+  const resetKeys = (editor: CalendarCardProEditor) =>
+    [...editor.shadowRoot!.querySelectorAll('[data-reset-keys]')].map((node) =>
+      node.getAttribute('data-reset-keys'),
+    );
+
+  const mountListCard = async () =>
+    mount({
+      view: 'list',
+      event_font_size: '17px',
+      list: { event_font_size: '18px' },
+      column: {},
+      time_grid: {},
+    });
+
+  const select = async (editor: CalendarCardProEditor, workspace: string) => {
+    emit(editor.shadowRoot!.querySelector<Form>('ha-form.workspace-form')!, {
+      editing_workspace: workspace,
+    });
+    await editor.updateComplete;
+  };
+
+  it('offers a list override its reset in the List workspace', async () => {
+    const { editor } = await mountListCard();
+    await select(editor, 'list');
+    expect(resetKeys(editor)).toContain('event_font_size');
+  });
+
+  it('offers no resets in the shared workspace, which inherits from nothing', async () => {
+    const { editor } = await mountListCard();
+    await select(editor, 'shared');
+    expect(resetKeys(editor)).toEqual([]);
+  });
+
+  it('leaves a list override untouched when the shared workspace is open', async () => {
+    const { editor, seen } = await mountListCard();
+    await select(editor, 'shared');
+    expect(editor.shadowRoot!.querySelector('[data-reset-keys="event_font_size"]')).toBeNull();
+    expect(seen).toHaveLength(0);
+  });
+});

--- a/tests/editor-schema.test.ts
+++ b/tests/editor-schema.test.ts
@@ -14,6 +14,7 @@ import {
   TIME_GRID_DEFAULT_OVERRIDES,
   TIME_GRID_ONLY_KEYS,
   VIEWS,
+  VIEW_BLOCKS,
   VIEW_SCOPE,
   appliesToView,
   describeColumnLayoutBands,
@@ -1534,8 +1535,16 @@ describe('editor: the chassis', () => {
 
     await change({ height_mode: 'fixed' });
 
-    expect(dispatched[0]).not.toHaveProperty('height_mode');
-    expect(dispatched[0].height).toBe('300px');
+    const stored = dispatched[0] as Record<string, unknown>;
+    const block = (stored.list ?? {}) as Record<string, unknown>;
+
+    expect(stored).not.toHaveProperty('height_mode');
+    expect(block).not.toHaveProperty('height_mode');
+
+    // Asserted wherever the router put it rather than at root. The List workspace writes
+    // into `list:`, the same way Column and Grid write into theirs — pinning the location
+    // here would make this a test of the routing table rather than of the synthetic key.
+    expect(block.height ?? stored.height).toBe('300px');
   });
 
   it('mounts one form per registered panel', async () => {
@@ -1835,10 +1844,15 @@ describe('editor: the panel set', () => {
       max_height: 'height_mode',
     };
 
-    // `weather`, `column` and `time_grid` are containers offered as their members rather than
-    // under their own name, so none is expected here. Their members are reconciled by the
-    // test below — skipping a container here once skipped everything inside it too.
-    const containers = new Set(['weather', 'column', 'time_grid']);
+    // `weather` and every registered view block are containers offered as their members
+    // rather than under their own name, so none is expected here. Their members are
+    // reconciled by the test below — skipping a container here once skipped everything
+    // inside it too. The view blocks are read off the registry, so a fourth view arrives
+    // covered rather than reported as a missing option.
+    const containers = new Set([
+      'weather',
+      ...Object.values(VIEW_BLOCKS).map((block) => block.blockKey),
+    ]);
 
     const missing = Object.keys(DEFAULT_CONFIG).filter((key) => {
       if (containers.has(key)) return false;
@@ -2789,6 +2803,38 @@ describe('editor: the write path over the whole configuration', () => {
    * A configuration with every top-level option set to something other than its
    * default, so that nothing is tested by accident of matching a default.
    */
+  const VIEW_BLOCK_KEYS = new Set<string>(
+    Object.values(VIEW_BLOCKS).map((block) => block.blockKey),
+  );
+
+  /**
+   * A block whose single entry cannot be mistaken for the value it would inherit.
+   *
+   * 🚨 The strip drops a block entry equal to what the block would inherit from root, and
+   * `everythingSet` flips every boolean at root — so a block written as
+   * `{ show_location: false }` beside a root `show_location: false` is stripped to nothing
+   * and the container reads as *lost*. Writing the shipped default instead guarantees the
+   * pair differ, whatever the flip produced.
+   *
+   * Found on the registry rather than named, so a fourth view needs no edit here. Every
+   * block shares `COLUMN_OVERRIDE_KEYS`, so a boolean member always exists; the assertion
+   * says so rather than letting an empty block quietly weaken the test.
+   *
+   * @param blockKey - The block's YAML key
+   * @returns A one-entry block that survives the strip
+   */
+  function blockThatSurvivesTheStrip(blockKey: string): Record<string, unknown> {
+    const block = Object.values(VIEW_BLOCKS).find((entry) => entry.blockKey === blockKey);
+    const key = block?.overrideKeys.find(
+      (candidate) =>
+        typeof (DEFAULT_CONFIG as unknown as Record<string, unknown>)[candidate] === 'boolean',
+    );
+
+    expect(key, `${blockKey} has no boolean override to write`).toBeDefined();
+
+    return { [key!]: (DEFAULT_CONFIG as unknown as Record<string, unknown>)[key!] };
+  }
+
   function everythingSet(): Types.Config {
     const custom: Record<string, unknown> = {};
 
@@ -2796,8 +2842,7 @@ describe('editor: the write path over the whole configuration', () => {
       if (key === 'entities') custom[key] = ['calendar.a'];
       else if (key === 'view') custom[key] = 'column';
       else if (key === 'weather') custom[key] = { ...(value as object), entity: 'weather.home' };
-      else if (key === 'column') custom[key] = { min_day_width: 200, show_location: false };
-      else if (key === 'time_grid') custom[key] = { min_day_width: 120, show_location: false };
+      else if (VIEW_BLOCK_KEYS.has(key)) custom[key] = blockThatSurvivesTheStrip(key);
       else if (key === 'tap_action' || key === 'hold_action')
         custom[key] = { action: 'navigate', navigation_path: '/x' };
       else if (typeof value === 'boolean') custom[key] = !value;

--- a/tests/editor-value-round-trip.test.ts
+++ b/tests/editor-value-round-trip.test.ts
@@ -17,7 +17,12 @@ import '../src/calendar-card-pro';
 import * as Config from '../src/config/config';
 import type * as Types from '../src/config/types';
 import * as ViewConfig from '../src/config/view';
-import { columnFormBlock, timeGridFormBlock, toStoredConfig } from '../src/rendering/editor/value';
+import {
+  VIEW_FORM_BLOCKS,
+  columnFormBlock,
+  timeGridFormBlock,
+  toStoredConfig,
+} from '../src/rendering/editor/value';
 
 /** The config `setConfig` would hold for a given piece of user YAML. */
 function asSetConfigWould(raw: Record<string, unknown>): Types.Config {
@@ -199,10 +204,13 @@ describe('the card element fills nested blocks on setConfig', () => {
  * views.
  */
 describe('a view block survives the round trip the panel puts it through', () => {
-  const formBlockFor: Record<string, (config: Types.Config) => Record<string, unknown>> = {
-    column: columnFormBlock,
-    grid: timeGridFormBlock,
-  };
+  // Production's own dispatch, not a copy of it. A copy would be a second table to keep
+  // in step, and the defect this file exists to report is exactly a view that reaches the
+  // panel without a builder — which a private copy would hide by supplying one.
+  const formBlockFor = VIEW_FORM_BLOCKS as Record<
+    string,
+    ((config: Types.Config) => Record<string, unknown>) | undefined
+  >;
 
   it.each(Object.keys(ViewConfig.VIEW_BLOCKS))('keeps a stored %s override', (view) => {
     const block = ViewConfig.VIEW_BLOCKS[view as Types.EffectiveView];
@@ -230,10 +238,13 @@ describe('a view block survives the round trip the panel puts it through', () =>
       [blockKey!]: { [key!]: false },
     });
 
-    expect(buildBlock(config)[key!], `${view}.${key} missing from the form block`).toBe(false);
-    expect(toStoredConfig({ ...config, [blockKey!]: buildBlock(config) })).toEqual({
+    expect(buildBlock!(config)[key!], `${view}.${key} missing from the form block`).toBe(false);
+    expect(toStoredConfig({ ...config, [blockKey!]: buildBlock!(config) })).toEqual({
       entities: [{ entity: 'calendar.a' }],
-      view,
+      // The strip prunes a `view` equal to the default, so the default view's case must
+      // not expect one back. Derived rather than special-cased on the name, so moving the
+      // default to another view does not quietly turn this into a test of nothing.
+      ...(view === Config.DEFAULT_CONFIG.view ? {} : { view }),
       [blockKey!]: { [key!]: false },
     });
   });
@@ -250,7 +261,7 @@ describe('a view block survives the round trip the panel puts it through', () =>
       view,
       [blockKey]: { [key]: value },
     });
-    const block = formBlockFor[view](config);
+    const block = formBlockFor[view]!(config);
 
     expect(block[key], `${view}.${key} missing from the form block`).toBe(value);
     expect(toStoredConfig({ ...config, [blockKey]: block })).toEqual({

--- a/tests/editor-view-withholding.test.ts
+++ b/tests/editor-view-withholding.test.ts
@@ -46,8 +46,19 @@ function fields(schema: ReadonlyArray<HaFormSchema>, path: ReadonlyArray<string>
   });
 }
 
+/**
+ * 🚨 Projects the view block the way the editor does, rather than handing the panels the
+ * raw configuration. The two were the same thing while root was list's storage; with
+ * `list:` registered they are not, and a parent control whose value has moved into the
+ * block would be absent here and present in the rendered editor — reported as the panel
+ * withholding a field it does not withhold.
+ *
+ * @param config - Raw configuration
+ * @param view - View to project for
+ * @returns A schema context matching the editor's own
+ */
 function context(config: Types.Config, view = config.view): SchemaCtx {
-  return { config, view, language: 'en' };
+  return { config: ViewConfig.resolveEffectiveConfig(config, view), view, language: 'en' };
 }
 
 function configFor(view: Types.EffectiveView, enabled = true): Types.Config {
@@ -408,16 +419,22 @@ describe('withholding is not a search filter or a config edit', () => {
   });
 
   it('preserves hidden root, calendar, and block values through edits and a view round trip', async () => {
-    const hidden = {
+    // Split because the v5 migration relocates list-only keys into `list:` on save, on a
+    // grid card as much as a list one — they are inert outside list either way. The
+    // empty-day pair is scoped `column,list`, so it is not list-only and stays at root.
+    const hiddenRoot = {
       empty_day_text: 'No plans',
       empty_day_color: '#607d8b',
+    };
+    const hiddenList = {
       compact_days_to_show: 2,
       compact_events_to_show: 3,
       compact_events_complete_days: true,
     };
     const config = buildConfig({
       ...configFor('grid'),
-      ...hidden,
+      ...hiddenRoot,
+      ...hiddenList,
       time_grid: { split_multiday_events: true, empty_day_text: 'Grid placeholder' },
     });
     const editor = await mount(config);
@@ -445,7 +462,8 @@ describe('withholding is not a search filter or a config edit', () => {
 
     expect(seen).toHaveLength(4);
     for (const saved of seen) {
-      expect(saved).toMatchObject(hidden);
+      expect(saved).toMatchObject(hiddenRoot);
+      expect(saved.list).toMatchObject(hiddenList);
       expect(saved.time_grid).toMatchObject({
         split_multiday_events: true,
         empty_day_text: 'Grid placeholder',
@@ -503,7 +521,7 @@ describe('empty-day reachability is reconciled across the config partition', () 
     // `COLUMN_OVERRIDE_KEYS`, so "fewer routable than derived" was a restatement of the
     // asymmetry. Both are routable as of v5.0.0 — the whole family the placeholder row
     // derives is reachable from the Column workspace, which is the property worth pinning.
-    expect(routable.length).toBe(family.length);
+    expect(routable).toEqual(family);
     expect({ unscoped, wrongScope }).toEqual({ unscoped: [], wrongScope: [] });
   });
 

--- a/tests/editor-workspace.test.ts
+++ b/tests/editor-workspace.test.ts
@@ -32,7 +32,10 @@ interface Form extends HTMLElement {
   computeLabel(node: HaFormSchema): string;
 }
 
-const EXPECTED_WORKSPACES: ReadonlyArray<EditorWorkspace> = VIEWS;
+// Written out rather than aliased to `WORKSPACES`, so the picker and the constant are two
+// surfaces that must agree instead of one restated twice. Shared leads because it is the
+// base the other three override.
+const EXPECTED_WORKSPACES: ReadonlyArray<EditorWorkspace> = ['shared', ...VIEWS];
 const PAIRS = EXPECTED_WORKSPACES.flatMap((from) =>
   EXPECTED_WORKSPACES.filter((to) => to !== from).map((to) => ({ from, to })),
 );
@@ -137,7 +140,10 @@ function assertWorkspaceFields(editor: EditorHost, current: EditorWorkspace): vo
   const main = forms(editor, 'ha-form.panel-form').flatMap((form) => names(form.schema));
   expect(main.length).toBeGreaterThan(50);
   for (const [key, scope] of Object.entries(VIEW_SCOPE)) {
-    expect(main.includes(key), `${current}: ${key}`).toBe(scope.has(current));
+    // Shared offers a key when more than one layout reads it; a view offers it when that
+    // view reads it. Asking `scope.has('shared')` would be false for every scoped key.
+    const expected = current === 'shared' ? scope.size > 1 : scope.has(current);
+    expect(main.includes(key), `${current}: ${key}`).toBe(expected);
   }
   expect(main.includes('hour_height')).toBe(current === 'grid');
   expect(main.includes('min_day_width')).toBe(current === 'grid' || current === 'column');
@@ -381,14 +387,56 @@ describe('workspace state survives echoes and pending edits', () => {
   });
 });
 
-it('rejects the removed duplicate Shared workspace without changing configuration', async () => {
-  const editor = await mount();
-  const seen = reports(editor);
-  vi.spyOn(Logger, 'warn').mockImplementation(() => {});
-  await change(editor, onlyForm(editor, 'ha-form.workspace-form'), { [WORKSPACE_FIELD]: 'shared' });
-  expect(workspace(editor)).toBe('list');
-  expect(WORKSPACES).toEqual(VIEWS);
-  expect(seen).toEqual([]);
+/**
+ * Shared is a workspace with no view behind it.
+ *
+ * It was deleted in the editor rework's Stage 5 on the correct measurement that it was
+ * byte-identical to List across 63 configurations — true only because list's keys lived at
+ * the top level. `list:` gives it a job, so these assert the two halves that make it more
+ * than a fourth name for List: switching to it writes nothing, and an edit made in it
+ * lands at the top level where every view can read it.
+ */
+describe('the shared workspace', () => {
+  it('offers one workspace per view plus the shared base', () => {
+    expect(WORKSPACES).toEqual(['shared', ...VIEWS]);
+  });
+
+  it('is selectable and changes no configuration by being selected', async () => {
+    const editor = await mount();
+    const seen = reports(editor);
+
+    await change(editor, onlyForm(editor, 'ha-form.workspace-form'), {
+      [WORKSPACE_FIELD]: 'shared',
+    });
+
+    expect(workspace(editor)).toBe('shared');
+    expect(seen).toEqual([]);
+  });
+
+  // The distinguishing behaviour. The same edit made in the List workspace lands in
+  // `list:`; made here it lands at the top level, which is the whole point of the layer.
+  it('writes an edit to the top level rather than into any block', async () => {
+    const editor = await mount({ view: 'list' });
+    const seen = reports(editor);
+
+    await change(editor, onlyForm(editor, 'ha-form.workspace-form'), {
+      [WORKSPACE_FIELD]: 'shared',
+    });
+    await change(editor, owner(editor, 'event_font_size'), { event_font_size: '24px' });
+
+    expect(seen).toEqual([{ entities: [{ entity: 'calendar.anna' }], event_font_size: '24px' }]);
+  });
+
+  it('writes the same edit into the list block from the List workspace', async () => {
+    const editor = await mount({ view: 'list' });
+    const seen = reports(editor);
+
+    await change(editor, owner(editor, 'event_font_size'), { event_font_size: '24px' });
+
+    expect(seen).toEqual([
+      { entities: [{ entity: 'calendar.anna' }], list: { event_font_size: '24px' } },
+    ]);
+  });
 });
 
 describe('the editor names each view once', () => {

--- a/tests/view-block-registry.test.ts
+++ b/tests/view-block-registry.test.ts
@@ -53,11 +53,18 @@ const baseConfig = (overrides: Record<string, unknown> = {}): Types.Config =>
 
 describe('the registry is the single source', () => {
   it('registers exactly the views that own a block', () => {
-    expect(Object.keys(VIEW_BLOCKS).sort()).toEqual(['column', 'grid']);
+    expect(Object.keys(VIEW_BLOCKS).sort()).toEqual(['column', 'grid', 'list']);
   });
 
-  it('reports no block for a view that has none', () => {
-    expect(viewBlockFor('list')).toBeUndefined();
+  // List's entry is what makes the three views symmetric, and it is the only one whose
+  // `defaultOverrides` is empty — the shipped card-level values *are* list's, so it has
+  // nothing to diverge from.
+  it('registers list with no divergent defaults and no keys of its own', () => {
+    const block = viewBlockFor('list');
+
+    expect(block?.blockKey).toBe('list');
+    expect(block?.defaultOverrides).toEqual({});
+    expect(block?.onlyKeys).toEqual([]);
   });
 
   // Derived rather than written out a second time, so a view cannot be registered in
@@ -187,10 +194,12 @@ describe('behaviour follows the registry', () => {
     );
   });
 
-  it('leaves a view with no registry entry untouched', () => {
+  // List is registered, so it no longer short-circuits on identity — but with an empty
+  // block and no divergent defaults the resolved value has to be the top-level one.
+  it('leaves every value alone for a registered view that overrides nothing', () => {
     const config = baseConfig({ day_spacing: '10px', column: { day_spacing: '99px' } });
 
-    expect(resolveEffectiveConfig(config, 'list')).toBe(config);
+    expect(resolveEffectiveConfig(config, 'list')).toEqual(config);
   });
 
   it('resolves a single option through the registered block too', () => {

--- a/tests/view-config.test.ts
+++ b/tests/view-config.test.ts
@@ -236,13 +236,24 @@ describe('resolveEffectiveConfig', () => {
    * quietly turn every one of those comparisons into a miss.
    */
   describe('object identity', () => {
-    it('returns the original in list view, however populated the block', () => {
+    it('returns the original in list view when the list block is absent', () => {
       const config = buildConfig({
         show_location: true,
         column: { show_location: false, event_font_size: '11px' },
       });
 
       expect(resolveEffectiveConfig(config, 'list')).toBe(config);
+    });
+
+    // The other half of the same invariant: identity is the no-op path, not a special
+    // case for list. A populated block has to allocate, or the override never applies.
+    it('allocates in list view once the list block carries a value', () => {
+      const config = buildConfig({ show_location: true, list: { show_location: false } });
+
+      const resolved = resolveEffectiveConfig(config, 'list');
+
+      expect(resolved).not.toBe(config);
+      expect(resolved.show_location).toBe(false);
     });
 
     // Column view always allocates, because `COLUMN_DEFAULT_OVERRIDES` applies there


### PR DESCRIPTION
Implements the approved config-layering plan. Targets `feature/grid-view-v5`, per Alex's sequencing.

Alex's six rulings, all applied: **layered** (not pure), **all in v5.0.0**, migration scope **A+**, presence-is-authorship **in scope**, `empty_day_color` **fixed**, docs gate **yes**.

## What changes

`list:` becomes a peer of `column:` and `time_grid:`, so the top level means only *shared base* — nothing view-specific remains there. The editor gains a fourth workspace, **All Layouts**, that edits it.

That workspace is the one deleted in Stage 5 after measuring byte-identical to List across 63 configurations. It was identical *because* list keys were the top level. With `list:` registered the two are genuinely different — Shared walks 98 controls to List's 111 — and a new invariant fails if they converge again.

Old configurations keep working **permanently**, not for a deprecation window: the editor is the only config write path, and a YAML-mode user never opens it.

## Things worth a reviewer's attention

**List edits now route into `list:`.** This is the visible behavior change. A `height_mode` edit on a plain list card dispatches `{ list: { height: '300px' } }`, not root `height`. Several tests pinned the old location and now assert wherever the router puts it.

**Divergent-default keys relocate only for a `view: list` card.** Relocating them unconditionally would change rendering for **13 of the 14** — column inherits 12 from the top level today, grid inherits `split_multiday_events`. Residual, and it is A+'s premise rather than a defect: a migrated list card later switched to column sees `DEFAULT_CONFIG` where it previously saw the old root value.

**Four defects found by implementing, not by planning:**

- Relocation inside `toStoredConfig` collided with Shared. That function has five callers — the diff baseline, reset controls, the customized-only projection — none of which wants a migration applied, and a Shared-authored divergent value was relocated on the very save that authored it. Moved to the single dispatch in `_report`.
- `appliesToSharedBase` had to refuse block-only keys. `hour_height` is unscoped because it has *no top-level home at all*, not because every view reads it; Shared would have offered it, and `destination()` returns `undefined` for Shared, so the edit would have been written where nothing reads it.
- `resolveEffectiveConfig` lost identity preservation. Registering `list` ended the `!block → return config` short-circuit, so every list card allocated a fresh object — correct rendering, silently missed memoization.
- Shared's *content* followed the card's displayed view, because the layout schema omits a row when the view is grid. Fixed with a second funnel, `baseViewForWorkspace()`, deliberately distinct from `viewForWorkspace()`.
- **The reset controls followed the built view rather than the workspace destination** — found in review by the Grid session, reproduced end to end, fixed in `99c1344`. Shared builds its panels as list, so `ctx.view` reads `'list'` there; once `list:` had a block, `OVERRIDE_BLOCK_BY_VIEW` resolved and Shared was offered the reset buttons belonging to `list:`. Clicking one deleted a List override from a workspace that cannot write to `list:`, leaving root — the layer being edited — untouched. Shared now offers none, which is what a reset *means*: `_resetViewValues` returns a value to what it inherits, and the shared base inherits from nothing. It is also what the root-writing workspace did before `list:` existed. A *reset to shipped default* for the shared layer would be new product surface and is deliberately not added here.
- **The same defect one call deeper, in the entity subforms** — also found by the Grid session, fixed in `4e0f17f`. `Entities.showsLocation` hides `location_icon` where no location row is drawn, and it asks `resolveViewOption`, which selects a block by view *name*. `workspaceConfig` resolves no block over the shared base, but that care was defeated by the name alone: with `show_location: true` at root and `list: { show_location: false }`, Shared read `list:` and hid the control — `list false | shared false | column true | grid true` — even though column and grid still drew locations, and Shared is where a value meant for them is set. Now `list false | shared true | column true | grid true`. Both sites go through a new `_destinationView(ctx)`, which names the question once: what layer this context *writes into*, as against what it *looks like*. Residual, recorded at the function: a base saying no locations with `column:` turning them back on still hides the control in Shared; the control remains offered in the workspace that overrode it.

**A reconciliation test was passing for the wrong reason.** In `editor-grid-reconciliation`, `forgets root authorship…` cleared a `list:` override that was absent, and the migration then moved root's value into `list:` — so the "key left root" assertion could not tell a clear from a move. Diagnosed by dumping the reports.

## Docs scope — a revision to the plan's number

The plan priced the docs blast radius off the *migration* scope: A+, 47 fences. Reading the fences shows that conflates two questions.

`docs/features/column-view.md` already teaches layering verbatim — a shared `event_font_size` at the top level, overridden in `column:`, with prose reading *"Anything the block does not mention keeps its top-level value."* Rewriting that into `list:` deletes the lesson the example exists to teach.

The migration acts on *existing v4* configs, where a root value was authored when top level meant list. The docs are *new v5* configs, where root means shared — so root is the idiomatic place for a divergent key, and only the **5 list-only keys** genuinely change home.

**47 fences → 15, of which 13 are editable.** `docs/RELEASE_NOTES.md` holds the other 2 and is left alone. Measured with a corrected fence probe: the plan's original had an *optional* language group, which skips a `json` opener and runs the lazy body to the wrong delimiter.

## Gate

`check:docs` check 30 derives the list-only set from `VIEW_SCOPE` rather than listing it, and fails on any example writing one at the top level. Verified by planting violations in `docs/` and in the README, and by breaking the derivation to confirm it refuses to run blind rather than passing on an empty set.

## Rebase note

`9e9b9c1` implemented `empty_day_color` on v5 independently and in parallel with this branch — same conclusion, same two test changes. Three conflicts, resolved by taking the stronger form of each rather than one side: v5's general invariant in `config-partition` (*no* `{list, column}` option is card-level, so the next one fails too) plus this branch's routability check, and v5's comment in `editor-view-withholding` with this branch's `toEqual(family)`, which pins content rather than length. Falsified after resolving — removing `empty_day_color` from `COLUMN_OVERRIDE_KEYS` fails 4 tests.

## Verification

All ten gates green, `check:bundle` on Node 22. Suite **4,355 → 4,417** on `npm test` (175 files, all four projects). `tests/config-list-block.test.ts` is new and mutation-swept against an unmutated control: 7 mutations, each caught by a *different* test with differing failure counts.

The reset fix is falsified rather than asserted: reverting the guard to `ctx.view` turns the two Shared assertions red while the List arm stays green, so the test cannot be satisfied by a guard that returns nothing everywhere.

**If the scope ruling is ever revisited, the unwind is measured, not estimated.** Forcing `moving = listOnly` in `relocateListKeys` — scope A exactly — gives **4,117 pass / 3 fail against a 4,120 control, both `--project unit`**, and all three failures are in `tests/config-list-block.test.ts`. Nothing in the editor, router, workspace, schema or DOM suites moves, which is the measured form of the claim that the structural half is common to both scopes. (Quote that pair as unit-only; it is not comparable to the 4,417 above, which includes the three DST projects re-running `*.dst.test.ts`.)

Screenshots under `.github/img/` are unaffected — no default rendering changed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

